### PR TITLE
[fixed] fixed click collector online offline button error

### DIFF
--- a/web-app/src/app/service/collector.service.ts
+++ b/web-app/src/app/service/collector.service.ts
@@ -61,7 +61,8 @@ export class CollectorService {
       httpParams = httpParams.append('collectors', collector);
     });
     const options = { params: httpParams };
-    return this.http.put<Message<any>>(`${collector_uri}/online/`, null, options);
+    // 修复上下线接口调用异常问题  miki
+    return this.http.put<Message<any>>(`${collector_uri}/online`, null, options);
   }
 
   public goOfflineCollector(collectors: Set<string>): Observable<Message<any>> {
@@ -72,7 +73,8 @@ export class CollectorService {
       httpParams = httpParams.append('collectors', collector);
     });
     const options = { params: httpParams };
-    return this.http.put<Message<any>>(`${collector_uri}/offline/`, null, options);
+    // 修复上下线接口调用异常问题  miki
+    return this.http.put<Message<any>>(`${collector_uri}/offline`, null, options);
   }
 
   public deleteCollector(collectors: Set<string>): Observable<Message<any>> {


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
When you click the collection cluster menu to perform offline and online operations on the collector, a window will pop up to prompt interface 404, because there is an “/” in front of the calling interface/online/and/offline/interface in the collector.service.ts code, and these two interfaces are removed here “/”

## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](../e2e) and all cases have passed.
