### PR TITLE
[bugfix] fix extract double and unit error when unit is Ki

### DIFF
--- a/collector/src/main/java/org/apache/hertzbeat/collector/util/CollectUtil.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/util/CollectUtil.java
@@ -55,7 +55,7 @@ public final class CollectUtil {
     private static final String CRYING_PLACEHOLDER_REX = "\\^o\\^";
     private static final String CRYING_PLACEHOLDER_REGEX = "(\\^o\\^)(\\w|-|$|\\.)+(\\^o\\^)";
     private static final Pattern CRYING_PLACEHOLDER_REGEX_PATTERN = Pattern.compile(CRYING_PLACEHOLDER_REGEX);
-    private static final List<String> UNIT_SYMBOLS = Arrays.asList("%", "G", "g", "M", "m", "K", "k", "B", "b");
+    private static final List<String> UNIT_SYMBOLS = Arrays.asList("%", "G", "g", "M", "m", "K", "k", "B", "b", "Ki", "Mi", "Gi");
 
     /**
      * private constructor, not allow to create instance.
@@ -104,7 +104,7 @@ public final class CollectUtil {
             log.debug(e.getMessage());
         }
 
-        if (!str.matches(DOUBLE_AND_UNIT_CHECK_REGEX)){
+        if (!str.matches(DOUBLE_AND_UNIT_CHECK_REGEX)) {
             return doubleAndUnit;
         }
         // extract unit from str value, eg: 23.43GB, 33KB, 44.22G

--- a/collector/src/test/java/org/apache/hertzbeat/collector/util/CollectUtilTest.java
+++ b/collector/src/test/java/org/apache/hertzbeat/collector/util/CollectUtilTest.java
@@ -81,6 +81,15 @@ class CollectUtilTest {
         assertNull(res4.getValue());
         assertNull(res4.getUnit());
 
+        CollectUtil.DoubleAndUnit res5 = CollectUtil.extractDoubleAndUnitFromStr("200Ki");
+        assertEquals(200, res5.getValue());
+        assertEquals("Ki", res5.getUnit());
+        CollectUtil.DoubleAndUnit res6 = CollectUtil.extractDoubleAndUnitFromStr("200Mi");
+        assertEquals(200, res6.getValue());
+        assertEquals("Mi", res6.getUnit());
+        CollectUtil.DoubleAndUnit res7 = CollectUtil.extractDoubleAndUnitFromStr("200Gi");
+        assertEquals(200, res7.getValue());
+        assertEquals("Gi", res7.getUnit());
     }
 
 


### PR DESCRIPTION
## What's changed?

1.  fix extract double and unit error when unit is Ki (#2096 ) 


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
