### PR TITLE
[doc] add  help doc for influxdb-promql and kafka-promql monitoring

### DIFF
--- a/home/docs/help/influxdb_promql.md
+++ b/home/docs/help/influxdb_promql.md
@@ -1,0 +1,63 @@
+---
+id: influxdb_promql
+title: Monitoring InfluxDB-PromQL
+sidebar_label: InfluxDB-PromQL
+keywords: [ Open Source Monitoring System, InfluxDB Monitoring, InfluxDB-PromQL Monitoring ]
+---
+
+> Monitor InfluxDB by querying generic metrics data from Prometheus server using Prometheus PromQL. This approach is suitable when Prometheus is already monitoring InfluxDB and you need to fetch
+> InfluxDB's
+> monitoring data from Prometheus server.
+
+### Configuration Parameters
+
+| Parameter Name      | Parameter Description                                                                                                      |
+|---------------------|----------------------------------------------------------------------------------------------------------------------------|
+| Monitoring Host     | IP, IPv6, or domain name of the target being monitored. Note ⚠️: Do not include protocol header (e.g., https://, http://). |
+| Monitoring name     | Name to identify this monitoring, ensuring uniqueness of names.                                                            |
+| Port                | Prometheus API port, default: 9090.                                                                                        |
+| Relative path       | Relative path of Prometheus to query PromQL, default: /api/v1/query                                                        |
+| Request mode        | Set the request method for API calls: GET, POST, PUT, DELETE, default: GET                                                 |
+| Enable HTTPS        | Whether to access the website via HTTPS, note ⚠️: enabling HTTPS generally requires changing the corresponding port to 443 |
+| Username            | Username for Basic or Digest authentication when accessing the API.                                                        |
+| Password            | Password for Basic or Digest authentication when accessing the API.                                                        |
+| Content-Type        | Resource type when carrying BODY request data.                                                                             |
+| Request BODY        | Set the BODY request data, effective for PUT and POST request methods.                                                     |
+| Collection interval | Interval for periodic data collection in seconds, the minimum interval that can be set is 30 seconds                       |
+| Description remarks | Additional remarks and descriptions for this monitoring. Users can add notes here.                                         |
+
+### Metrics Collection
+
+#### Metric Set: basic_influxdb_memstats_alloc
+
+| Metric Name | Metric Unit | Metric help description              |
+|-------------|-------------|--------------------------------------|
+| instance    | None        | Instance to which the metric belongs |
+| timestamp   | None        | Timestamp of metric collection       |
+| value       | None        | Metric value                         |
+
+#### Metric Set: influxdb_database_numMeasurements
+
+| Metric Name | Metric Unit | Metric help description              |
+|-------------|-------------|--------------------------------------|
+| job         | None        | Metric name                          |
+| instance    | None        | Instance to which the metric belongs |
+| database    | None        | Name of the database                 |
+| timestamp   | None        | Timestamp of metric collection       |
+| value       | None        | Metric value                         |
+
+#### Metric Set: influxdb_query_rate_seconds
+
+| Metric Name | Metric Unit | Metric help description              |
+|-------------|-------------|--------------------------------------|
+| instance    | None        | Instance to which the metric belongs |
+| timestamp   | None        | Timestamp of metric collection       |
+| value       | None        | Metric value                         |
+
+#### Metric Set: influxdb_queryExecutor_queriesFinished_10s
+
+| Metric Name | Metric Unit | Metric help description              |
+|-------------|-------------|--------------------------------------|
+| instance    | None        | Instance to which the metric belongs |
+| timestamp   | None        | Timestamp of metric collection       |
+| value       | None        | Metric value                         |

--- a/home/docs/help/influxdb_promql.md
+++ b/home/docs/help/influxdb_promql.md
@@ -5,13 +5,11 @@ sidebar_label: InfluxDB-PromQL
 keywords: [ Open Source Monitoring System, InfluxDB Monitoring, InfluxDB-PromQL Monitoring ]
 ---
 
-> Monitor InfluxDB by querying generic metrics data from Prometheus server using Prometheus PromQL. This approach is suitable when Prometheus is already monitoring InfluxDB and you need to fetch
-> InfluxDB's
-> monitoring data from Prometheus server.
+> Monitor InfluxDB by querying generic metrics data from Prometheus server using Prometheus PromQL. This approach is suitable when Prometheus is already monitoring InfluxDB and you need to fetch InfluxDB's monitoring data from Prometheus server.
 
 ### Configuration Parameters
 
-| Parameter Name      | Parameter Description                                                                                                      |
+| Parameter Name      | Parameter help description                                                                                                 |
 |---------------------|----------------------------------------------------------------------------------------------------------------------------|
 | Monitoring Host     | IP, IPv6, or domain name of the target being monitored. Note ⚠️: Do not include protocol header (e.g., https://, http://). |
 | Monitoring name     | Name to identify this monitoring, ensuring uniqueness of names.                                                            |

--- a/home/docs/help/kafka_promql.md
+++ b/home/docs/help/kafka_promql.md
@@ -1,0 +1,66 @@
+---
+id: kafka_promql
+title: Monitoring Kafka-PromQL
+sidebar_label: Kafka-PromQL
+keywords: [ Open Source Monitoring System, Open Source Middleware Monitoring, Kafka Monitoring, Kafka-PromQL Monitoring ]
+---
+
+> Monitor Kafka by querying generic metrics data from Prometheus server using Prometheus PromQL. This approach is suitable when Prometheus is already monitoring Kafka and you need to fetch Kafka's
+> monitoring data from Prometheus server.
+
+### Prerequisites
+
+1. Deploy Kafka.
+2. Deploy kafka_exporter.
+3. Collect monitoring metrics exposed by kafka_exporter through Prometheus.
+
+### Configuration Parameters
+
+| Parameter Name      | Parameter Description                                                                                                      |
+|---------------------|----------------------------------------------------------------------------------------------------------------------------|
+| Monitoring Host     | IP, IPv6, or domain name of the target being monitored. Note ⚠️: Do not include protocol header (e.g., https://, http://). |
+| Monitoring name     | Name to identify this monitoring, ensuring uniqueness of names.                                                            |
+| Port                | Prometheus API port, default: 9090.                                                                                        |
+| Relative path       | Relative path of Prometheus to query PromQL, default: /api/v1/query                                                        |
+| Request mode        | Set the request method for API calls: GET, POST, PUT, DELETE, default: GET                                                 |
+| Enable HTTPS        | Whether to access the website via HTTPS, note ⚠️: enabling HTTPS generally requires changing the corresponding port to 443 |
+| Username            | Username for Basic or Digest authentication when accessing the API.                                                        |
+| Password            | Password for Basic or Digest authentication when accessing the API.                                                        |
+| Content-Type        | Resource type when carrying BODY request data.                                                                             |
+| Request BODY        | Set the BODY request data, effective for PUT and POST request methods.                                                     |
+| Collection interval | Interval for periodic data collection in seconds, the minimum interval that can be set is 30 seconds                       |
+| Description remarks | Additional remarks and descriptions for this monitoring. Users can add notes here.                                         |
+
+### Metrics Collection
+
+#### Metric Set: kafka_brokers
+
+| Metric Name | Metric Unit | Metric help description              |
+|-------------|-------------|--------------------------------------|
+| \_\_name__  | None        | Metric name                          |
+| instance    | None        | Instance to which the metric belongs |
+| timestamp   | None        | Timestamp of metric collection       |
+| value       | None        | Metric value                         |
+
+#### Metric Set: kafka_topic_partitions
+
+| Metric Name | Metric Unit | Metric help description              |
+|-------------|-------------|--------------------------------------|
+| \_\_name__  | None        | Metric name                          |
+| instance    | None        | Instance to which the metric belongs |
+| timestamp   | None        | Timestamp of metric collection       |
+| value       | None        | Metric value                         |
+
+#### Metric Set: kafka_server_brokertopicmetrics_bytesinpersec
+
+| Metric Name | Metric Unit | Metric help description              |
+|-------------|-------------|--------------------------------------|
+| \_\_name__  | None        | Metric name                          |
+| instance    | None        | Instance to which the metric belongs |
+| timestamp   | None        | Timestamp of metric collection       |
+| value       | None        | Metric value                         |
+
+### Other Kafka Monitoring Methods Supported by HertzBeat
+
+1. If Kafka is enabled with JMX monitoring, you can use [Kafka](kafka) Monitoring.
+2. If Kafka cluster deploys kafka_exporter to expose monitoring metrics, you can refer to [Prometheus task](prometheus) to configure the Prometheus collection task to monitor kafka.

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/influxdb_promql.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/influxdb_promql.md
@@ -1,0 +1,63 @@
+---
+id: influxdb_promql
+title: 监控：InfluxDB-PromQL
+sidebar_label: InfluxDB-PromQL
+keywords: [ 开源监控系统, InfluxDB监控,InfluxDB-PromQL监控 ]
+---
+
+> 使用 Prometheus PromQL 从 Prometheus 服务器中查询到 InfluxDB 的通用指标数据来进行监控。此方案适用于 Prometheus 已监控 InfluxDB，需要从 Prometheus 服务器抓取 InfluxDB 的监控数据。
+
+### 配置参数
+
+| 参数名称         | 参数帮助描述                                               |
+|--------------|------------------------------------------------------|
+| 监控Host       | 被监控的对端IPV4，IPV6或域名。注意⚠️不带协议头(eg: https://, http://)。 |
+| 任务名称         | 标识此监控的名称，名称需要保证唯一性。                                  |
+| 端口           | Prometheus api 端口，默认值：9090。                          |
+| 相对路径         | Prometheus查询PromQL的URL，默认值：/api/v1/query。            |
+| 请求方式         | 设置接口调用的请求方式：GET,POST,PUT,DELETE，默认值：GET。             |
+| 启用HTTPS      | 是否通过HTTPS访问网站，注意⚠️开启HTTPS一般默认对应端口需要改为443。            |
+| 用户名          | 接口Basic认证或Digest认证时使用的用户名。                           |
+| 密码           | 接口Basic认证或Digest认证时使用的密码。                            |
+| Content-Type | 设置携带BODY请求体数据请求时的资源类型。                               |
+| 请求BODY       | 设置携带BODY请求体数据，PUT POST请求方式时有效。                       |
+| 采集间隔         | 监控周期性采集数据间隔时间，单位秒，可设置的最小间隔为30秒。                      |
+| 描述备注         | 更多标识和描述此监控的备注信息，用户可以在这里备注信息。                         |
+
+### 采集指标
+
+#### 指标集合：basic_influxdb_memstats_alloc
+
+| 指标名称      | 指标单位 | 指标帮助描述  |
+|-----------|------|---------|
+| instance  | 无    | 指标所属实例  |
+| timestamp | 无    | 采集指标时间戳 |
+| value     | 无    | 指标值     |
+
+#### 指标集合： influxdb_database_numMeasurements
+
+| 指标名称      | 指标单位 | 指标帮助描述  |
+|-----------|------|---------|
+| job       | 无    | 指标名称    |
+| instance  | 无    | 指标所属实例  |
+| database  | 无    | 数据库名称   |
+| timestamp | 无    | 采集指标时间戳 |
+| value     | 无    | 指标值     |
+
+#### 指标集合： influxdb_query_rate_seconds
+
+| 指标名称      | 指标单位 | 指标帮助描述  |
+|-----------|------|---------|
+| instance  | 无    | 指标所属实例  |
+| timestamp | 无    | 采集指标时间戳 |
+| value     | 无    | 指标值     |
+
+#### 指标集合： influxdb_queryExecutor_queriesFinished_10s
+
+| 指标名称      | 指标单位 | 指标帮助描述  |
+|-----------|------|---------|
+| instance  | 无    | 指标所属实例  |
+| timestamp | 无    | 采集指标时间戳 |
+| value     | 无    | 指标值     |
+
+

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/kafka_promql.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/kafka_promql.md
@@ -1,0 +1,56 @@
+---
+id: kafka_promql
+title: 监控：Kafka-PromQL
+sidebar_label: Kafka-PromQL
+keywords: [ 开源监控系统,开源中间件监控, Kafka监控,Kafka-PromQL监控 ]
+---
+
+> 使用 Prometheus PromQL 从 Prometheus 服务器中查询到 Kafka 的通用指标数据来进行监控。此方案适用于 Prometheus 已监控 Kafka，需要从 Prometheus 服务器抓取 Kafka 的监控数据。
+
+### 前置条件
+
+1. 部署 kafka；
+2. 部署 kafka_exporter；
+3. 通过 prometheus 采集 kafka_exporter暴露的监控指标；
+
+### 配置参数
+
+| 参数名称         | 参数帮助描述                                               |
+|--------------|------------------------------------------------------|
+| 监控Host       | 被监控的对端IPV4，IPV6或域名。注意⚠️不带协议头(eg: https://, http://)。 |
+| 任务名称         | 标识此监控的名称，名称需要保证唯一性。                                  |
+| 端口           | Prometheus api 端口，默认值：9090。                          |
+| 相对路径         | Prometheus查询PromQL的URL，默认值：/api/v1/query。            |
+| 请求方式         | 设置接口调用的请求方式：GET,POST,PUT,DELETE，默认值：GET。             |
+| 启用HTTPS      | 是否通过HTTPS访问网站，注意⚠️开启HTTPS一般默认对应端口需要改为443。            |
+| 用户名          | 接口Basic认证或Digest认证时使用的用户名。                           |
+| 密码           | 接口Basic认证或Digest认证时使用的密码。                            |
+| Content-Type | 设置携带BODY请求体数据请求时的资源类型。                               |
+| 请求BODY       | 设置携带BODY请求体数据，PUT POST请求方式时有效。                       |
+| 采集间隔         | 监控周期性采集数据间隔时间，单位秒，可设置的最小间隔为30秒。                      |
+| 描述备注         | 更多标识和描述此监控的备注信息，用户可以在这里备注信息。                         |
+
+### 采集指标
+
+#### 指标集合：kafka_brokers
+
+| 指标名称       | 指标单位 | 指标帮助描述  |
+|------------|------|---------|
+| \_\_name__ | 无    | 指标名称    |
+| instance   | 无    | 指标所属实例  |
+| timestamp  | 无    | 采集指标时间戳 |
+| value      | 无    | 指标值     |
+
+#### 指标集合： kafka_topic_partitions
+
+| 指标名称       | 指标单位 | 指标帮助描述  |
+|------------|------|---------|
+| \_\_name__ | 无    | 指标名称    |
+| instance   | 无    | 指标所属实例  |
+| timestamp  | 无    | 采集指标时间戳 |
+| value      | 无    | 指标值     |
+
+### HertzBeat支持的其他Kafka监控方式
+
+1. kafka启用了JMX监控，可以使用 [Kafka](kafka) 监控；
+2. kafka集群部署kafka_exporter暴露的监控指标，可以参考 [Prometheus任务](prometheus) 配置Prometheus采集任务监控kafka。

--- a/home/sidebars.json
+++ b/home/sidebars.json
@@ -272,7 +272,8 @@
           "type": "category",
           "label": "custom",
           "items": [
-            "help/kafka_promql"
+            "help/kafka_promql",
+            "help/influxdb_promql"
           ]
         },
         {

--- a/home/sidebars.json
+++ b/home/sidebars.json
@@ -270,6 +270,13 @@
         },
         {
           "type": "category",
+          "label": "custom",
+          "items": [
+            "help/kafka_promql"
+          ]
+        },
+        {
+          "type": "category",
           "label": "network",
           "items": [
             "help/huawei_switch"

--- a/manager/src/main/resources/define/app-influxdb_promql.yml
+++ b/manager/src/main/resources/define/app-influxdb_promql.yml
@@ -42,7 +42,7 @@ params:
     type: number
     range: '[0,65535]'
     required: true
-    defaultValue: 80
+    defaultValue: 9090
   - field: method
     name:
       zh-CN: 请求方式
@@ -58,6 +58,7 @@ params:
         value: PUT
       - label: DELETE请求
         value: DELETE
+    defaultValue: GET
   - field: uri
     name:
       zh-CN: 相对路径
@@ -66,6 +67,7 @@ params:
     limit: 200
     required: true
     placeholder: 'API地址除IP端口外的路径 例如:/v2/book/bar'
+    defaultValue: /api/v1/query
   - field: ssl
     name:
       zh-CN: 启动SSL

--- a/manager/src/main/resources/define/app-kafka_promql.yml
+++ b/manager/src/main/resources/define/app-kafka_promql.yml
@@ -42,7 +42,7 @@ params:
     type: number
     range: '[0,65535]'
     required: true
-    defaultValue: 80
+    defaultValue: 9090
   - field: method
     name:
       zh-CN: 请求方式
@@ -58,6 +58,7 @@ params:
         value: PUT
       - label: DELETE请求
         value: DELETE
+    defaultValue: GET
   - field: uri
     name:
       zh-CN: 相对路径
@@ -66,6 +67,7 @@ params:
     limit: 200
     required: true
     placeholder: 'API地址除IP端口外的路径 例如:/v2/book/bar'
+    defaultValue: /api/v1/query
   - field: ssl
     name:
       zh-CN: 启动SSL


### PR DESCRIPTION
## What's changed?

1. ddd default values to kafka_promql and influxdb_promql monitoring template.
2. add help document for influxdb-promql and kafka-promql monitoring.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
