### PR TITLE
[bugfix]: correct setInterval time interval to 2 minutes

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.ts
@@ -106,7 +106,7 @@ export class MonitorListComponent implements OnInit, OnDestroy {
     // Set up an interval to refresh the table every 2 minutes
     this.intervalId = setInterval(() => {
       this.sync();
-    }, 12000); // 120000 ms = 2 minutes
+    }, 120000); // 120000 ms = 2 minutes
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
Correct the setInterval function timing in monitor-list.component.ts to ensure the table refreshes every 2 minutes as intended. The previous code incorrectly specified the interval as12,000 milliseconds instead of the intended 120,000 milliseconds.

## What's changed?

[bugfix]: correct setInterval time interval to 2 minutes


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
