### PR TITLE
Replace deprecated methods with builder pattern for RedisURI construction

### DIFF
--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/http/promethus/PrometheusLastParser.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/http/promethus/PrometheusLastParser.java
@@ -40,8 +40,6 @@ public class PrometheusLastParser extends AbstractPrometheusParse {
     @Override
     public void parse(String resp, List<String> aliasFields, HttpProtocol http, CollectRep.MetricsData.Builder builder) {
         CollectRep.ValueRow.Builder valueRowBuilder = CollectRep.ValueRow.newBuilder();
-        for (String aliasField : aliasFields) {
-            valueRowBuilder.addColumns(CommonConstants.NULL_VALUE);
-        }
+        aliasFields.forEach(aliasField -> valueRowBuilder.addColumns(CommonConstants.NULL_VALUE));
     }
 }

--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/redis/RedisCommonCollectImpl.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/redis/RedisCommonCollectImpl.java
@@ -268,16 +268,16 @@ public class RedisCommonCollectImpl extends AbstractCollect {
     }
 
     private RedisURI redisUri(RedisProtocol redisProtocol) {
-        RedisURI redisUri = RedisURI.create(redisProtocol.getHost(), Integer.parseInt(redisProtocol.getPort()));
+        RedisURI.Builder redisUriBuilder = RedisURI.builder().withHost(redisProtocol.getHost()).withPort(Integer.parseInt(redisProtocol.getPort()));
         if (StringUtils.hasText(redisProtocol.getUsername())) {
-            redisUri.setUsername(redisProtocol.getUsername());
+        	redisUriBuilder.withClientName(redisProtocol.getUsername());
         }
         if (StringUtils.hasText(redisProtocol.getPassword())) {
-            redisUri.setPassword(redisProtocol.getPassword().toCharArray());
+        	redisUriBuilder.withPassword(redisProtocol.getPassword().toCharArray());
         }
         Duration timeout = Duration.ofMillis(CollectUtil.getTimeout(redisProtocol.getTimeout()));
-        redisUri.setTimeout(timeout);
-        return redisUri;
+        redisUriBuilder.withTimeout(timeout);
+        return redisUriBuilder.build();
     }
 
     private String removeCr(String value) {

--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/redis/RedisCommonCollectImpl.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/redis/RedisCommonCollectImpl.java
@@ -270,10 +270,10 @@ public class RedisCommonCollectImpl extends AbstractCollect {
     private RedisURI redisUri(RedisProtocol redisProtocol) {
         RedisURI.Builder redisUriBuilder = RedisURI.builder().withHost(redisProtocol.getHost()).withPort(Integer.parseInt(redisProtocol.getPort()));
         if (StringUtils.hasText(redisProtocol.getUsername())) {
-        	redisUriBuilder.withClientName(redisProtocol.getUsername());
+            redisUriBuilder.withClientName(redisProtocol.getUsername());
         }
         if (StringUtils.hasText(redisProtocol.getPassword())) {
-        	redisUriBuilder.withPassword(redisProtocol.getPassword().toCharArray());
+            redisUriBuilder.withPassword(redisProtocol.getPassword().toCharArray());
         }
         Duration timeout = Duration.ofMillis(CollectUtil.getTimeout(redisProtocol.getTimeout()));
         redisUriBuilder.withTimeout(timeout);

--- a/collector/src/main/java/org/apache/hertzbeat/collector/util/JsonPathParser.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/util/JsonPathParser.java
@@ -23,6 +23,8 @@ import com.jayway.jsonpath.spi.cache.LRUCache;
 
 import java.util.*;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * json path parser
  */
@@ -45,7 +47,7 @@ public class JsonPathParser {
      * @return content [{'name': 'tom', 'speed': '433'},{'name': 'lili', 'speed': '543'}]
      */
     public static List<Object> parseContentWithJsonPath(String content, String jsonPath) {
-        if (content == null || jsonPath == null || "".equals(content) || "".equals(jsonPath)) {
+        if (StringUtils.isAnyEmpty(content, jsonPath)) {
             return Collections.emptyList();
         }
         return PARSER.parse(content).read(jsonPath);
@@ -58,7 +60,7 @@ public class JsonPathParser {
      * @return content [{'name': 'tom', 'speed': '433'},{'name': 'lili', 'speed': '543'}]
      */
     public static <T> T parseContentWithJsonPath(String content, String jsonPath, TypeRef<T> typeRef) {
-        if (content == null || jsonPath == null || "".equals(content) || "".equals(jsonPath)) {
+        if (StringUtils.isAnyEmpty(content, jsonPath)) {
             return null;
         }
         return PARSER.parse(content).read(jsonPath, typeRef);


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
- Replaced the deprecated methods in RedisCommonCollectImpl with the builder pattern for RedisURI creation. This enhancement improves the maintainability and extensibility of the code.
- Eliminated unnecessary string object allocations and enhanced readability using forEach and lambda expressions. This leads to code simplification and improved comprehension.
- Improved readability by using StringUtils.isAnyEmpty() method. This helps clarify the intent of the code and prevents potential bugs.

These three changes enhance the quality of the code, allowing for better maintainability and extensibility.

## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
