### PR TITLE
Add an input box component with a removal function.

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
@@ -89,25 +89,21 @@
   <button style="margin-right: 25px; float: right" class="mobile-hide" nz-button nzType="primary" (click)="onFilterSearchMonitors()">
     {{ 'common.search' | i18n }}
   </button>
-  <input
-    style="margin-right: 5px; float: right; width: 180px; border-radius: 9px; text-align: center"
+  <app-multi-func-input
+    groupStyle="margin-right: 5px; float: right; width: 180px; border-radius: 9px;"
+    inputStyle="text-align: center"
     class="mobile-hide"
-    nz-input
-    type="text"
     [placeholder]="'monitors.search.placeholder' | i18n"
-    nzSize="default"
-    (keyup.enter)="onFilterSearchMonitors()"
-    [(ngModel)]="filterContent"
+    [(value)]="filterContent"
+    (valueChange)="onFilterSearchMonitors()"
   />
-  <input
-    style="margin-right: 5px; float: right; width: 90px; border-radius: 9px; text-align: center"
+  <app-multi-func-input
+    groupStyle="margin-right: 10px; float: right; width: 90px; border-radius: 9px;"
+    inputStyle="text-align: center"
     class="mobile-hide"
-    nz-input
-    type="text"
     [placeholder]="'monitors.search.tag' | i18n"
-    nzSize="default"
-    (keyup.enter)="onFilterSearchMonitors()"
-    [(ngModel)]="tag"
+    [(value)]="tag"
+    (valueChange)="onFilterSearchMonitors()"
   />
   <nz-select
     style="margin-right: 10px; float: right"

--- a/web-app/src/app/shared/components/multi-func-input/multi-func-input.component.html
+++ b/web-app/src/app/shared/components/multi-func-input/multi-func-input.component.html
@@ -1,0 +1,35 @@
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+-->
+
+<nz-input-group [nzSuffix]="inputClearTpl" [style]="groupStyle">
+  <input
+    nz-input
+    [(ngModel)]="inputValue"
+    [placeholder]="placeholder"
+    [type]="type"
+    [style]="inputStyle"
+    [nzSize]="size"
+    (ngModelChange)="onChange()"
+  />
+</nz-input-group>
+<ng-template #inputClearTpl>
+  @if (allowClear && inputValue) {
+  <span nz-icon class="ant-input-clear-icon" nzTheme="fill" nzType="close-circle" (click)="inputValue = null; onChange()"></span>
+  }
+</ng-template>

--- a/web-app/src/app/shared/components/multi-func-input/multi-func-input.component.spec.ts
+++ b/web-app/src/app/shared/components/multi-func-input/multi-func-input.component.spec.ts
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MultiFuncInputComponent } from './multi-func-input.component';
+
+describe('MultiFuncInputComponent', () => {
+  let component: MultiFuncInputComponent;
+  let fixture: ComponentFixture<MultiFuncInputComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [MultiFuncInputComponent]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(MultiFuncInputComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web-app/src/app/shared/components/multi-func-input/multi-func-input.component.ts
+++ b/web-app/src/app/shared/components/multi-func-input/multi-func-input.component.ts
@@ -26,7 +26,6 @@ import { NzSizeLDSType } from 'ng-zorro-antd/core/types';
   styleUrls: ['./multi-func-input.component.less']
 })
 export class MultiFuncInputComponent implements OnInit {
-
   constructor() {}
 
   @Input() value!: any;
@@ -49,5 +48,4 @@ export class MultiFuncInputComponent implements OnInit {
       this.valueChange.emit(this.inputValue);
     }
   }
-
 }

--- a/web-app/src/app/shared/components/multi-func-input/multi-func-input.component.ts
+++ b/web-app/src/app/shared/components/multi-func-input/multi-func-input.component.ts
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { Component, OnInit, EventEmitter, Input, Output } from '@angular/core';
+import { NzSizeLDSType } from 'ng-zorro-antd/core/types';
+
+@Component({
+  selector: 'app-multi-func-input',
+  templateUrl: './multi-func-input.component.html',
+  styleUrls: ['./multi-func-input.component.less']
+})
+export class MultiFuncInputComponent implements OnInit {
+
+  constructor() {}
+
+  @Input() value!: any;
+  @Input() groupStyle!: string;
+  @Input() inputStyle!: string;
+  @Input() placeholder!: string;
+  @Input() allowClear: boolean = true;
+  @Input() type: string = 'text';
+  @Input() size: NzSizeLDSType = 'default';
+  @Output() readonly valueChange = new EventEmitter<string>();
+
+  inputValue: any | undefined;
+
+  ngOnInit(): void {
+    this.inputValue = this.value;
+  }
+
+  onChange() {
+    if (this.inputValue !== this.value) {
+      this.valueChange.emit(this.inputValue);
+    }
+  }
+
+}

--- a/web-app/src/app/shared/shared.module.ts
+++ b/web-app/src/app/shared/shared.module.ts
@@ -10,6 +10,7 @@ import { NzTagModule } from 'ng-zorro-antd/tag';
 
 import { HelpMassageShowComponent } from './components/help-massage-show/help-massage-show.component';
 import { KeyValueInputComponent } from './components/key-value-input/key-value-input.component';
+import { MultiFuncInputComponent } from './components/multi-func-input/multi-func-input.component';
 import { MetricsFieldInputComponent } from './components/metrics-field-input/metrics-field-input.component';
 import { ElapsedTimePipe } from './pipe/elapsed-time.pipe';
 import { I18nElsePipe } from './pipe/i18n-else.pipe';
@@ -18,7 +19,7 @@ import { SHARED_DELON_MODULES } from './shared-delon.module';
 import { SHARED_ZORRO_MODULES } from './shared-zorro.module';
 
 const ThirdModules: Array<Type<void>> = [];
-const COMPONENTS: Array<Type<void>> = [KeyValueInputComponent, HelpMassageShowComponent, MetricsFieldInputComponent];
+const COMPONENTS: Array<Type<void>> = [KeyValueInputComponent, MultiFuncInputComponent, HelpMassageShowComponent, MetricsFieldInputComponent];
 const DIRECTIVES: Array<Type<void>> = [TimezonePipe, I18nElsePipe, ElapsedTimePipe];
 
 @NgModule({

--- a/web-app/src/app/shared/shared.module.ts
+++ b/web-app/src/app/shared/shared.module.ts
@@ -10,8 +10,8 @@ import { NzTagModule } from 'ng-zorro-antd/tag';
 
 import { HelpMassageShowComponent } from './components/help-massage-show/help-massage-show.component';
 import { KeyValueInputComponent } from './components/key-value-input/key-value-input.component';
-import { MultiFuncInputComponent } from './components/multi-func-input/multi-func-input.component';
 import { MetricsFieldInputComponent } from './components/metrics-field-input/metrics-field-input.component';
+import { MultiFuncInputComponent } from './components/multi-func-input/multi-func-input.component';
 import { ElapsedTimePipe } from './pipe/elapsed-time.pipe';
 import { I18nElsePipe } from './pipe/i18n-else.pipe';
 import { TimezonePipe } from './pipe/timezone.pipe';
@@ -19,7 +19,12 @@ import { SHARED_DELON_MODULES } from './shared-delon.module';
 import { SHARED_ZORRO_MODULES } from './shared-zorro.module';
 
 const ThirdModules: Array<Type<void>> = [];
-const COMPONENTS: Array<Type<void>> = [KeyValueInputComponent, MultiFuncInputComponent, HelpMassageShowComponent, MetricsFieldInputComponent];
+const COMPONENTS: Array<Type<void>> = [
+  KeyValueInputComponent,
+  MultiFuncInputComponent,
+  HelpMassageShowComponent,
+  MetricsFieldInputComponent
+];
 const DIRECTIVES: Array<Type<void>> = [TimezonePipe, I18nElsePipe, ElapsedTimePipe];
 
 @NgModule({


### PR DESCRIPTION
## What's changed?

![1719207867154](https://github.com/apache/hertzbeat/assets/3371163/a48e5e76-d34f-4d60-aafc-fa81f6951698)
Replace the two `input` components in the monitoring center with `input` components that have a **allowClear** function, so that they are consistent with the `select` components in supporting quick clear of filter values.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
