### PR TITLE
[feature] Add automatic refresh to the monitoring center

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Component, Inject, OnInit } from '@angular/core';
+import {Component, Inject, OnDestroy, OnInit} from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { I18NService } from '@core';
 import { ALAIN_I18N_TOKEN } from '@delon/theme';
@@ -40,7 +40,7 @@ import { formatTagName } from '../../../shared/utils/common-util';
   templateUrl: './monitor-list.component.html',
   styleUrls: ['./monitor-list.component.less']
 })
-export class MonitorListComponent implements OnInit {
+export class MonitorListComponent implements OnInit, OnDestroy {
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -74,6 +74,7 @@ export class MonitorListComponent implements OnInit {
   appSearchOrigin: any[] = [];
   appSearchResult: any[] = [];
   appSearchLoading = false;
+  intervalId: any;
 
   switchExportTypeModalFooter: ModalButtonOptions[] = [
     { label: this.i18nSvc.fanyi('common.button.cancel'), type: 'default', onClick: () => (this.isSwitchExportTypeModalVisible = false) }
@@ -99,6 +100,16 @@ export class MonitorListComponent implements OnInit {
       this.tableLoading = true;
       this.loadMonitorTable();
     });
+    // Set up an interval to refresh the table every 2 minutes
+    this.intervalId = setInterval(() => {
+      this.sync();
+    }, 12000); // 120000 ms = 2 minutes
+  }
+
+  ngOnDestroy(): void {
+    if (this.intervalId) {
+      clearInterval(this.intervalId);
+    }
   }
 
   onFilterSearchMonitors() {


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

Add automatic refresh to the monitoring center.

Screenshot of successful API call for auto-refresh：
![3dc75899358aade73e36779fb0fe352](https://github.com/apache/hertzbeat/assets/61108539/25529d6b-87da-4978-b530-d7dff0c3c9b5)


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
