### PR TITLE
[bugfix]Tag with empty value Shouldn't transform to Tag:

### DIFF
--- a/manager/src/main/java/org/apache/hertzbeat/manager/service/impl/TagServiceImpl.java
+++ b/manager/src/main/java/org/apache/hertzbeat/manager/service/impl/TagServiceImpl.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hertzbeat.common.entity.manager.Monitor;
 import org.apache.hertzbeat.common.entity.manager.Tag;
 import org.apache.hertzbeat.manager.dao.TagDao;
@@ -55,6 +56,7 @@ public class TagServiceImpl implements TagService {
     public void modifyTag(Tag tag) {
         Optional<Tag> tagOptional = tagDao.findById(tag.getId());
         if (tagOptional.isPresent()) {
+            tag.setTagValue(StringUtils.isEmpty(tag.getTagValue()) ? null : tag.getTagValue());
             tagDao.save(tag);
         } else {
             throw new IllegalArgumentException("The tag is not existed");


### PR DESCRIPTION
## What's changed?

Fix [the issue](https://github.com/apache/hertzbeat/issues/2023)
### What is the bug
When I set Tag's  name to 'TEST' and value to ''，I expect to get `TEST` Tag, but sometime(when tag's value has set a value then delete the value to empty String) I get `TEST:`(with colon)

### How to fix the bug
- If the value is empty String('')，set the value to null

### Effect
![image](https://github.com/apache/hertzbeat/assets/3973419/7d60645e-f257-47ec-bd12-365c84339ff0)
![image](https://github.com/apache/hertzbeat/assets/3973419/394f9896-acd4-489c-ab33-dce6aec509c7)

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
