### PR TITLE
[bugfix] modify the prompt information for deleting used tags

### DIFF
--- a/manager/src/main/java/org/apache/hertzbeat/manager/dao/TagMonitorBindDao.java
+++ b/manager/src/main/java/org/apache/hertzbeat/manager/dao/TagMonitorBindDao.java
@@ -17,6 +17,7 @@
 
 package org.apache.hertzbeat.manager.dao;
 
+import java.util.HashSet;
 import java.util.Set;
 import org.apache.hertzbeat.common.entity.manager.TagMonitorBind;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -32,11 +33,19 @@ public interface TagMonitorBindDao extends JpaRepository<TagMonitorBind, Long>, 
      * @param monitorId monitorId
      */
     void deleteTagMonitorBindsByMonitorId(Long monitorId);
-    
+
     /**
      * delete tags bind by monitor id
      * @param monitorIds monitor list
      */
     void deleteTagMonitorBindsByMonitorIdIn(Set<Long> monitorIds);
-    
+
+
+    /**
+     * count tags bind relation by tag id
+     * @param tagIds list of tagId
+     * @return count
+     */
+    long countByTagIdIn(HashSet<Long> tagIds);
+
 }

--- a/manager/src/main/java/org/apache/hertzbeat/manager/dao/TagMonitorBindDao.java
+++ b/manager/src/main/java/org/apache/hertzbeat/manager/dao/TagMonitorBindDao.java
@@ -17,7 +17,6 @@
 
 package org.apache.hertzbeat.manager.dao;
 
-import java.util.HashSet;
 import java.util.Set;
 import org.apache.hertzbeat.common.entity.manager.TagMonitorBind;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -46,6 +45,6 @@ public interface TagMonitorBindDao extends JpaRepository<TagMonitorBind, Long>, 
      * @param tagIds list of tagId
      * @return count
      */
-    long countByTagIdIn(HashSet<Long> tagIds);
+    long countByTagIdIn(Set<Long> tagIds);
 
 }

--- a/manager/src/main/java/org/apache/hertzbeat/manager/service/impl/TagServiceImpl.java
+++ b/manager/src/main/java/org/apache/hertzbeat/manager/service/impl/TagServiceImpl.java
@@ -27,7 +27,9 @@ import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hertzbeat.common.entity.manager.Monitor;
 import org.apache.hertzbeat.common.entity.manager.Tag;
+import org.apache.hertzbeat.common.support.exception.CommonException;
 import org.apache.hertzbeat.manager.dao.TagDao;
+import org.apache.hertzbeat.manager.dao.TagMonitorBindDao;
 import org.apache.hertzbeat.manager.service.TagService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
@@ -46,6 +48,9 @@ public class TagServiceImpl implements TagService {
 
     @Autowired
     private TagDao tagDao;
+
+    @Autowired
+    private TagMonitorBindDao tagMonitorBindDao;
 
     @Override
     public void addTags(List<Tag> tags) {
@@ -70,6 +75,9 @@ public class TagServiceImpl implements TagService {
 
     @Override
     public void deleteTags(HashSet<Long> ids) {
+        if (tagMonitorBindDao.countByTagIdIn(ids) != 0) {
+            throw  new CommonException("The tag is in use and cannot be deleted.");
+        }
         tagDao.deleteTagsByIdIn(ids);
     }
 

--- a/manager/src/main/java/org/apache/hertzbeat/manager/service/impl/TagServiceImpl.java
+++ b/manager/src/main/java/org/apache/hertzbeat/manager/service/impl/TagServiceImpl.java
@@ -76,7 +76,7 @@ public class TagServiceImpl implements TagService {
     @Override
     public void deleteTags(HashSet<Long> ids) {
         if (tagMonitorBindDao.countByTagIdIn(ids) != 0) {
-            throw  new CommonException("The tag is in use and cannot be deleted.");
+            throw new CommonException("The tag is in use and cannot be deleted.");
         }
         tagDao.deleteTagsByIdIn(ids);
     }

--- a/manager/src/test/java/org/apache/hertzbeat/manager/service/TagServiceTest.java
+++ b/manager/src/test/java/org/apache/hertzbeat/manager/service/TagServiceTest.java
@@ -26,11 +26,14 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Optional;
 import org.apache.hertzbeat.common.entity.manager.Tag;
+import org.apache.hertzbeat.common.support.exception.CommonException;
 import org.apache.hertzbeat.manager.dao.TagDao;
+import org.apache.hertzbeat.manager.dao.TagMonitorBindDao;
 import org.apache.hertzbeat.manager.service.impl.TagServiceImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -52,6 +55,9 @@ class TagServiceTest {
 
     @Mock
     private TagDao tagDao;
+
+    @Mock
+    private TagMonitorBindDao tagMonitorBindDao;
 
     @Test
     void addTags() {
@@ -80,6 +86,13 @@ class TagServiceTest {
     @Test
     void deleteTags() {
         doNothing().when(tagDao).deleteTagsByIdIn(anySet());
+        when(tagMonitorBindDao.countByTagIdIn(anySet())).thenReturn(0L);
         assertDoesNotThrow(() -> tagService.deleteTags(new HashSet<>(1)));
+    }
+
+    @Test
+    void deleteUsingTags() {
+        when(tagMonitorBindDao.countByTagIdIn(anySet())).thenReturn(1L);
+        assertThrows(CommonException.class,() -> tagService.deleteTags(new HashSet<>(1)));
     }
 }


### PR DESCRIPTION
## What's changed?

1. modify the prompt information for deleting used tags
**Before:**
![before](https://github.com/apache/hertzbeat/assets/30208283/27e4487e-6549-46c9-8d3f-9489c7263492)
**After:**
![after](https://github.com/apache/hertzbeat/assets/30208283/023b32af-2db5-4493-a294-2140a7e0a7e8)
## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
