### PR TITLE
[bugfix] clear qbdata when cascade change

### DIFF
--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.ts
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.ts
@@ -164,7 +164,7 @@ export class AlertSettingComponent implements OnInit {
   onNewAlertDefine() {
     this.define = new AlertDefine();
     this.define.tags = [];
-    this.resetQbData({ condition: 'and', rules: [] });
+    this.resetQbDataDefault();
     this.isManageModalAdd = true;
     this.isManageModalVisible = true;
     this.isManageModalOkLoading = false;
@@ -593,6 +593,7 @@ export class AlertSettingComponent implements OnInit {
   };
 
   cascadeOnChange(values: string[]): void {
+    this.resetQbDataDefault();
     if (values == null || values.length != 3) {
       return;
     }
@@ -645,7 +646,7 @@ export class AlertSettingComponent implements OnInit {
     } catch (e) {
       console.error(e);
       this.isExpr = true;
-      this.resetQbData({ condition: 'and', rules: [] });
+      this.resetQbDataDefault();
       return;
     }
   }
@@ -653,7 +654,7 @@ export class AlertSettingComponent implements OnInit {
   onManageModalCancel() {
     this.cascadeValues = [];
     this.isExpr = false;
-    this.resetQbData({ condition: 'and', rules: [] });
+    this.resetQbDataDefault();
     this.isManageModalVisible = false;
   }
 
@@ -661,10 +662,14 @@ export class AlertSettingComponent implements OnInit {
     this.qbFormCtrl.reset((this.qbData = qbData));
   }
 
+  resetQbDataDefault() {
+    this.resetQbData({ condition: 'and', rules: [] });
+  }
+
   resetManageModalData() {
     this.cascadeValues = [];
     this.isExpr = false;
-    this.resetQbData({ condition: 'and', rules: [] });
+    this.resetQbDataDefault();
     this.isManageModalVisible = false;
   }
 


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
clear qbdata when cascade change
if u changed the cascade value to 3 length、add some rule and then change it back to 2 length. the rules datas were not cleared
## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
