### PR TITLE
fix : ingress tls inoperative

### DIFF
--- a/script/helm/hertzbeat/templates/manager/ingress.yaml
+++ b/script/helm/hertzbeat/templates/manager/ingress.yaml
@@ -25,6 +25,9 @@ metadata:
   labels:
     {{- include "hertzbeat.labels" . | nindent 4 }}
 spec:
+  {{if .Values.expose.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.expose.ingress.ingressClassName }}
+  {{end}}
   rules:
     - host: {{ .Values.expose.ingress.host }}
       http:

--- a/script/helm/hertzbeat/values.yaml
+++ b/script/helm/hertzbeat/values.yaml
@@ -135,9 +135,9 @@ expose:
     sourceRanges: [ ]
   ingress:
     enabled: true
+    ingressClassName: ""
     host: "hertzbeat.domain"
     annotations: {}    
     tls:
-      enabled: false
-      tls:
-        - secretName: your-tls-secret 
+      enabled: true
+      secretName: your-tls-secret


### PR DESCRIPTION
## What's changed?

1. repair default value.yaml ingress tls secretName path error.
2. add ingress class name property

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

none
