### PR TITLE
[improve] Delete the timestamp field in the class MetricFamily.Metric

### DIFF
--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/prometheus/parser/MetricFamily.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/prometheus/parser/MetricFamily.java
@@ -53,11 +53,6 @@ public class MetricFamily {
          * value
          */
         private double value;
-
-        /**
-         * timestamp
-         */
-        private long timestamp;
     }
 
     /**


### PR DESCRIPTION
## What's changed?

Delete the timestamp field in the class MetricFamily.Metric https://github.com/apache/hertzbeat/issues/1877

## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
