### PR TITLE
feat: supports TTL for greptimedb data storage

### DIFF
--- a/home/docs/start/greptime-init.md
+++ b/home/docs/start/greptime-init.md
@@ -60,9 +60,10 @@ warehouse:
          driver-class-name: com.mysql.cj.jdbc.Driver
          username: greptime
          password: greptime
+         expire-time: 30d
 ```
 
-The default database is `hertzbeat` in the `url`.
+The default database is `hertzbeat` in the `url`, and it will be created automatically. The `expire-time` specifies the TTL(time-to-live) of the auto-created database, it's 30 days by default.
 
 2. Restart HertzBeat
 

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/greptime-init.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/greptime-init.md
@@ -60,9 +60,10 @@ warehouse:
          driver-class-name: com.mysql.cj.jdbc.Driver
          username: greptime
          password: greptime
+         expire-time: 30d
 ```
 
-默认数据库是 URL 中配置的  `hertzbeat` 。
+默认数据库是 URL 中配置的  `hertzbeat` ，将自动创建。 `expire-time` 是自动创建的数据库的 TTL （数据过期）时间，默认为 30 天。
 
 2. 重启 HertzBeat
 

--- a/manager/src/main/resources/application.yml
+++ b/manager/src/main/resources/application.yml
@@ -146,6 +146,7 @@ warehouse:
       driver-class-name: com.mysql.cj.jdbc.Driver
       username: greptime
       password: greptime
+      expire-time: 30d
     iot-db:
       enabled: false
       host: 127.0.0.1

--- a/warehouse/src/main/java/org/apache/hertzbeat/warehouse/store/history/greptime/GreptimeProperties.java
+++ b/warehouse/src/main/java/org/apache/hertzbeat/warehouse/store/history/greptime/GreptimeProperties.java
@@ -27,5 +27,7 @@ import org.springframework.boot.context.properties.bind.DefaultValue;
 public record GreptimeProperties(@DefaultValue("false") boolean enabled,
 	@DefaultValue("127.0.0.1:4001") String grpcEndpoints,
 	@DefaultValue("jdbc:mysql://127.0.0.1:4002/hertzbeat?connectionTimeZone=Asia/Shanghai&forceConnectionTimeZoneToSession=true") String url,
-	@DefaultValue("com.mysql.cj.jdbc.Driver") String driverClassName, String username, String password) {
+	@DefaultValue("com.mysql.cj.jdbc.Driver") String driverClassName, String username, String password,
+	// Database TTL, default is 30 days.
+	@DefaultValue("30d") String expireTime) {
 }


### PR DESCRIPTION
## What's changed?

The following PR of #2095. It adds `TTL` for auto-created database, 30 days by default.


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
