### PR TITLE
[bugfix] fix some template menus hidden when too long

### DIFF
--- a/web-app/src/app/routes/setting/define/define.component.less
+++ b/web-app/src/app/routes/setting/define/define.component.less
@@ -1,0 +1,6 @@
+
+:host ::ng-deep {
+  .ant-menu-inline.ant-menu-root .ant-menu-item > .ant-menu-title-content, .ant-menu-inline.ant-menu-root .ant-menu-submenu-title > .ant-menu-title-content {
+    overflow: unset;
+  }
+}


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

before

<img width="830" alt="iShot_2024-06-17_23 49 25" src="https://github.com/apache/hertzbeat/assets/24788200/691d95e8-6887-462b-a91b-6923ab8aa0ae">

fix:

<img width="843" alt="iShot_2024-06-17_23 49 08" src="https://github.com/apache/hertzbeat/assets/24788200/fc5cd438-713d-4fe9-ae46-61fd5c89c8be">


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
