### PR TITLE
[alerter]optimize: Append not resolved alert description to resolved alert

### DIFF
--- a/alerter/src/main/java/org/apache/hertzbeat/alert/calculate/CalculateAlarm.java
+++ b/alerter/src/main/java/org/apache/hertzbeat/alert/calculate/CalculateAlarm.java
@@ -177,7 +177,7 @@ public class CalculateAlarm {
                                 String alarmKey = String.valueOf(monitorId) + define.getId();
                                 triggeredAlertMap.remove(alarmKey);
                                 if (define.isRecoverNotice()) {
-                                    handleRecoveredAlert(currentTimeMilli, define, expr, alarmKey);
+                                    handleRecoveredAlert(currentTimeMilli, define, alarmKey);
                                 }
                             }
                         } catch (Exception e) {
@@ -232,7 +232,7 @@ public class CalculateAlarm {
                                 String alarmKey = String.valueOf(monitorId) + define.getId() + tagBuilder;
                                 triggeredAlertMap.remove(alarmKey);
                                 if (define.isRecoverNotice()) {
-                                    handleRecoveredAlert(currentTimeMilli, define, expr, alarmKey);
+                                    handleRecoveredAlert(currentTimeMilli, define, alarmKey);
                                 }
                             }
                         } catch (Exception e) {
@@ -244,12 +244,12 @@ public class CalculateAlarm {
         }
     }
 
-    private void handleRecoveredAlert(long currentTimeMilli, AlertDefine define, String expr, String alarmKey) {
+    private void handleRecoveredAlert(long currentTimeMilli, AlertDefine define, String alarmKey) {
         Alert notResolvedAlert = notRecoveredAlertMap.remove(alarmKey);
         if (notResolvedAlert != null) {
             // Sending an alarm Restore
             Map<String, String> tags = notResolvedAlert.getTags();
-            String content = this.bundle.getString("alerter.alarm.recover") + " : " + expr;
+            String content = this.bundle.getString("alerter.alarm.recover") + " : " + notResolvedAlert.getContent();
             Alert resumeAlert = Alert.builder()
                     .tags(tags)
                     .target(define.getApp() + "." + define.getMetric() + "." + define.getField())


### PR DESCRIPTION
## What's changed?

[related issue](https://github.com/apache/hertzbeat/issues/2582)

Enhanced the resolved alert description by appending the trigger alert's description, improving the context provided during alert resolution.

Suppose an alert is triggered with the following content:
```
The xxx server is in exception.
```

Before the modification, the resolved alert description was:
```
Alert Resolved Notice: status > 0
```

After the modification, the description becomes:
```
Alert Resolved Notice: The xxx server is in exception.
```

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
