### PR TITLE
Comparing N objects for null with Assert.noNullElements().

### DIFF
--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/redis/RedisCommonCollectImpl.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/redis/RedisCommonCollectImpl.java
@@ -330,9 +330,7 @@ public class RedisCommonCollectImpl extends AbstractCollect {
     }
 
     private void preCheck(Metrics metrics) {
-        if (metrics == null || metrics.getRedis() == null) {
-            throw new IllegalArgumentException("Redis collect must has redis params");
-        }
+    	Assert.noNullElements(new Object[] {metrics, metrics.getRedis()}, "Redis collect must has redis params");
         RedisProtocol redisProtocol = metrics.getRedis();
         Assert.hasText(redisProtocol.getHost(), "Redis Protocol host is required.");
         Assert.hasText(redisProtocol.getPort(), "Redis Protocol port is required.");


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
If you want to compare N objects for null and throw an IllegalArgumentException, you can easily handle it with `Assert.noNullElements()`.

## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
