### PR TITLE
[improve] Implement cascading parameter list for HTTP protocol

### DIFF
--- a/manager/src/main/resources/define/app-api.yml
+++ b/manager/src/main/resources/define/app-api.yml
@@ -56,7 +56,7 @@ params:
     # default value
     defaultValue: 80
     # field-param field key
-  - field: method
+  - field: httpMethod
     # name-param field display i18n name
     name:
       zh-CN: 请求方式
@@ -164,6 +164,8 @@ params:
     # 参数输入框提示信息
     # param field input placeholder
     placeholder: 'Available When POST PUT'
+    # dependent parameter values list
+    parent: [ POST,PUT ]
     # required-true or false
     required: false
     # hide param-true or false
@@ -278,7 +280,7 @@ metrics:
       # http connect timeout
       timeout: ^_^timeout^_^
       # http method: GET POST PUT DELETE PATCH
-      method: ^_^method^_^
+      method: ^_^httpMethod^_^
       # if enabled https
       ssl: ^_^ssl^_^
       # http request payload

--- a/manager/src/main/resources/define/app-api_code.yml
+++ b/manager/src/main/resources/define/app-api_code.yml
@@ -56,7 +56,7 @@ params:
     # default value
     defaultValue: 80
     # field-param field key
-  - field: method
+  - field: httpMethod
     # name-param field display i18n name
     name:
       zh-CN: 请求方式
@@ -180,6 +180,8 @@ params:
     type: textarea
     # param field input placeholder
     placeholder: 'Available When POST PUT'
+    # dependent parameter values list
+    parent: [ POST,PUT ]
     # required-true or false
     required: false
     # hide param-true or false
@@ -291,7 +293,7 @@ metrics:
       port: ^_^port^_^
       url: ^_^uri^_^
       timeout: ^_^timeout^_^
-      method: ^_^method^_^
+      method: ^_^httpMethod^_^
       ssl: ^_^ssl^_^
       payload: ^_^payload^_^
       headers:

--- a/manager/src/main/resources/define/app-prometheus.yml
+++ b/manager/src/main/resources/define/app-prometheus.yml
@@ -127,21 +127,6 @@ params:
     required: false
     # hide param-true or false
     hide: true
-  # field-param field key
-  - field: payload
-    # name-param field display i18n name
-    name:
-      zh-CN: 请求BODY
-      en-US: BODY
-    # type-param field type(most mapping the html input type)
-    type: textarea
-    # param field input placeholder
-    placeholder: 'Available When POST PUT'
-    # required-true or false
-    required: false
-    # hide param-true or false
-    hide: true
-    # field-param field key
   - field: authType
     # name-param field display i18n name
     name:

--- a/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.html
+++ b/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.html
@@ -143,7 +143,7 @@
               [(ngModel)]="params[i].paramValue"
               [required]="paramDefine.required"
               nzButtonStyle="solid"
-              (ngModelChange)="onSnmpVersionChanged($event, paramDefine.field)"
+              (ngModelChange)="onParentChanged($event, paramDefine.field)"
               [name]="paramDefine.field"
               [id]="paramDefine.field"
             >
@@ -186,135 +186,137 @@
 
       <nz-collapse [nzGhost]="true" style="margin-bottom: 16px">
         <nz-collapse-panel [nzHeader]="extraColHeader" [nzShowArrow]="false">
-          <nz-form-item *ngFor="let paramDefine of advancedParamDefines; let i = index">
-            <nz-form-label
-              *ngIf="paramDefine.field !== 'host' && (paramDefine.type === 'text' || paramDefine.type === 'array')"
-              nzSpan="7"
-              [nzRequired]="paramDefine.required"
-              [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control
-              *ngIf="paramDefine.field !== 'host' && (paramDefine.type === 'text' || paramDefine.type === 'array')"
-              nzSpan="8"
-              [nzErrorTip]="'validation.required' | i18n"
-            >
-              <input
-                nz-input
-                [(ngModel)]="advancedParams[i].paramValue"
-                [required]="paramDefine.required"
-                [name]="paramDefine.field"
-                [type]="paramDefine.type"
-                [id]="paramDefine.field"
-                [placeholder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
-              />
-            </nz-form-control>
-
-            <nz-form-label
-              *ngIf="paramDefine.type === 'textarea'"
-              nzSpan="7"
-              [nzRequired]="paramDefine.required"
-              [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control *ngIf="paramDefine.type === 'textarea'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
-              <textarea
-                nz-input
-                [(ngModel)]="advancedParams[i].paramValue"
-                [required]="paramDefine.required"
-                [name]="paramDefine.field"
-                [id]="paramDefine.field"
-                [placeholder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
-                rows="8"
-              ></textarea>
-            </nz-form-control>
-
-            <nz-form-label
-              *ngIf="paramDefine.type === 'password'"
-              nzSpan="7"
-              [nzRequired]="paramDefine.required"
-              [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control *ngIf="paramDefine.type === 'password'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
-              <nz-input-group [nzSuffix]="suffixTemplate" style="width: 100%">
+          <ng-container *ngFor="let paramDefine of advancedParamDefines; let i = index">
+            <nz-form-item *ngIf="advancedParams[i].display">
+              <nz-form-label
+                *ngIf="paramDefine.field !== 'host' && (paramDefine.type === 'text' || paramDefine.type === 'array')"
+                nzSpan="7"
+                [nzRequired]="paramDefine.required"
+                [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control
+                *ngIf="paramDefine.field !== 'host' && (paramDefine.type === 'text' || paramDefine.type === 'array')"
+                nzSpan="8"
+                [nzErrorTip]="'validation.required' | i18n"
+              >
                 <input
-                  [type]="passwordVisible ? 'text' : 'password'"
                   nz-input
-                  placeholder="input password"
-                  [required]="paramDefine.required"
                   [(ngModel)]="advancedParams[i].paramValue"
-                  [id]="paramDefine.field"
+                  [required]="paramDefine.required"
                   [name]="paramDefine.field"
+                  [type]="paramDefine.type"
+                  [id]="paramDefine.field"
                   [placeholder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
                 />
-              </nz-input-group>
-              <ng-template #suffixTemplate>
-                <i nz-icon [nzType]="passwordVisible ? 'eye-invisible' : 'eye'" (click)="passwordVisible = !passwordVisible"></i>
-              </ng-template>
-            </nz-form-control>
+              </nz-form-control>
 
-            <nz-form-label *ngIf="paramDefine.type === 'number'" nzSpan="7" [nzRequired]="paramDefine.required" [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control *ngIf="paramDefine.type === 'number'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
-              <nz-input-number
-                [(ngModel)]="advancedParams[i].paramValue"
-                [required]="paramDefine.required"
-                [nzMin]="-1000"
-                [nzMax]="65535"
-                [nzStep]="1"
-                [nzPlaceHolder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
-                [name]="paramDefine.field"
-                [id]="paramDefine.field"
-              ></nz-input-number>
-            </nz-form-control>
+              <nz-form-label
+                *ngIf="paramDefine.type === 'textarea'"
+                nzSpan="7"
+                [nzRequired]="paramDefine.required"
+                [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control *ngIf="paramDefine.type === 'textarea'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
+                <textarea
+                  nz-input
+                  [(ngModel)]="advancedParams[i].paramValue"
+                  [required]="paramDefine.required"
+                  [name]="paramDefine.field"
+                  [id]="paramDefine.field"
+                  [placeholder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
+                  rows="8"
+                ></textarea>
+              </nz-form-control>
 
-            <nz-form-label *ngIf="paramDefine.type === 'boolean'" nzSpan="7" [nzRequired]="paramDefine.required" [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control *ngIf="paramDefine.type === 'boolean'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
-              <nz-switch
-                [(ngModel)]="advancedParams[i].paramValue"
-                [required]="paramDefine.required"
-                [name]="paramDefine.field"
-                [id]="paramDefine.field"
-              ></nz-switch>
-            </nz-form-control>
+              <nz-form-label
+                *ngIf="paramDefine.type === 'password'"
+                nzSpan="7"
+                [nzRequired]="paramDefine.required"
+                [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control *ngIf="paramDefine.type === 'password'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
+                <nz-input-group [nzSuffix]="suffixTemplate" style="width: 100%">
+                  <input
+                    [type]="passwordVisible ? 'text' : 'password'"
+                    nz-input
+                    placeholder="input password"
+                    [required]="paramDefine.required"
+                    [(ngModel)]="advancedParams[i].paramValue"
+                    [id]="paramDefine.field"
+                    [name]="paramDefine.field"
+                    [placeholder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
+                  />
+                </nz-input-group>
+                <ng-template #suffixTemplate>
+                  <i nz-icon [nzType]="passwordVisible ? 'eye-invisible' : 'eye'" (click)="passwordVisible = !passwordVisible"></i>
+                </ng-template>
+              </nz-form-control>
 
-            <nz-form-label *ngIf="paramDefine.type === 'radio'" nzSpan="7" [nzRequired]="paramDefine.required" [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control *ngIf="paramDefine.type === 'radio'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
-              <nz-radio-group
-                [(ngModel)]="advancedParams[i].paramValue"
-                [required]="paramDefine.required"
-                nzButtonStyle="solid"
-                [name]="paramDefine.field"
-                [id]="paramDefine.field"
-              >
-                <label nz-radio-button [nzValue]="optionItem.value" *ngFor="let optionItem of paramDefine.options">
-                  {{ optionItem.label }}
-                </label>
-              </nz-radio-group>
-            </nz-form-control>
+              <nz-form-label *ngIf="paramDefine.type === 'number'" nzSpan="7" [nzRequired]="paramDefine.required" [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control *ngIf="paramDefine.type === 'number'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
+                <nz-input-number
+                  [(ngModel)]="advancedParams[i].paramValue"
+                  [required]="paramDefine.required"
+                  [nzMin]="-1000"
+                  [nzMax]="65535"
+                  [nzStep]="1"
+                  [nzPlaceHolder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
+                  [name]="paramDefine.field"
+                  [id]="paramDefine.field"
+                ></nz-input-number>
+              </nz-form-control>
 
-            <nz-form-label
-              *ngIf="paramDefine.type === 'key-value'"
-              nzSpan="7"
-              [nzRequired]="paramDefine.required"
-              [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control *ngIf="paramDefine.type === 'key-value'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
-              <app-key-value-input
-                [(value)]="advancedParams[i].paramValue"
-                [id]="paramDefine.field"
-                keyAlias="Header Name"
-                valueAlias="Header Value"
-              ></app-key-value-input>
-            </nz-form-control>
-          </nz-form-item>
+              <nz-form-label *ngIf="paramDefine.type === 'boolean'" nzSpan="7" [nzRequired]="paramDefine.required" [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control *ngIf="paramDefine.type === 'boolean'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
+                <nz-switch
+                  [(ngModel)]="advancedParams[i].paramValue"
+                  [required]="paramDefine.required"
+                  [name]="paramDefine.field"
+                  [id]="paramDefine.field"
+                ></nz-switch>
+              </nz-form-control>
+
+              <nz-form-label *ngIf="paramDefine.type === 'radio'" nzSpan="7" [nzRequired]="paramDefine.required" [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control *ngIf="paramDefine.type === 'radio'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
+                <nz-radio-group
+                  [(ngModel)]="advancedParams[i].paramValue"
+                  [required]="paramDefine.required"
+                  nzButtonStyle="solid"
+                  [name]="paramDefine.field"
+                  [id]="paramDefine.field"
+                >
+                  <label nz-radio-button [nzValue]="optionItem.value" *ngFor="let optionItem of paramDefine.options">
+                    {{ optionItem.label }}
+                  </label>
+                </nz-radio-group>
+              </nz-form-control>
+
+              <nz-form-label
+                *ngIf="paramDefine.type === 'key-value'"
+                nzSpan="7"
+                [nzRequired]="paramDefine.required"
+                [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control *ngIf="paramDefine.type === 'key-value'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
+                <app-key-value-input
+                  [(value)]="advancedParams[i].paramValue"
+                  [id]="paramDefine.field"
+                  keyAlias="Header Name"
+                  valueAlias="Header Value"
+                ></app-key-value-input>
+              </nz-form-control>
+            </nz-form-item>
+          </ng-container>
         </nz-collapse-panel>
       </nz-collapse>
       <ng-template #extraColHeader>

--- a/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-edit/monitor-edit.component.ts
@@ -164,9 +164,15 @@ export class MonitorEditComponent implements OnInit {
                 this.hostName = define.name;
               }
             });
+            this.onPageInit()
             let paramDefine = this.paramDefines.find(param => param.field === 'snmpVersion');
             if (paramDefine) {
-              this.onSnmpVersionChanged(this.paramValueMap.get(paramDefine.field)?.paramValue, paramDefine.field);
+              this.onParentChanged(this.paramValueMap.get(paramDefine.field)?.paramValue, paramDefine.field);
+            }
+            paramDefine = this.paramDefines.find(param => param.field === 'httpMethod');
+
+            if (paramDefine) {
+              this.onParentChanged(this.paramValueMap.get(paramDefine.field)?.paramValue, paramDefine.field);
             }
           } else {
             console.warn(message.msg);
@@ -190,6 +196,15 @@ export class MonitorEditComponent implements OnInit {
       );
   }
 
+  onPageInit() {
+    this.paramDefines.forEach((paramDefine, index) => {
+      this.params[index].display = true;
+    });
+    this.advancedParamDefines.forEach((advancedParamDefine, index) => {
+      this.advancedParams[index].display = true;
+    });
+  }
+
   onParamBooleanChanged(booleanValue: boolean, field: string) {
     // 对SSL的端口联动处理, 不开启SSL默认80端口，开启SSL默认443
     if (field === 'ssl') {
@@ -205,13 +220,22 @@ export class MonitorEditComponent implements OnInit {
     }
   }
 
-  onSnmpVersionChanged(snmpVersion: string, field: string) {
-    // 对不同snmp版本需要的参数进行动态展示
+  onParentChanged(parentValue: string, field: string) {
+    // 基础设置参数级联展示
     if (field === 'snmpVersion') {
       this.paramDefines.forEach((paramDefine, index) => {
         this.params[index].display = true;
-        if (paramDefine.parent != null && !paramDefine.parent.toString().includes(snmpVersion)) {
+        if (paramDefine.parent != undefined && !paramDefine.parent.toString().includes(parentValue)) {
           this.params[index].display = false;
+        }
+      });
+    }
+    // 高级设置参数级联展示
+    if (field === 'httpMethod') {
+      this.advancedParamDefines.forEach((advancedParamDefine, index) => {
+        this.advancedParams[index].display = true;
+        if (advancedParamDefine.parent != undefined && !advancedParamDefine.parent.toString().includes(parentValue)) {
+          this.advancedParams[index].display = false;
         }
       });
     }

--- a/web-app/src/app/routes/monitor/monitor-new/monitor-new.component.html
+++ b/web-app/src/app/routes/monitor/monitor-new/monitor-new.component.html
@@ -151,7 +151,7 @@
             <nz-radio-group
               [(ngModel)]="params[i].paramValue"
               nzButtonStyle="solid"
-              (ngModelChange)="onSnmpVersionChanged($event, paramDefine.field)"
+              (ngModelChange)="onParentChanged($event, paramDefine.field)"
               [required]="paramDefine.required"
               [name]="paramDefine.field"
               [id]="paramDefine.field"
@@ -195,135 +195,137 @@
 
       <nz-collapse [nzGhost]="true" style="margin-bottom: 16px">
         <nz-collapse-panel [nzHeader]="extraColHeader" [nzShowArrow]="false">
-          <nz-form-item *ngFor="let paramDefine of advancedParamDefines; let i = index">
-            <nz-form-label
-              *ngIf="paramDefine.field !== 'host' && (paramDefine.type === 'text' || paramDefine.type === 'array')"
-              nzSpan="7"
-              [nzRequired]="paramDefine.required"
-              [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control
-              *ngIf="paramDefine.field !== 'host' && (paramDefine.type === 'text' || paramDefine.type === 'array')"
-              nzSpan="8"
-              [nzErrorTip]="'validation.required' | i18n"
-            >
-              <input
-                nz-input
-                [(ngModel)]="advancedParams[i].paramValue"
-                [required]="paramDefine.required"
-                [name]="paramDefine.field"
-                [type]="paramDefine.type"
-                [id]="paramDefine.field"
-                [placeholder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
-              />
-            </nz-form-control>
-
-            <nz-form-label
-              *ngIf="paramDefine.type === 'textarea'"
-              nzSpan="7"
-              [nzRequired]="paramDefine.required"
-              [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control *ngIf="paramDefine.type === 'textarea'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
-              <textarea
-                nz-input
-                [(ngModel)]="advancedParams[i].paramValue"
-                [required]="paramDefine.required"
-                [name]="paramDefine.field"
-                [id]="paramDefine.field"
-                [placeholder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
-                rows="8"
-              ></textarea>
-            </nz-form-control>
-
-            <nz-form-label
-              *ngIf="paramDefine.type === 'password'"
-              nzSpan="7"
-              [nzRequired]="paramDefine.required"
-              [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control *ngIf="paramDefine.type === 'password'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
-              <nz-input-group [nzSuffix]="suffixTemplate" style="width: 100%">
+          <ng-container *ngFor="let paramDefine of advancedParamDefines; let i = index">
+            <nz-form-item *ngIf="advancedParams[i].display">
+              <nz-form-label
+                *ngIf="paramDefine.field !== 'host' && (paramDefine.type === 'text' || paramDefine.type === 'array')"
+                nzSpan="7"
+                [nzRequired]="paramDefine.required"
+                [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control
+                *ngIf="paramDefine.field !== 'host' && (paramDefine.type === 'text' || paramDefine.type === 'array')"
+                nzSpan="8"
+                [nzErrorTip]="'validation.required' | i18n"
+              >
                 <input
-                  [type]="passwordVisible ? 'text' : 'password'"
                   nz-input
-                  placeholder="input password"
-                  [required]="paramDefine.required"
                   [(ngModel)]="advancedParams[i].paramValue"
-                  [id]="paramDefine.field"
+                  [required]="paramDefine.required"
                   [name]="paramDefine.field"
+                  [type]="paramDefine.type"
+                  [id]="paramDefine.field"
                   [placeholder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
                 />
-              </nz-input-group>
-              <ng-template #suffixTemplate>
-                <i nz-icon [nzType]="passwordVisible ? 'eye-invisible' : 'eye'" (click)="passwordVisible = !passwordVisible"></i>
-              </ng-template>
-            </nz-form-control>
+              </nz-form-control>
 
-            <nz-form-label *ngIf="paramDefine.type === 'number'" nzSpan="7" [nzRequired]="paramDefine.required" [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control *ngIf="paramDefine.type === 'number'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
-              <nz-input-number
-                [(ngModel)]="advancedParams[i].paramValue"
-                [required]="paramDefine.required"
-                [nzMin]="-1000"
-                [nzMax]="65535"
-                [nzStep]="1"
-                [nzPlaceHolder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
-                [name]="paramDefine.field"
-                [id]="paramDefine.field"
-              ></nz-input-number>
-            </nz-form-control>
+              <nz-form-label
+                *ngIf="paramDefine.type === 'textarea'"
+                nzSpan="7"
+                [nzRequired]="paramDefine.required"
+                [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control *ngIf="paramDefine.type === 'textarea'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
+                <textarea
+                  nz-input
+                  [(ngModel)]="advancedParams[i].paramValue"
+                  [required]="paramDefine.required"
+                  [name]="paramDefine.field"
+                  [id]="paramDefine.field"
+                  [placeholder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
+                  rows="8"
+                ></textarea>
+              </nz-form-control>
 
-            <nz-form-label *ngIf="paramDefine.type === 'boolean'" nzSpan="7" [nzRequired]="paramDefine.required" [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control *ngIf="paramDefine.type === 'boolean'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
-              <nz-switch
-                [(ngModel)]="advancedParams[i].paramValue"
-                [required]="paramDefine.required"
-                [name]="paramDefine.field"
-                [id]="paramDefine.field"
-              ></nz-switch>
-            </nz-form-control>
+              <nz-form-label
+                *ngIf="paramDefine.type === 'password'"
+                nzSpan="7"
+                [nzRequired]="paramDefine.required"
+                [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control *ngIf="paramDefine.type === 'password'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
+                <nz-input-group [nzSuffix]="suffixTemplate" style="width: 100%">
+                  <input
+                    [type]="passwordVisible ? 'text' : 'password'"
+                    nz-input
+                    placeholder="input password"
+                    [required]="paramDefine.required"
+                    [(ngModel)]="advancedParams[i].paramValue"
+                    [id]="paramDefine.field"
+                    [name]="paramDefine.field"
+                    [placeholder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
+                  />
+                </nz-input-group>
+                <ng-template #suffixTemplate>
+                  <i nz-icon [nzType]="passwordVisible ? 'eye-invisible' : 'eye'" (click)="passwordVisible = !passwordVisible"></i>
+                </ng-template>
+              </nz-form-control>
 
-            <nz-form-label *ngIf="paramDefine.type === 'radio'" nzSpan="7" [nzRequired]="paramDefine.required" [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control *ngIf="paramDefine.type === 'radio'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
-              <nz-radio-group
-                [(ngModel)]="advancedParams[i].paramValue"
-                [required]="paramDefine.required"
-                nzButtonStyle="solid"
-                [name]="paramDefine.field"
-                [id]="paramDefine.field"
-              >
-                <label nz-radio-button [nzValue]="optionItem.value" *ngFor="let optionItem of paramDefine.options">
-                  {{ optionItem.label }}
-                </label>
-              </nz-radio-group>
-            </nz-form-control>
+              <nz-form-label *ngIf="paramDefine.type === 'number'" nzSpan="7" [nzRequired]="paramDefine.required" [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control *ngIf="paramDefine.type === 'number'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
+                <nz-input-number
+                  [(ngModel)]="advancedParams[i].paramValue"
+                  [required]="paramDefine.required"
+                  [nzMin]="-1000"
+                  [nzMax]="65535"
+                  [nzStep]="1"
+                  [nzPlaceHolder]="paramDefine.placeholder ? paramDefine.placeholder : ''"
+                  [name]="paramDefine.field"
+                  [id]="paramDefine.field"
+                ></nz-input-number>
+              </nz-form-control>
 
-            <nz-form-label
-              *ngIf="paramDefine.type === 'key-value'"
-              nzSpan="7"
-              [nzRequired]="paramDefine.required"
-              [nzFor]="paramDefine.field"
-              >{{ paramDefine.name }}
-            </nz-form-label>
-            <nz-form-control *ngIf="paramDefine.type === 'key-value'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
-              <app-key-value-input
-                [(value)]="advancedParams[i].paramValue"
-                [id]="paramDefine.field"
-                keyAlias="Header Name"
-                valueAlias="Header Value"
-              ></app-key-value-input>
-            </nz-form-control>
-          </nz-form-item>
+              <nz-form-label *ngIf="paramDefine.type === 'boolean'" nzSpan="7" [nzRequired]="paramDefine.required" [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control *ngIf="paramDefine.type === 'boolean'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
+                <nz-switch
+                  [(ngModel)]="advancedParams[i].paramValue"
+                  [required]="paramDefine.required"
+                  [name]="paramDefine.field"
+                  [id]="paramDefine.field"
+                ></nz-switch>
+              </nz-form-control>
+
+              <nz-form-label *ngIf="paramDefine.type === 'radio'" nzSpan="7" [nzRequired]="paramDefine.required" [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control *ngIf="paramDefine.type === 'radio'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
+                <nz-radio-group
+                  [(ngModel)]="advancedParams[i].paramValue"
+                  [required]="paramDefine.required"
+                  nzButtonStyle="solid"
+                  [name]="paramDefine.field"
+                  [id]="paramDefine.field"
+                >
+                  <label nz-radio-button [nzValue]="optionItem.value" *ngFor="let optionItem of paramDefine.options">
+                    {{ optionItem.label }}
+                  </label>
+                </nz-radio-group>
+              </nz-form-control>
+
+              <nz-form-label
+                *ngIf="paramDefine.type === 'key-value'"
+                nzSpan="7"
+                [nzRequired]="paramDefine.required"
+                [nzFor]="paramDefine.field"
+                >{{ paramDefine.name }}
+              </nz-form-label>
+              <nz-form-control *ngIf="paramDefine.type === 'key-value'" nzSpan="8" [nzErrorTip]="'validation.required' | i18n">
+                <app-key-value-input
+                  [(value)]="advancedParams[i].paramValue"
+                  [id]="paramDefine.field"
+                  keyAlias="Header Name"
+                  valueAlias="Header Value"
+                ></app-key-value-input>
+              </nz-form-control>
+            </nz-form-item>
+          </ng-container>
         </nz-collapse-panel>
       </nz-collapse>
       <ng-template #extraColHeader>

--- a/web-app/src/app/routes/monitor/monitor-new/monitor-new.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-new/monitor-new.component.ts
@@ -179,13 +179,22 @@ export class MonitorNewComponent implements OnInit {
     }
   }
 
-  onSnmpVersionChanged(snmpVersion: string, field: string) {
-    // 对不同snmp版本需要的参数进行动态展示
+  onParentChanged(parentValue: string, field: string) {
+    // 基础设置参数级联展示
     if (field === 'snmpVersion') {
       this.paramDefines.forEach((paramDefine, index) => {
         this.params[index].display = true;
-        if (paramDefine.parent != undefined && !paramDefine.parent.toString().includes(snmpVersion)) {
+        if (paramDefine.parent != undefined && !paramDefine.parent.toString().includes(parentValue)) {
           this.params[index].display = false;
+        }
+      });
+    }
+    // 高级设置参数级联展示
+    if (field === 'httpMethod') {
+      this.advancedParamDefines.forEach((advancedParamDefine, index) => {
+        this.advancedParams[index].display = true;
+        if (advancedParamDefine.parent != undefined && !advancedParamDefine.parent.toString().includes(parentValue)) {
+          this.advancedParams[index].display = false;
         }
       });
     }


### PR DESCRIPTION
## What's changed?
similar to https://github.com/apache/hertzbeat/pull/1976.
relate to https://github.com/apache/hertzbeat/issues/1705

The previous PR caused incorrect parameter display when monitoring the usage of other protocols. This PR fixes this bug.

<!-- Describe Your PR Here -->
When add a new monitor using HTTP:

https://github.com/apache/hertzbeat/assets/61108539/c19ea532-f9c0-45e0-9160-28bc4187b1f0

When edit a existing monitor using HTTP:

https://github.com/apache/hertzbeat/assets/61108539/93ee72b3-303f-41c0-9412-94ca1857ee38



## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
