### PR TITLE
Add a loading animation to the `/setting/define` page.

### DIFF
--- a/web-app/src/app/routes/setting/define/define.component.html
+++ b/web-app/src/app/routes/setting/define/define.component.html
@@ -23,110 +23,113 @@
   [module_name]="'menu.advanced.define'"
   [icon_name]="'code'"
 ></app-help-massage-show>
+
 <nz-divider></nz-divider>
 
-<nz-layout style="min-height: 100vh">
-  <nz-sider style="height: 100%; overflow: auto; margin: 4px" [nzTrigger]="null">
-    <ul nz-menu nzTheme="light" nzMode="inline" nzInlineCollapsed="false">
-      <li *ngIf="currentApp != null" style="text-align: center; margin-top: 12px">
-        <button nzGhost nz-button nzType="primary" nzSize="small" (click)="onNewMonitorDefine()">
-          <i nz-icon nzType="appstore-add" nzTheme="outline"></i>
-          {{ 'define.new' | i18n }}
-        </button>
-      </li>
-      <li *ngFor="let menuItem of appMenusArr" nz-submenu [nzTitle]="renderCategoryName(menuItem[0])">
-        <ul>
-          <li nz-menu-item *ngFor="let app of menuItem[1]" [nzSelected]="app.selected" style="padding-left: 24px">
-            <button
-              *ngIf="app.hide == true || app.hide == undefined"
-              nz-button
-              nzSize="small"
-              nz-tooltip
-              [nz-tooltip]="'define.hide-true.tip' | i18n"
-              nz-popconfirm
-              [nzPopconfirmTitle]="'define.hide-true.confirm' | i18n"
-              (nzOnConfirm)="updateAppTemplateConfig(app.value, !app.hide)"
-              nzPopconfirmPlacement="bottom"
-            >
-              <i nz-icon nzType="eye-invisible" nzTheme="outline"></i>
-            </button>
-            <button
-              *ngIf="app.hide == false"
-              nz-button
-              nzSize="small"
-              nz-tooltip
-              [nz-tooltip]="'define.hide-false.tip' | i18n"
-              nz-popconfirm
-              [nzPopconfirmTitle]="'define.hide-false.confirm' | i18n"
-              (nzOnConfirm)="updateAppTemplateConfig(app.value, !app.hide)"
-              nzPopconfirmPlacement="bottom"
-            >
-              <i nz-icon nzType="eye" nzTheme="outline"></i>
-            </button>
-            <button
-              nz-button
-              nzSize="small"
-              routerLink="/setting/define"
-              [queryParams]="{ app: app.value }"
-              class="label"
-              [title]="app.label"
-            >
-              {{ app.label }}
-            </button>
-          </li>
-        </ul>
-      </li>
-    </ul>
-  </nz-sider>
-  <nz-layout>
-    <nz-content>
-      <div style="margin: 10px 10px 4px 10px">
-        <button nzGhost *ngIf="currentApp != null" nz-button nzType="primary" routerLink="/monitors" [queryParams]="{ app: currentApp }">
-          <i nz-icon nzType="file-text" nzTheme="outline"></i>
-          {{ 'app-' + currentApp + '.yml' }}
-          <i nz-icon nzType="more" nzTheme="outline"></i>
-        </button>
-        <button *ngIf="code != originalCode" nz-button nzType="primary" [nzLoading]="saveLoading" (click)="onSaveAndApply()">
-          <i nz-icon nzType="save" nzTheme="outline"></i>
-          {{ 'define.save-apply' | i18n }}
-        </button>
-        <button *ngIf="false" nz-button nzType="primary" (click)="onDeleteDefineYml()">
-          <i nz-icon nzType="up-circle" nzTheme="outline"></i>
-          {{ 'define.enable' | i18n : { app: currentApp } }}
-        </button>
-        <button *ngIf="false" nz-button nzDanger nzType="primary" (click)="onDeleteDefineYml()">
-          <i nz-icon nzType="down-circle" nzTheme="outline"></i>
-          {{ 'define.disable' | i18n : { app: currentApp } }}
-        </button>
-        <button *ngIf="currentApp != null" nz-button nzDanger nzType="primary" (click)="onDeleteDefineYml()">
-          <i nz-icon nzType="delete" nzTheme="outline"></i>
-          {{ 'define.delete' | i18n : { app: currentApp } }}
-        </button>
+<nz-spin [nzSpinning]="menuLoading">
+  <nz-layout style="min-height: 100vh">
+    <nz-sider style="height: 100%; overflow: auto; margin: 4px" [nzTrigger]="null">
+      <ul nz-menu nzTheme="light" nzMode="inline" nzInlineCollapsed="false">
+        <li *ngIf="currentApp != null" style="text-align: center; margin-top: 12px">
+          <button nzGhost nz-button nzType="primary" nzSize="small" (click)="onNewMonitorDefine()">
+            <i nz-icon nzType="appstore-add" nzTheme="outline"></i>
+            {{ 'define.new' | i18n }}
+          </button>
+        </li>
+        <li *ngFor="let menuItem of appMenusArr" nz-submenu [nzTitle]="renderCategoryName(menuItem[0])">
+          <ul>
+            <li nz-menu-item *ngFor="let app of menuItem[1]" [nzSelected]="app.selected" style="padding-left: 24px">
+              <button
+                *ngIf="app.hide == true || app.hide == undefined"
+                nz-button
+                nzSize="small"
+                nz-tooltip
+                [nz-tooltip]="'define.hide-true.tip' | i18n"
+                nz-popconfirm
+                [nzPopconfirmTitle]="'define.hide-true.confirm' | i18n"
+                (nzOnConfirm)="updateAppTemplateConfig(app.value, !app.hide)"
+                nzPopconfirmPlacement="bottom"
+              >
+                <i nz-icon nzType="eye-invisible" nzTheme="outline"></i>
+              </button>
+              <button
+                *ngIf="app.hide == false"
+                nz-button
+                nzSize="small"
+                nz-tooltip
+                [nz-tooltip]="'define.hide-false.tip' | i18n"
+                nz-popconfirm
+                [nzPopconfirmTitle]="'define.hide-false.confirm' | i18n"
+                (nzOnConfirm)="updateAppTemplateConfig(app.value, !app.hide)"
+                nzPopconfirmPlacement="bottom"
+              >
+                <i nz-icon nzType="eye" nzTheme="outline"></i>
+              </button>
+              <button
+                nz-button
+                nzSize="small"
+                routerLink="/setting/define"
+                [queryParams]="{ app: app.value }"
+                class="label"
+                [title]="app.label"
+              >
+                {{ app.label }}
+              </button>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </nz-sider>
+    <nz-layout>
+      <nz-content>
+        <div style="margin: 10px 10px 4px 10px">
+          <button nzGhost *ngIf="currentApp != null" nz-button nzType="primary" routerLink="/monitors" [queryParams]="{ app: currentApp }">
+            <i nz-icon nzType="file-text" nzTheme="outline"></i>
+            {{ 'app-' + currentApp + '.yml' }}
+            <i nz-icon nzType="more" nzTheme="outline"></i>
+          </button>
+          <button *ngIf="code != originalCode" nz-button nzType="primary" [nzLoading]="saveLoading" (click)="onSaveAndApply()">
+            <i nz-icon nzType="save" nzTheme="outline"></i>
+            {{ 'define.save-apply' | i18n }}
+          </button>
+          <button *ngIf="false" nz-button nzType="primary" (click)="onDeleteDefineYml()">
+            <i nz-icon nzType="up-circle" nzTheme="outline"></i>
+            {{ 'define.enable' | i18n : { app: currentApp } }}
+          </button>
+          <button *ngIf="false" nz-button nzDanger nzType="primary" (click)="onDeleteDefineYml()">
+            <i nz-icon nzType="down-circle" nzTheme="outline"></i>
+            {{ 'define.disable' | i18n : { app: currentApp } }}
+          </button>
+          <button *ngIf="currentApp != null" nz-button nzDanger nzType="primary" (click)="onDeleteDefineYml()">
+            <i nz-icon nzType="delete" nzTheme="outline"></i>
+            {{ 'define.delete' | i18n : { app: currentApp } }}
+          </button>
 
-        <nz-switch
-          style="margin-right: 25px; float: right"
-          [ngModel]="dark"
-          (ngModelChange)="onDarkModeChange($event)"
-          [nzUnCheckedChildren]="unchecked"
-          [nzCheckedChildren]="checked"
-        ></nz-switch>
-        <ng-template #unchecked>
-          <span nz-icon nzType="bulb"></span>
-        </ng-template>
-        <ng-template #checked>
-          <span nz-icon nzType="poweroff"></span>
-        </ng-template>
-      </div>
-      <div style="margin: 4px 10px 4px 4px; height: 100%; width: 100%">
-        <nz-code-editor
-          class="editor"
-          [nzLoading]="loading"
-          [nzOriginalText]="originalCode"
-          [(ngModel)]="code"
-          [nzEditorMode]="'diff'"
-          [nzEditorOption]="{ language: 'yaml', theme: 'vs-dark', folding: true }"
-        ></nz-code-editor>
-      </div>
-    </nz-content>
+          <nz-switch
+            style="margin-right: 25px; float: right"
+            [ngModel]="dark"
+            (ngModelChange)="onDarkModeChange($event)"
+            [nzUnCheckedChildren]="unchecked"
+            [nzCheckedChildren]="checked"
+          ></nz-switch>
+          <ng-template #unchecked>
+            <span nz-icon nzType="bulb"></span>
+          </ng-template>
+          <ng-template #checked>
+            <span nz-icon nzType="poweroff"></span>
+          </ng-template>
+        </div>
+        <div style="margin: 4px 10px 4px 4px; height: 100%; width: 100%">
+          <nz-code-editor
+            class="editor"
+            [nzLoading]="loading"
+            [nzOriginalText]="originalCode"
+            [(ngModel)]="code"
+            [nzEditorMode]="'diff'"
+            [nzEditorOption]="{ language: 'yaml', theme: 'vs-dark', folding: true }"
+          ></nz-code-editor>
+        </div>
+      </nz-content>
+    </nz-layout>
   </nz-layout>
-</nz-layout>
+</nz-spin>

--- a/web-app/src/app/routes/setting/define/define.component.ts
+++ b/web-app/src/app/routes/setting/define/define.component.ts
@@ -46,6 +46,7 @@ export class DefineComponent implements OnInit {
     @Inject(ALAIN_I18N_TOKEN) private i18nSvc: I18NService
   ) {}
 
+  menuLoading: boolean = false;
   appMenusArr: any[][] = [];
   appLabel: Record<string, string> = {};
   loading = false;
@@ -69,11 +70,13 @@ export class DefineComponent implements OnInit {
   }
 
   loadMenus() {
+    this.menuLoading = true;
     const getHierarchy$ = this.appDefineSvc
       .getAppHierarchy(this.i18nSvc.defaultLang)
       .pipe(
         finalize(() => {
           getHierarchy$.unsubscribe();
+          this.menuLoading = false;
         })
       )
       .subscribe(


### PR DESCRIPTION
## What's changed?

before:
![before](https://github.com/apache/hertzbeat/assets/3371163/9b9658cd-8437-4ee4-ad1b-9322d4d66e13)

after:
![after](https://github.com/apache/hertzbeat/assets/3371163/80016557-147a-413b-99bc-e4d39e292dbc)

Add a loading animation to the `/setting/define` page.


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
