### PR TITLE
[Improve] run hertzbeat in docker compose support dependen service condition

### DIFF
--- a/script/docker-compose/hertzbeat-mysql-iotdb/docker-compose.yaml
+++ b/script/docker-compose/hertzbeat-mysql-iotdb/docker-compose.yaml
@@ -25,6 +25,11 @@ services:
     container_name: compose-mysql
     hostname: mysql
     restart: always
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 --silent']
+      interval: 3s
+      retries: 5
+      start_period: 3m
     ports:
       - "3306"
     environment:
@@ -41,6 +46,12 @@ services:
     container_name: compose-iotdb
     hostname: iotdb
     restart: always
+    healthcheck:
+      test: ["CMD", "ls", "/iotdb/data"]
+      interval: 10s
+      retries: 5
+      timeout: 5s
+      start_period: 30s
     environment:
       TZ: Asia/Shanghai
     ports:
@@ -60,8 +71,10 @@ services:
       TZ: Asia/Shanghai
       LANG: zh_CN.UTF-8
     depends_on:
-      - mysql
-      - iotdb
+      mysql:
+        condition: service_healthy
+      iotdb:
+        condition: service_healthy
     volumes:
       - ./conf/application.yml:/opt/hertzbeat/config/application.yml
       - ./conf/sureness.yml:/opt/hertzbeat/config/sureness.yml

--- a/script/docker-compose/hertzbeat-mysql-tdengine/docker-compose.yaml
+++ b/script/docker-compose/hertzbeat-mysql-tdengine/docker-compose.yaml
@@ -25,6 +25,11 @@ services:
     container_name: compose-mysql
     hostname: mysql
     restart: always
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 --silent']
+      interval: 3s
+      retries: 5
+      start_period: 3m
     ports:
       - "3306"
     environment:
@@ -41,6 +46,12 @@ services:
     container_name: compose-tdengine
     hostname: tdengine
     restart: always
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -u root:taosdata -d "show databases" tdengine:6041/rest/sql']
+      interval: 10s
+      retries: 5
+      timeout: 5s
+      start_period: 1m
     environment:
       TZ: Asia/Shanghai
     ports:
@@ -59,8 +70,10 @@ services:
       TZ: Asia/Shanghai
       LANG: zh_CN.UTF-8
     depends_on:
-      - mysql
-      - tdengine
+      mysql:
+        condition: service_healthy
+      tdengine:
+        condition: service_healthy
     volumes:
       - ./conf/application.yml:/opt/hertzbeat/config/application.yml
       - ./conf/sureness.yml:/opt/hertzbeat/config/sureness.yml

--- a/script/docker-compose/hertzbeat-mysql-victoria-metrics/docker-compose.yaml
+++ b/script/docker-compose/hertzbeat-mysql-victoria-metrics/docker-compose.yaml
@@ -25,6 +25,11 @@ services:
     container_name: compose-mysql
     hostname: mysql
     restart: always
+    healthcheck:
+      test: ['CMD-SHELL', 'mysqladmin ping -h 127.0.0.1 --silent']
+      interval: 3s
+      retries: 5
+      start_period: 3m
     ports:
       - "3306"
     environment:
@@ -41,6 +46,12 @@ services:
     container_name: compose-victoria-metrics
     hostname: victoria-metrics
     restart: always
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "-", "http://victoria-metrics:8428/-/healthy"]
+      interval: 10s
+      retries: 5
+      timeout: 5s
+      start_period: 30s
     environment:
       TZ: Asia/Shanghai
     ports:
@@ -59,8 +70,10 @@ services:
       TZ: Asia/Shanghai
       LANG: zh_CN.UTF-8
     depends_on:
-      - mysql
-      - victoria-metrics
+      mysql:
+        condition: service_healthy
+      victoria-metrics:
+        condition: service_healthy
     volumes:
       - ./conf/application.yml:/opt/hertzbeat/config/application.yml
       - ./conf/sureness.yml:/opt/hertzbeat/config/sureness.yml

--- a/script/docker-compose/hertzbeat-postgresql-iotdb/conf/application.yml
+++ b/script/docker-compose/hertzbeat-postgresql-iotdb/conf/application.yml
@@ -81,22 +81,22 @@ spring:
 
   # Not Require, Please config if you need email notify
   # 非必填：不使用邮箱作为警告通知可以去掉spring.mail配置
-#  mail:
-#    # Attention: this is mail server address.
-#    # 请注意此为邮件服务器地址：qq邮箱为 smtp.qq.com qq企业邮箱为 smtp.exmail.qq.com
-#    host: smtp.qq.com
-#    username: example@qq.com
-#    # Attention: this is not email account password, this requires an email authorization code
-#    # 请注意此非邮箱账户密码 此需填写邮箱授权码
-#    password: xxqzvuqbnqvbbdac
-#    port: 465
-#    default-encoding: UTF-8
-#    properties:
-#      mail:
-#        smtp:
-#          socketFactoryClass: javax.net.ssl.SSLSocketFactory
-#          ssl:
-#            enable: true
+  mail:
+    # Attention: this is mail server address.
+    # 请注意此为邮件服务器地址：qq邮箱为 smtp.qq.com qq企业邮箱为 smtp.exmail.qq.com
+    host: smtp.qq.com
+    username: example@qq.com
+    # Attention: this is not email account password, this requires an email authorization code
+    # 请注意此非邮箱账户密码 此需填写邮箱授权码
+    password: xxqzvuqbnqvbbdac
+    port: 465
+    default-encoding: UTF-8
+    properties:
+      mail:
+        smtp:
+          socketFactoryClass: javax.net.ssl.SSLSocketFactory
+          ssl:
+            enable: true
 
 warehouse:
   store:

--- a/script/docker-compose/hertzbeat-postgresql-iotdb/docker-compose.yaml
+++ b/script/docker-compose/hertzbeat-postgresql-iotdb/docker-compose.yaml
@@ -25,6 +25,12 @@ services:
     container_name: compose-postgresql
     hostname: postgresql
     restart: always
+    healthcheck:
+      test: [ "CMD", "pg_isready" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     ports:
       - '5432:5432'
     environment:
@@ -41,6 +47,12 @@ services:
     container_name: compose-iotdb
     hostname: iotdb
     restart: always
+    healthcheck:
+      test: ["CMD", "ls", "/iotdb/data"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
     environment:
       TZ: Asia/Shanghai
     ports:
@@ -60,8 +72,10 @@ services:
       TZ: Asia/Shanghai
       LANG: zh_CN.UTF-8
     depends_on:
-      - postgres
-      - iotdb
+      postgres:
+        condition: service_healthy
+      iotdb:
+        condition: service_healthy
     volumes:
       - ./conf/application.yml:/opt/hertzbeat/config/application.yml
       - ./conf/sureness.yml:/opt/hertzbeat/config/sureness.yml


### PR DESCRIPTION
## What's changed?

- fix hertzbeat-postgresql-iotdb docker compose start error bug
- run hertzbeat in docker compose support dependen service  #1675 

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.com/docs/others/contributing/)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](../e2e) and all cases have passed.
