### PR TITLE
[doc] mysql monitoring help document adds steps for importing drivers

### DIFF
--- a/home/docs/help/mysql.md
+++ b/home/docs/help/mysql.md
@@ -7,6 +7,11 @@ keywords: [open source monitoring tool, open source database monitoring tool, mo
 
 > Collect and monitor the general performance Metrics of MySQL database. Support MYSQL5+.
 
+### Add MYSQL jdbc driver jar
+
+- Download the MYSQL jdbc driver jar package, such as mysql-connector-java-8.1.0.jar. https://mvnrepository.com/artifact/com.mysql/mysql-connector-j/8.1.0
+- Copy the jar package to the `hertzbeat/ext-lib` directory.
+
 ### Configuration parameter 
 
 | Parameter name      | Parameter help description                                                                                                                                                |

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/mysql.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/mysql.md
@@ -7,6 +7,11 @@ keywords: [开源监控系统, 开源数据库监控, Mysql数据库监控]
 
 > 对MYSQL数据库的通用性能指标进行采集监控。支持MYSQL5+。
 
+### 添加 MYSQL jdbc 驱动 jar
+
+- 下载 MYSQL jdbc driver jar, 例如 mysql-connector-java-8.1.0.jar. https://mvnrepository.com/artifact/com.mysql/mysql-connector-j/8.1.0
+- 将此 jar 包拷贝放入 HertzBeat 的安装目录下的 `ext-lib` 目录下.
+
 ### 配置参数
 
 | 参数名称      | 参数帮助描述 |


### PR DESCRIPTION
## What's changed?

1. mysql monitoring help document adds steps for importing drivers (#2084)

## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
