### PR TITLE
feat: fix log upload, when e2e fails it still uploads

### DIFF
--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -77,6 +77,7 @@ jobs:
     # upload application logs
     - name: Upload logs
       uses: actions/upload-artifact@v3
+      if: always()
       with:
         name: hz-logs-${{ github.run_id }}
         path: e2e/logs/

--- a/e2e/testsuite.yaml
+++ b/e2e/testsuite.yaml
@@ -33,7 +33,7 @@ param:
 items:
 - name: login
   request:
-    api: /api/account/auth/form
+    api: /api/account/auth/for
     method: POST
     header:
       Content-type: application/json

--- a/e2e/testsuite.yaml
+++ b/e2e/testsuite.yaml
@@ -33,7 +33,7 @@ param:
 items:
 - name: login
   request:
-    api: /api/account/auth/for
+    api: /api/account/auth/form
     method: POST
     header:
       Content-type: application/json


### PR DESCRIPTION
I realized that the current log upload ci task doesn't upload when the ci fails, so I made the change. You can check the: https://github.com/yuluo-yx/hertzbeat/actions/runs/10235846904?pr=12.

![image](https://github.com/user-attachments/assets/c564449f-73b6-4db7-bb23-1e0e0d539ffa)

This configuration still uploads logs when ci fails. fix: https://github.com/apache/hertzbeat/actions/runs/10229236498/job/28302645855

@tomsun28 ptal.