### PR TITLE
[bugfix] fix collector startup error classpath

### DIFF
--- a/script/assembly/collector/bin/startup.sh
+++ b/script/assembly/collector/bin/startup.sh
@@ -99,7 +99,7 @@ echo -e "Starting the HertzBeat $SERVER_NAME ..."
 
 if [ -f "./java/bin/java" ]; then
     echo -e "Use the inner package jdk to start"
-    nohup ./java/bin/java $JAVA_OPTS $JAVA_MEM_OPTS $CONFIG_FILES $CLASSPATH $MAIN_CLASS >logs/startup.log 2>&1 &
+    nohup ./java/bin/java $JAVA_OPTS $JAVA_MEM_OPTS $CONFIG_FILES -cp $CLASSPATH $MAIN_CLASS >logs/startup.log 2>&1 &
 else
     JAVA_EXIST=`which java | grep bin | wc -l`
     if [ $JAVA_EXIST -le 0 ]; then
@@ -107,7 +107,7 @@ else
       exit 1
     fi
     echo -e "Use the system environment jdk to start"
-    nohup java $JAVA_OPTS $JAVA_MEM_OPTS $CONFIG_FILES $CLASSPATH $MAIN_CLASS >logs/startup.log 2>&1 &
+    nohup java $JAVA_OPTS $JAVA_MEM_OPTS $CONFIG_FILES -cp $CLASSPATH $MAIN_CLASS >logs/startup.log 2>&1 &
 fi
 
 COUNT=0


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
fix collector startup error classpath

```
java.lang.ClassNotFoundException: /Users/tom/code/opensource/hertzbeat/dist/apache-hertzbeat-collector-1/6/0-incubating-bin/apache-hertzbeat-collector-1/6/0/jar:/Users/tom/code/opensource/hertzbeat/dist/apache-hertzbeat-collector-1/6/0-incubating-bin/ext-lib/*
```

## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
