### PR TITLE
[bugfix] Only POST and PUT methods carry payload

### DIFF
--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/http/HttpCollectImpl.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/http/HttpCollectImpl.java
@@ -549,7 +549,7 @@ public class HttpCollectImpl extends AbstractCollect {
         }
 
         // if it has payload, would override post params
-        if (StringUtils.hasLength(httpProtocol.getPayload())) {
+        if (StringUtils.hasLength(httpProtocol.getPayload()) && (HttpMethod.POST.matches(httpMethod) || HttpMethod.PUT.matches(httpMethod))) {
             requestBuilder.setEntity(new StringEntity(httpProtocol.getPayload(), StandardCharsets.UTF_8));
         }
 


### PR DESCRIPTION
 #2298 
## before
Any method can carry a payload

## What's changed?

<!-- Describe Your PR Here -->
Consistent with front end，Only POST and PUT methods carry payload

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
