### PR TITLE
[feature:update-checkstyle] Limit the java file header 

### DIFF
--- a/script/checkstyle/checkstyle.xml
+++ b/script/checkstyle/checkstyle.xml
@@ -228,7 +228,7 @@
             <property name="offset" value="0"/>
         </module>
         <module name="AtclauseOrder">
-            <property name="tagOrder" value="@param, @return, @throws, @deprecated, @author"/>
+            <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
             <property name="target"
                       value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
@@ -275,6 +275,12 @@
             <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)"/>
             <property name="checkFormat" value="$1"/>
             <property name="influenceFormat" value="1"/>
+        </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" 
+                      value="^.*(@author|@date).*" />
+            <property name="message" 
+                      value="Java file header cannot contain @author or @date" />
         </module>
     </module>
 </module>


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
refer to: https://github.com/apache/hertzbeat/issues/1781

add module to checkstyle.xml
```xml
<module name="RegexpSinglelineJava">
    <property name="format" 
              value="^.*(@author|@date).*" />
    <property name="message" 
              value="Java file header cannot contain @author or @date" />
</module>
```

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
