### PR TITLE
[bugfix] fix alarm recover not match in converge reduce in some condition

### DIFF
--- a/alerter/src/main/java/org/apache/hertzbeat/alert/reduce/AlarmConvergeReduce.java
+++ b/alerter/src/main/java/org/apache/hertzbeat/alert/reduce/AlarmConvergeReduce.java
@@ -64,17 +64,11 @@ public class AlarmConvergeReduce {
                 isHasIgnore = true;
                 tags.remove(CommonConstants.IGNORE);
             }
-            int alertHash = Objects.hash(CommonConstants.ALERT_PRIORITY_CODE_CRITICAL)
-                    + Arrays.hashCode(tags.keySet().toArray(new String[0]))
-                    + Arrays.hashCode(tags.values().toArray(new String[0]));
+            int alertHash = generateAlertHash(CommonConstants.ALERT_PRIORITY_CODE_CRITICAL, tags);
             converageAlertMap.remove(alertHash);
-            alertHash = Objects.hash(CommonConstants.ALERT_PRIORITY_CODE_EMERGENCY)
-                    + Arrays.hashCode(tags.keySet().toArray(new String[0]))
-                    + Arrays.hashCode(tags.values().toArray(new String[0]));
+            alertHash = generateAlertHash(CommonConstants.ALERT_PRIORITY_CODE_EMERGENCY, tags);
             converageAlertMap.remove(alertHash);
-            alertHash = Objects.hash(CommonConstants.ALERT_PRIORITY_CODE_WARNING)
-                    + Arrays.hashCode(tags.keySet().toArray(new String[0]))
-                    + Arrays.hashCode(tags.values().toArray(new String[0]));
+            alertHash = generateAlertHash(CommonConstants.ALERT_PRIORITY_CODE_WARNING, tags);
             converageAlertMap.remove(alertHash);
             if (isHasIgnore) {
                 tags.put(CommonConstants.IGNORE, CommonConstants.IGNORE);
@@ -132,9 +126,7 @@ public class AlarmConvergeReduce {
                 if (evalInterval <= 0) {
                     return true;
                 }
-                int alertHash = Objects.hash(currentAlert.getPriority())
-                        + Arrays.hashCode(currentAlert.getTags().keySet().toArray(new String[0]))
-                        + Arrays.hashCode(currentAlert.getTags().values().toArray(new String[0]));
+                int alertHash = generateAlertHash(currentAlert.getPriority(), currentAlert.getTags());
                 Alert preAlert = converageAlertMap.get(alertHash);
                 if (preAlert == null) {
                     currentAlert.setTimes(1);
@@ -164,5 +156,13 @@ public class AlarmConvergeReduce {
             }
         }
         return true;
+    }
+    
+    private int generateAlertHash(byte priority, Map<String, String> tags) {
+        List<String> keyList = tags.keySet().stream().filter(Objects::nonNull).sorted().toList();
+        List<String> valueList = tags.values().stream().filter(Objects::nonNull).sorted().toList();
+        return Objects.hash(priority)
+                + Arrays.hashCode(keyList.toArray(new String[0]))
+                + Arrays.hashCode(valueList.toArray(new String[0]));
     }
 }


### PR DESCRIPTION
## What's changed?

When using the hashkey of tags as a match, the order of the hash string must also be kept consistent.

<!-- Describe Your PR Here -->


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
