### PR TITLE
Optimize the visual experience of the `nz-table` template.

### DIFF
--- a/web-app/src/app/routes/alert/alert-center/alert-center.component.html
+++ b/web-app/src/app/routes/alert/alert-center/alert-center.component.html
@@ -99,7 +99,7 @@
   [nzPageSizeOptions]="[8, 15, 25]"
   (nzQueryParams)="onTablePageChange($event)"
   nzShowPagination="true"
-  [nzScroll]="{ x: '1240px', y: '100%' }"
+  [nzScroll]="{ x: '1240px' }"
 >
   <thead>
     <tr>

--- a/web-app/src/app/routes/alert/alert-converge/alert-converge.component.html
+++ b/web-app/src/app/routes/alert/alert-converge/alert-converge.component.html
@@ -63,7 +63,7 @@
   [nzPageSizeOptions]="[8, 15, 25]"
   (nzQueryParams)="onTablePageChange($event)"
   nzShowPagination="true"
-  [nzScroll]="{ x: '1240px', y: '100%' }"
+  [nzScroll]="{ x: '1240px' }"
 >
   <thead>
     <tr>

--- a/web-app/src/app/routes/alert/alert-notice/alert-notice.component.html
+++ b/web-app/src/app/routes/alert/alert-notice/alert-notice.component.html
@@ -37,13 +37,7 @@
         {{ 'alert.notice.receiver.new' | i18n }}
       </button>
     </div>
-    <nz-table
-      #fixedTable
-      [nzData]="receivers"
-      [nzLoading]="receiverTableLoading"
-      [nzScroll]="{ x: '1240px' }"
-      nzFrontPagination="false"
-    >
+    <nz-table #fixedTable [nzData]="receivers" [nzLoading]="receiverTableLoading" [nzScroll]="{ x: '1240px' }" nzFrontPagination="false">
       <thead>
         <tr>
           <th nzAlign="center" nzWidth="15%">{{ 'alert.notice.receiver.people' | i18n }}</th>
@@ -171,13 +165,7 @@
       </button>
     </div>
 
-    <nz-table
-      #ruleFixedTable
-      [nzData]="rules"
-      [nzLoading]="ruleTableLoading"
-      [nzScroll]="{ x: '1240px' }"
-      nzFrontPagination="false"
-    >
+    <nz-table #ruleFixedTable [nzData]="rules" [nzLoading]="ruleTableLoading" [nzScroll]="{ x: '1240px' }" nzFrontPagination="false">
       <thead>
         <tr>
           <th nzAlign="center" nzWidth="15%">{{ 'alert.notice.rule.name' | i18n }}</th>

--- a/web-app/src/app/routes/alert/alert-notice/alert-notice.component.html
+++ b/web-app/src/app/routes/alert/alert-notice/alert-notice.component.html
@@ -41,7 +41,7 @@
       #fixedTable
       [nzData]="receivers"
       [nzLoading]="receiverTableLoading"
-      [nzScroll]="{ x: '1240px', y: '100%' }"
+      [nzScroll]="{ x: '1240px' }"
       nzFrontPagination="false"
     >
       <thead>
@@ -175,7 +175,7 @@
       #ruleFixedTable
       [nzData]="rules"
       [nzLoading]="ruleTableLoading"
-      [nzScroll]="{ x: '1240px', y: '100%' }"
+      [nzScroll]="{ x: '1240px' }"
       nzFrontPagination="false"
     >
       <thead>
@@ -250,7 +250,7 @@
       #templateFixedTable
       [nzData]="templates"
       [nzLoading]="templateTableLoading"
-      [nzScroll]="{ x: '1240px', y: '100%' }"
+      [nzScroll]="{ x: '1240px' }"
       nzFrontPagination="false"
     >
       <thead>

--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.html
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.html
@@ -86,7 +86,7 @@
   [nzPageSizeOptions]="[8, 15, 25]"
   (nzQueryParams)="onTablePageChange($event)"
   nzShowPagination="true"
-  [nzScroll]="{ x: '1240px', y: '100%' }"
+  [nzScroll]="{ x: '1240px' }"
 >
   <thead>
     <tr>

--- a/web-app/src/app/routes/alert/alert-silence/alert-silence.component.html
+++ b/web-app/src/app/routes/alert/alert-silence/alert-silence.component.html
@@ -64,7 +64,7 @@
   [nzPageSizeOptions]="[8, 15, 25]"
   (nzQueryParams)="onTablePageChange($event)"
   nzShowPagination="true"
-  [nzScroll]="{ x: '1240px', y: '100%' }"
+  [nzScroll]="{ x: '1240px' }"
 >
   <thead>
     <tr>

--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
@@ -136,7 +136,7 @@
   [nzPageSizeOptions]="[8, 15, 25]"
   (nzQueryParams)="onTablePageChange($event)"
   nzShowPagination="true"
-  [nzScroll]="{ x: '1240px', y: '100%' }"
+  [nzScroll]="{ x: '1240px' }"
 >
   <thead>
     <tr>

--- a/web-app/src/app/routes/setting/collector/collector.component.html
+++ b/web-app/src/app/routes/setting/collector/collector.component.html
@@ -78,7 +78,7 @@
   [nzPageSizeOptions]="[8, 15, 25]"
   (nzQueryParams)="onTablePageChange($event)"
   nzShowPagination="true"
-  [nzScroll]="{ x: '1240px', y: '100%' }"
+  [nzScroll]="{ x: '1240px' }"
 >
   <thead>
     <tr>

--- a/web-app/src/app/routes/setting/status/status.component.html
+++ b/web-app/src/app/routes/setting/status/status.component.html
@@ -157,13 +157,7 @@
         </a>
       </button>
     </div>
-    <nz-table
-      #fixedTable
-      [nzData]="statusComponents"
-      nzFrontPagination="false"
-      [nzLoading]="componentLoading"
-      [nzScroll]="{ x: '1240px' }"
-    >
+    <nz-table #fixedTable [nzData]="statusComponents" nzFrontPagination="false" [nzLoading]="componentLoading" [nzScroll]="{ x: '1240px' }">
       <thead>
         <tr>
           <th nzAlign="center" nzWidth="15%">{{ 'status.component.name' | i18n }}</th>

--- a/web-app/src/app/routes/setting/status/status.component.html
+++ b/web-app/src/app/routes/setting/status/status.component.html
@@ -162,7 +162,7 @@
       [nzData]="statusComponents"
       nzFrontPagination="false"
       [nzLoading]="componentLoading"
-      [nzScroll]="{ x: '1240px', y: '100%' }"
+      [nzScroll]="{ x: '1240px' }"
     >
       <thead>
         <tr>
@@ -250,7 +250,7 @@
       [nzData]="statusIncidences"
       nzFrontPagination="false"
       [nzLoading]="incidentLoading"
-      [nzScroll]="{ x: '1240px', y: '100%' }"
+      [nzScroll]="{ x: '1240px' }"
     >
       <thead>
         <tr>

--- a/web-app/src/app/routes/setting/tags/tags.component.html
+++ b/web-app/src/app/routes/setting/tags/tags.component.html
@@ -67,7 +67,7 @@
   [nzPageSizeOptions]="[8, 15, 25]"
   (nzQueryParams)="onTablePageChange($event)"
   nzShowPagination="true"
-  [nzScroll]="{ x: '1240px', y: '100%' }"
+  [nzScroll]="{ x: '1240px' }"
 >
   <thead>
     <tr>


### PR DESCRIPTION
## What's changed?

This PR is similar to #2111, removing the unnecessary `y: 100%` value within `nzScroll` in `ng-table` and setting it to auto by default.


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
