### PR TITLE
[doc] supplement custom plugin doc

### DIFF
--- a/home/docs/help/plugin.md
+++ b/home/docs/help/plugin.md
@@ -18,8 +18,10 @@ Currently, `HertzBeat` only set up the trigger `alert` method after alarm, if yo
    ![plugin-1.png](/img/docs/help/plugin-1.png)
 2. In the `org.apache.hertzbeat.plugin.impl` directory, create a new interface implementation class, such as `org.apache.hertzbeat.plugin.impl.DemoPluginImpl`, and receive the `Alert` class as a parameter, implement the `alert ` method, the logic is customized by the user, here we simply print the object.
    ![plugin-2.png](/img/docs/help/plugin-2.png)
-3. Package the `hertzbeat-plugin` module.
+3. Add the fully qualified names of the interface implementation classes to the `META-INF/services/org.apache.hertzbeat.plugin.Plugin` file, with each implementation class name on a separate line.
+4. Package the `hertzbeat-plugin` module.
+
    ![plugin-3.png](/img/docs/help/plugin-3.png)
-4. Copy the packaged `jar` package to the `ext-lib` directory under the installation directory (for `docker` installations, mount the `ext-lib` directory first, then copy it there).
+5. Copy the packaged `jar` package to the `ext-lib` directory under the installation directory (for `docker` installations, mount the `ext-lib` directory first, then copy it there).
    ![plugin-4.png](/img/docs/help/plugin-4.png)
-5. Then restart `HertzBeat` to enable the customized post-alert handling policy.
+6. Then restart `HertzBeat` to enable the customized post-alert handling policy.

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/plugin.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/plugin.md
@@ -18,8 +18,10 @@ sidebar_label: 自定义插件
     ![plugin-1.png](/img/docs/help/plugin-1.png)
 2. 在`org.apache.hertzbeat.plugin.impl`目录下, 新建一个接口实现类，如`org.apache.hertzbeat.plugin.impl.DemoPluginImpl`,在实现类中接收`Alert`类作为参数，实现`alert`方法，逻辑由用户自定义，这里我们简单打印一下对象。
     ![plugin-2.png](/img/docs/help/plugin-2.png)
-3. 打包`hertzbeat-plugin`模块。
+3. 在 `META-INF/services/org.apache.hertzbeat.plugin.Plugin` 文件中增加接口实现类的全限定名，每个实现类全限定名单独成行。
+4. 打包`hertzbeat-plugin`模块。
+
     ![plugin-3.png](/img/docs/help/plugin-3.png)
-4. 将打包后的`jar`包，拷贝到安装目录下的`ext-lib`目录下（若为`docker`安装则先将`ext-lib`目录挂载出来，再拷贝到该目录下）
+5. 将打包后的`jar`包，拷贝到安装目录下的`ext-lib`目录下（若为`docker`安装则先将`ext-lib`目录挂载出来，再拷贝到该目录下）
     ![plugin-4.png](/img/docs/help/plugin-4.png)
-5. 然后重启`HertzBeat`，即可实现自定义告警后处理策略。
+6. 然后重启`HertzBeat`，即可实现自定义告警后处理策略。


### PR DESCRIPTION


## What's changed?

1. supplement plugin doc and add steps to define service provider files
This PR is a supplement to the custom plugin documentation, providing additional documentation for already released plugin features. It can be published in the 1.6.x documentation.


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
