### PR TITLE
[fix] Fix possible potential thread safe bugs

### DIFF
--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/ConnectionCommonCache.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/cache/ConnectionCommonCache.java
@@ -197,15 +197,18 @@ public class ConnectionCommonCache<T, C extends AbstractConnection<?>> {
             cacheMap.remove(key);
             return Optional.empty();
         }
-        C value = cacheMap.get(key);
-        if (value == null) {
-            log.error("[connection common cache] value is null, remove it, key {}.", key);
-            cacheMap.remove(key);
-            timeoutMap.remove(key);
-        } else if (refreshCache) {
-            cacheTime[0] = System.currentTimeMillis();
-            timeoutMap.put(key, cacheTime);
-        }
+        C value = cacheMap.compute(key, (k, v) -> {
+            if (v == null) {
+                log.error("[connection common cache] value is null, remove it, key {}.", key);
+                timeoutMap.remove(key);
+                return null;
+            }
+            if (refreshCache) {
+                cacheTime[0] = System.currentTimeMillis();
+                timeoutMap.put(key, cacheTime);
+            }
+            return v;
+        });
         return Optional.ofNullable(value);
     }
 

--- a/collector/src/test/java/org/apache/hertzbeat/collector/collect/common/cache/CommonCacheTest.java
+++ b/collector/src/test/java/org/apache/hertzbeat/collector/collect/common/cache/CommonCacheTest.java
@@ -17,30 +17,35 @@
 
 package org.apache.hertzbeat.collector.collect.common.cache;
 
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test case for {@link ConnectionCommonCache}
  */
-@ExtendWith(MockitoExtension.class)
 class CommonCacheTest {
 
-    @Mock
     private AbstractConnection<?> mockConnection;
 
-    @InjectMocks
     private ConnectionCommonCache<String, AbstractConnection<?>> cache;
 
     @BeforeEach
     void setUp() {
         cache = new ConnectionCommonCache<>();
+        mockConnection = new AbstractConnection<>() {
+            @Override
+            public Object getConnection() {
+                return null;
+            }
+
+            @Override
+            public void closeConnection() throws Exception {
+            }
+        };
     }
 
     @Test

--- a/manager/src/main/java/org/apache/hertzbeat/manager/scheduler/ConcurrentTreeMap.java
+++ b/manager/src/main/java/org/apache/hertzbeat/manager/scheduler/ConcurrentTreeMap.java
@@ -81,4 +81,17 @@ public class ConcurrentTreeMap<K, V> extends TreeMap<K, V> {
             readWriteLock.readLock().unlock();
         }
     }
+
+    public Map.Entry<K, V> ceilingOrFirstEntry(K key) {
+        readWriteLock.readLock().lock();
+        try {
+            Map.Entry<K, V> entry = super.ceilingEntry(key);
+            if (entry == null) {
+                return super.firstEntry();
+            }
+            return entry;
+        } finally {
+            readWriteLock.readLock().unlock();
+        }
+    }
 }

--- a/manager/src/main/java/org/apache/hertzbeat/manager/scheduler/ConsistentHash.java
+++ b/manager/src/main/java/org/apache/hertzbeat/manager/scheduler/ConsistentHash.java
@@ -243,10 +243,7 @@ public class ConsistentHash {
             dispatchJobCache.add(new DispatchJob(dispatchHash, jobId));
             return null;
         }
-        Map.Entry<Integer, Node> ceilEntry = hashCircle.ceilingEntry(dispatchHash);
-        if (ceilEntry == null) {
-            ceilEntry = hashCircle.firstEntry();
-        }
+        Map.Entry<Integer, Node> ceilEntry = hashCircle.ceilingOrFirstEntry(dispatchHash);
         int virtualKey = ceilEntry.getKey();
         Node curNode = ceilEntry.getValue();
 
@@ -265,10 +262,7 @@ public class ConsistentHash {
             log.warn("There is no available collector registered.");
             return null;
         }
-        Map.Entry<Integer, Node> ceilEntry = hashCircle.ceilingEntry(dispatchHash);
-        if (ceilEntry == null) {
-            ceilEntry = hashCircle.firstEntry();
-        }
+        Map.Entry<Integer, Node> ceilEntry = hashCircle.ceilingOrFirstEntry(dispatchHash);
         return ceilEntry.getValue();
     }
 
@@ -416,10 +410,10 @@ public class ConsistentHash {
             if (virtualNodeMap == null) {
                 virtualNodeMap = new ConcurrentHashMap<>(16);
             }
-            Set<Long[]> virtualNodeJobs = virtualNodeMap.get(virtualHashKey);
-            if (virtualNodeJobs != null) {
-                reDispatchJobs.addAll(virtualNodeJobs);
-            }
+            virtualNodeMap.computeIfPresent(virtualHashKey, (k, v) -> {
+                reDispatchJobs.addAll(v);
+                return v;
+            });
             virtualNodeMap.put(virtualHashKey, reDispatchJobs);
         }
         


### PR DESCRIPTION
## What's changed?
Refactored some code to ensure thread safety. And I think `addNode()` and `removeNode()` in `ConsistentHash` class may cause thread unsafe issues.  Please give some suggestions.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
