### PR TITLE
Optimize the [Threshold Rule] Form.

### DIFF
--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.html
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.html
@@ -209,7 +209,7 @@
           ></nz-cascader>
         </nz-form-control>
       </nz-form-item>
-      <nz-form-item>
+      <nz-form-item *ngIf="cascadeValues.length != 2">
         <nz-form-label [nzSpan]="7" nzFor="rule" nzRequired="true" [nzTooltipTitle]="'alert.setting.rule.label' | i18n">
           {{ 'alert.setting.rule' | i18n }}
         </nz-form-label>
@@ -229,7 +229,7 @@
               {{ 'alert.setting.rule.switch-expr.1' | i18n }}
             </label>
           </nz-radio-group>
-          <div *ngIf="cascadeValues.length != 2 && isExpr" style="margin-top: 5px">
+          <div *ngIf="isExpr" style="margin-top: 5px">
             <nz-textarea-count [nzMaxCharacterCount]="100">
               <textarea
                 [(ngModel)]="define.expr"
@@ -270,7 +270,7 @@
               </nz-collapse-panel>
             </nz-collapse>
           </div>
-          <div *ngIf="cascadeValues.length != 2 && !isExpr" style="margin-top: 5px">
+          <div *ngIf="!isExpr" style="margin-top: 5px">
             <div id="rule">
               <div style="width: 100%; margin-bottom: 2px" nz-row *ngFor="let alertRule of alertRules; let i = index">
                 <nz-select


### PR DESCRIPTION
## What's changed?

before:
![89d1a4e005dca6be0330a5a26a0f333](https://github.com/apache/hertzbeat/assets/3371163/aa5b0c72-cc49-4dd4-8ac0-673476eefed3)

after:
![a6737cabfae20686061574e63ef2893](https://github.com/apache/hertzbeat/assets/3371163/c348a7c9-f7a1-40f0-b598-adbe714d0460)


When the [`Metric Target`] is set as [`Monitor Availability`], the [`Threshold Rule`] belongs to an invalid field (it is currently displayed but cannot be edited), so it should not be shown.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
