### PR TITLE
Optimize the execution efficiency of Gitpod tasks

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,7 +1,0 @@
-FROM gitpod/workspace-full
-
-USER gitpod
-
-RUN bash -c ". /home/gitpod/.sdkman/bin/sdkman-init.sh && \
-    sdk install java 17.0.12-amzn && \
-    sdk default java 17.0.12-amzn"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,27 +1,33 @@
-image:
-    file: .gitpod.Dockerfile
 tasks:
-    - name: Setup
-      init: |
-          cp -r contrib/ide/vscode .vscode
-          mvn clean install
-          cd web-app
-          yarn install
-      command: |
-          gp sync-done setup
-          exit 0
+
     - name: Run backend
+      before: cd manager
       command: |
-          gp sync-await setup
-
-          cd manager
+          gp sync-await setup-backend
           mvn spring-boot:run
-    - name: Run frontend
-      command: |
-          gp sync-await setup
 
-          cd web-app
-          yarn start
+    - name: Run frontend
+      before: cd web-app
+      command: |
+          gp sync-await setup-frontend
+          yarn start --public-host "`gp url 4200`"
+      openMode: split-right
+
+    - name: Setup backend
+      init: |
+          sdk install java 17.0.11.fx-zulu < /dev/null
+          sdk default java 17.0.11.fx-zulu < /dev/null
+          mvn clean install -DskipTests
+      command: |
+          gp sync-done setup-backend
+          exit 0
+
+    - name: Setup frontend
+      init: |
+          cd web-app && yarn install
+      command: |
+          gp sync-done setup-frontend
+          exit 0
       openMode: split-right
 
 vscode:
@@ -39,3 +45,9 @@ ports:
     - port: 4200
       name: Hertzbeat
       onOpen: open-browser
+
+    - port: 1157
+      onOpen: ignore
+
+    - port: 1158
+      onOpen: ignore


### PR DESCRIPTION
## What's changed?

Installing JDK17 based on default container isolation is far more efficient than building a dedicated container separately.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
