### PR TITLE
[fix] fixed name error in monitoring template and improve NGQL protocol

### DIFF
--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/nebulagraph/NgqlCollectImpl.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/nebulagraph/NgqlCollectImpl.java
@@ -67,6 +67,7 @@ public class NgqlCollectImpl extends AbstractCollect {
         if (!nebulaTemplate.isInitSuccess()) {
             builder.setCode(CollectRep.Code.FAIL);
             builder.setMsg("Failed to connect Nebula Graph");
+            return;
         }
         stopWatch.stop();
         long responseTime = stopWatch.getTotalTimeMillis();

--- a/manager/src/main/resources/define/app-nebula_graph_cluster.yml
+++ b/manager/src/main/resources/define/app-nebula_graph_cluster.yml
@@ -16,7 +16,7 @@
 # The monitoring type category：service-application service monitoring db-database monitoring custom-custom monitoring os-operating system monitoring mid-middleware
 category: db
 # The monitoring type eg: linux windows tomcat mysql aws...
-app: nebulagraph_cluster
+app: nebula_graph_cluster
 # The app api i18n name
 name:
   zh-CN: NebulaGraph集群


### PR DESCRIPTION
…ate cannot be edited

## What's changed?

1. fixed the problem that the NebulaGraph cluster monitoring template cannot be edited
2. add return statement when nebulaGraph connect error

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
