### PR TITLE
[bugfix] fix ConnectionCommonCache possible npe

### DIFF
--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/ConnectionCommonCache.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/ConnectionCommonCache.java
@@ -219,6 +219,9 @@ public class ConnectionCommonCache<T, C extends AbstractConnection<?>> {
         timeoutMap.remove(key);
         C value = cacheMap.remove(key);
         try {
+            if (value == null) {
+                return;
+            }
             value.close();
         } catch (Exception e) {
             log.error("connection close error: {}.", e.getMessage(), e);


### PR DESCRIPTION
## What's changed?

The value may be null when `addCache -> removeCache`.

It can be reproduced in this unit test.
https://github.com/apache/hertzbeat/blob/78ca5aebf3423324050b58ac661dad4b8c567c6f/collector/src/test/java/org/apache/hertzbeat/collector/collect/redis/RedisClusterCollectImplTest.java#L70

Previously, because there was type checking, it did not trigger a npe.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
