### PR TITLE
[improve] Refactor common cache code

### DIFF
--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/AbstractConnection.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/AbstractConnection.java
@@ -18,27 +18,25 @@
 package org.apache.hertzbeat.collector.collect.common.cache;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.sshd.client.session.ClientSession;
 
 /**
- * ssh connection holder
+ * AbstractConnection
  */
 @Slf4j
-public class SshConnect extends AbstractConnection<ClientSession> {
-    private final ClientSession clientSession;
+public abstract class AbstractConnection<T> implements AutoCloseable {
 
-    public SshConnect(ClientSession clientSession) {
-        this.clientSession = clientSession;
-    }
+    /**
+     * @return Returns the connection.
+     */
+    public abstract T getConnection();
+
+    /**
+     * Close connection
+     */
+    public abstract void closeConnection() throws Exception;
 
     @Override
-    public void closeConnection() throws Exception {
-        if (clientSession != null) {
-            clientSession.close();
-        }
-    }
-
-    public ClientSession getConnection() {
-        return clientSession;
+    public void close() throws Exception{
+        closeConnection();
     }
 }

--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/ConnectionCommonCache.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/ConnectionCommonCache.java
@@ -34,7 +34,7 @@ import lombok.extern.slf4j.Slf4j;
  * lru common resource cache for client-server connection
  */
 @Slf4j
-public class ConnectionCommonCache {
+public class ConnectionCommonCache<T, C extends AbstractConnection<?>> {
 
     /**
      * default cache time 200s
@@ -54,34 +54,32 @@ public class ConnectionCommonCache {
     /**
      * cache timeout map
      */
-    private Map<Object, Long[]> timeoutMap;
+    private Map<T, Long[]> timeoutMap;
 
     /**
      * object cache
      */
-    private ConcurrentLinkedHashMap<Object, Object> cacheMap;
+    private ConcurrentLinkedHashMap<T, C> cacheMap;
 
     /**
      * the executor who clean cache when timeout
      */
     private ThreadPoolExecutor timeoutCleanerExecutor;
 
-    private ConnectionCommonCache() {
+    public ConnectionCommonCache() {
         init();
     }
 
     private void init() {
         cacheMap = new ConcurrentLinkedHashMap
-                .Builder<>()
+                .Builder<T, C>()
                 .maximumWeightedCapacity(DEFAULT_MAX_CAPACITY)
                 .listener((key, value) -> {
                     timeoutMap.remove(key);
-                    if (value instanceof AutoCloseable closeable) {
-                        try {
-                            closeable.close();
-                        } catch (Exception e) {
-                            log.error("connection close error: {}.", e.getMessage(), e);
-                        }
+                    try {
+                        value.close();
+                    } catch (Exception e) {
+                        log.error("connection close error: {}.", e.getMessage(), e);
                     }
                     log.info("connection common cache discard key: {}, value: {}.", key, value);
                 }).build();
@@ -112,12 +110,10 @@ public class ConnectionCommonCache {
                         || cacheTime[0] + cacheTime[1] < currentTime) {
                     cacheMap.remove(key);
                     timeoutMap.remove(key);
-                    if (value instanceof AutoCloseable closeable) {
-                        try {
-                            closeable.close();
-                        } catch (Exception e) {
-                            log.error("connection close error: {}.", e.getMessage(), e);
-                        }
+                    try {
+                        value.close();
+                    } catch (Exception e) {
+                        log.error("connection close error: {}.", e.getMessage(), e);
                     }
 
                 }
@@ -143,12 +139,10 @@ public class ConnectionCommonCache {
                     log.warn("[connection common cache] clean the timeout cache, key {}", key);
                     timeoutMap.remove(key);
                     cacheMap.remove(key);
-                    if (value instanceof AutoCloseable closeable) {
-                        try {
-                            closeable.close();
-                        } catch (Exception e) {
-                            log.error("connection close error: {}.", e.getMessage(), e);
-                        }
+                    try {
+                        value.close();
+                    } catch (Exception e) {
+                        log.error("connection close error: {}.", e.getMessage(), e);
                     }
                 }
             });
@@ -165,7 +159,7 @@ public class ConnectionCommonCache {
      * @param value    cache value
      * @param timeDiff cache time millis
      */
-    public void addCache(Object key, Object value, Long timeDiff) {
+    public void addCache(T key, C value, Long timeDiff) {
         removeCache(key);
         if (timeDiff == null) {
             timeDiff = DEFAULT_CACHE_TIMEOUT;
@@ -181,7 +175,7 @@ public class ConnectionCommonCache {
      * @param key   cache key
      * @param value cache value
      */
-    public void addCache(Object key, Object value) {
+    public void addCache(T key, C value) {
         addCache(key, value, DEFAULT_CACHE_TIMEOUT);
     }
 
@@ -192,7 +186,7 @@ public class ConnectionCommonCache {
      * @param refreshCache is refresh cache
      * @return cache object
      */
-    public Optional<Object> getCache(Object key, boolean refreshCache) {
+    public Optional<C> getCache(T key, boolean refreshCache) {
         Long[] cacheTime = timeoutMap.get(key);
         if (cacheTime == null || cacheTime.length != CACHE_TIME_LENGTH) {
             log.info("[connection common cache] not hit the cache, key {}.", key);
@@ -204,7 +198,7 @@ public class ConnectionCommonCache {
             cacheMap.remove(key);
             return Optional.empty();
         }
-        Object value = cacheMap.get(key);
+        C value = cacheMap.get(key);
         if (value == null) {
             log.error("[connection common cache] value is null, remove it, key {}.", key);
             cacheMap.remove(key);
@@ -221,7 +215,7 @@ public class ConnectionCommonCache {
      *
      * @param key key
      */
-    public void removeCache(Object key) {
+    public void removeCache(T key) {
         timeoutMap.remove(key);
         Object value = cacheMap.remove(key);
         if (value instanceof AutoCloseable closeable) {
@@ -233,19 +227,4 @@ public class ConnectionCommonCache {
         }
     }
 
-    /**
-     * get common cache instance
-     *
-     * @return connection common cache
-     */
-    public static ConnectionCommonCache getInstance() {
-        return SingleInstance.INSTANCE;
-    }
-
-    /**
-     * static single instance
-     */
-    private static class SingleInstance {
-        private static final ConnectionCommonCache INSTANCE = new ConnectionCommonCache();
-    }
 }

--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/JdbcConnect.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/JdbcConnect.java
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
  * jdbc common connection
  */
 @Slf4j
-public class JdbcConnect implements AutoCloseable {
+public class JdbcConnect extends AbstractConnection<Connection> {
 
     private final Connection connection;
 
@@ -33,12 +33,13 @@ public class JdbcConnect implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void closeConnection() throws Exception {
         if (connection != null) {
             connection.close();
         }
     }
 
+    @Override
     public Connection getConnection() {
         return connection;
     }

--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/JmxConnect.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/JmxConnect.java
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
  * jmx connect object
  **/
 @Slf4j
-public class JmxConnect implements AutoCloseable {
+public class JmxConnect extends AbstractConnection<JMXConnector> {
 
     private final JMXConnector connection;
 
@@ -34,12 +34,13 @@ public class JmxConnect implements AutoCloseable {
 
 
     @Override
-    public void close() throws Exception {
+    public void closeConnection() throws Exception {
         if (connection != null) {
             connection.close();
         }
     }
 
+    @Override
     public JMXConnector getConnection() {
         return connection;
     }

--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/MongodbConnect.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/MongodbConnect.java
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
  * mongodb connect client
  */
 @Slf4j
-public class MongodbConnect implements AutoCloseable {
+public class MongodbConnect extends AbstractConnection<MongoClient> {
     private final MongoClient mongoClient;
 
     public MongodbConnect(MongoClient mongoClient) {
@@ -32,13 +32,14 @@ public class MongodbConnect implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception{
+    public void closeConnection() throws Exception {
         if (this.mongoClient != null) {
             this.mongoClient.close();
         }
     }
 
-    public MongoClient getMongoClient() {
+    @Override
+    public MongoClient getConnection() {
         return mongoClient;
     }
 }

--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/RedfishConnect.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/RedfishConnect.java
@@ -24,7 +24,7 @@ import org.apache.hertzbeat.collector.collect.redfish.ConnectSession;
  * redfish connect session
  */
 @Slf4j
-public class RedfishConnect implements AutoCloseable {
+public class RedfishConnect extends AbstractConnection<ConnectSession> {
     private final ConnectSession reddishConnectSession;
 
     public RedfishConnect(ConnectSession reddishConnectSession) {
@@ -32,12 +32,13 @@ public class RedfishConnect implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void closeConnection() throws Exception {
         if (reddishConnectSession != null) {
             reddishConnectSession.close();
         }
     }
 
+    @Override
     public ConnectSession getConnection() {
         return reddishConnectSession;
     }

--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/RedisConnect.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/RedisConnect.java
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
  * redis connection
  */
 @Slf4j
-public class RedisConnect implements AutoCloseable {
+public class RedisConnect extends AbstractConnection<StatefulConnection<String, String>> {
 
     private final StatefulConnection<String, String> connection;
 
@@ -33,12 +33,13 @@ public class RedisConnect implements AutoCloseable {
     }
 
     @Override
-    public void close() throws Exception {
+    public void closeConnection() throws Exception {
         if (connection != null) {
             connection.closeAsync();
         }
     }
 
+    @Override
     public StatefulConnection<String, String> getConnection() {
         return connection;
     }


### PR DESCRIPTION
## What's changed?

### Motivation

The current version does not use generics, resulting in the need for forced type casting.

Because each collector is a singleton, member variables can be used to save its own cache.

In addition, `ConnectionCommonCache` can also be used as a basic component for other businesses to use.

### Modifications

- Both of `ConnectionCommonCache`'s  key and value use generics.
- Using the constructor instead of the static method.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
