### PR TITLE
[bugfix] fix statuspage index exception

### DIFF
--- a/manager/src/main/java/org/apache/hertzbeat/manager/service/impl/StatusPageServiceImpl.java
+++ b/manager/src/main/java/org/apache/hertzbeat/manager/service/impl/StatusPageServiceImpl.java
@@ -160,6 +160,10 @@ public class StatusPageServiceImpl implements StatusPageService {
     }
     
     private StatusPageHistory combineOneDayStatusPageHistory(List<StatusPageHistory> statusPageHistories, StatusPageComponent component, long nowTimestamp) {
+        if (statusPageHistories.isEmpty()) {
+            return StatusPageHistory.builder().timestamp(nowTimestamp)
+                    .normal(0).abnormal(0).unknown(0).componentId(component.getId()).state(component.getState()).build();
+        }
         if (statusPageHistories.size() == 1) {
             return statusPageHistories.get(0);
         }


### PR DESCRIPTION
## What's changed?

Fix this issue: https://github.com/apache/hertzbeat/issues/1702

Return a default empty  StatusPageHistory when statusPageHistories size is 0

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](../e2e) and all cases have passed.
