### PR TITLE
[improve] modify ssh client common config

### DIFF
--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/ssh/CommonSshClient.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/ssh/CommonSshClient.java
@@ -43,7 +43,7 @@ public class CommonSshClient {
         PropertyResolverUtils.updateProperty(
                 SSH_CLIENT, CoreModuleProperties.HEARTBEAT_INTERVAL.getName(), 2000);
         PropertyResolverUtils.updateProperty(
-                SSH_CLIENT, CoreModuleProperties.HEARTBEAT_REPLY_WAIT.getName(), 300_000);
+                SSH_CLIENT, CoreModuleProperties.HEARTBEAT_NO_REPLY_MAX.getName(), 5);
         PropertyResolverUtils.updateProperty(
                 SSH_CLIENT, CoreModuleProperties.SOCKET_KEEPALIVE.getName(), true);
         // set support all KeyExchange

--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/ssh/CommonSshClient.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/ssh/CommonSshClient.java
@@ -43,7 +43,7 @@ public class CommonSshClient {
         PropertyResolverUtils.updateProperty(
                 SSH_CLIENT, CoreModuleProperties.HEARTBEAT_INTERVAL.getName(), 2000);
         PropertyResolverUtils.updateProperty(
-                SSH_CLIENT, CoreModuleProperties.HEARTBEAT_NO_REPLY_MAX.getName(), 5);
+                SSH_CLIENT, CoreModuleProperties.HEARTBEAT_NO_REPLY_MAX.getName(), 150);
         PropertyResolverUtils.updateProperty(
                 SSH_CLIENT, CoreModuleProperties.SOCKET_KEEPALIVE.getName(), true);
         // set support all KeyExchange

--- a/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/ssh/CommonSshClient.java
+++ b/collector/src/main/java/org/apache/hertzbeat/collector/collect/common/ssh/CommonSshClient.java
@@ -43,7 +43,7 @@ public class CommonSshClient {
         PropertyResolverUtils.updateProperty(
                 SSH_CLIENT, CoreModuleProperties.HEARTBEAT_INTERVAL.getName(), 2000);
         PropertyResolverUtils.updateProperty(
-                SSH_CLIENT, CoreModuleProperties.HEARTBEAT_NO_REPLY_MAX.getName(), 150);
+                SSH_CLIENT, CoreModuleProperties.HEARTBEAT_NO_REPLY_MAX.getName(), 30);
         PropertyResolverUtils.updateProperty(
                 SSH_CLIENT, CoreModuleProperties.SOCKET_KEEPALIVE.getName(), true);
         // set support all KeyExchange


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
modify ssh client common properties. Change HEARTBEAT_REPLY_WAIT to HEARTBEAT_NO_REPLY_MAX
see issue #2397


HEARTBEAT_NO_REPLY_MAX property:
The meaning of HEARTBEAT_NO_REPLY_MAX:
This property defines the maximum number of consecutive heartbeat responses that can be lost before the SSH client considers the connection to be disconnected.
Specific scenario example:
Let's assume we have the following configuration:

HEARTBEAT_INTERVAL is set to 10 seconds (10,000 milliseconds)
HEARTBEAT_NO_REPLY_MAX is set to 3

Scenario description:

The SSH client sends a heartbeat request to the server every 10 seconds.
Under normal circumstances:

The client sends a heartbeat
The server responds to the heartbeat
The connection is considered active


Now, let's assume some network issues occur:

0 seconds: The client sends the first heartbeat, no response received
10 seconds: The client sends the second heartbeat, still no response
20 seconds: The client sends the third heartbeat, again no response
30 seconds: The client prepares to send the fourth heartbeat


At this point, because there have been 3 consecutive heartbeats without a response, reaching the HEARTBEAT_NO_REPLY_MAX value:

The SSH client will consider the connection to be disconnected
The client may attempt to re-establish the connection or notify the application layer that the connection has been lost


If the network recovers to normal after sending the third heartbeat:

The server responds to the third heartbeat
The counter will be reset
The connection continues to remain active



The benefits of this mechanism are:

It can promptly detect network issues or server unresponsiveness.
It provides a degree of fault tolerance, not immediately disconnecting due to occasional network jitters.
Parameters can be adjusted based on network environment and application requirements to balance quick response and connection stability.
## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
