### PR TITLE
bugfix collector startup error can not find JdbcClient

### DIFF
--- a/collector/pom.xml
+++ b/collector/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
-            <version>5.3.23</version>
         </dependency>
         <!-- kafka -->
         <dependency>

--- a/collector/src/main/resources/application.yml
+++ b/collector/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
     default-property-inclusion: ALWAYS
   # need to disable spring boot mongodb auto config, or default mongodb connection tried and failed...
   autoconfigure:
-    exclude: org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration, org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration
+    exclude: org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration, org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration, org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration, org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration
 
 ---
 spring:

--- a/common/src/main/java/org/apache/hertzbeat/common/config/EclipseLinkJpaConfiguration.java
+++ b/common/src/main/java/org/apache/hertzbeat/common/config/EclipseLinkJpaConfiguration.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import javax.sql.DataSource;
 import org.eclipse.persistence.config.PersistenceUnitProperties;
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.orm.jpa.JpaBaseConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.JpaProperties;
 import org.springframework.context.annotation.Configuration;
@@ -36,7 +36,7 @@ import org.springframework.transaction.jta.JtaTransactionManager;
  * jpa eclipselink impl config
  */
 @Configuration
-@EnableAutoConfiguration
+@ConditionalOnProperty(prefix = "spring.datasource", name = "url")
 public class EclipseLinkJpaConfiguration extends JpaBaseConfiguration {
 
     protected EclipseLinkJpaConfiguration(DataSource dataSource, JpaProperties properties, 


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

bugfix collector startup error can not find JdbcClient

```
Error starting ApplicationContext. To display the condition evaluation report re-run your application with 'debug' enabled.
2024-05-07 14:00:38.497 [main] ERROR org.springframework.boot.SpringApplication Line:851 - Application run failed
java.lang.IllegalArgumentException: Could not find class [org.springframework.jdbc.core.simple.JdbcClient]
	at org.springframework.util.ClassUtils.resolveClassName(ClassUtils.java:355)
	at org.springframework.core.annotation.TypeMappedAnnotation.adapt(TypeMappedAnnotation.java:465)
	at org.springframework.core.annotation.TypeMappedAnnotation.getValue(TypeMappedAnnotation.java:390)
```

## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
