### PR TITLE
fix the mounting issues in script/docker-compose/hertzbeat-postgresql-victoria-metrics/docker-compose.yaml 

### DIFF
--- a/script/docker-compose/hertzbeat-postgresql-victoria-metrics/docker-compose.yaml
+++ b/script/docker-compose/hertzbeat-postgresql-victoria-metrics/docker-compose.yaml
@@ -39,8 +39,7 @@ services:
       TZ: Asia/Shanghai
     volumes:
       - ./dbdata/pgdata/data:/var/lib/postgresql/data
-      - ./conf/sql:/docker-entrypoint-initdb.d/
-      - ./ext-lib:/opt/hertzbeat/ext-lib
+      - ./conf/sql:/docker-entrypoint-initdb.d/      
     networks:
       - hertzbeat
 
@@ -81,6 +80,7 @@ services:
       - ./conf/application.yml:/opt/hertzbeat/config/application.yml
       - ./conf/sureness.yml:/opt/hertzbeat/config/sureness.yml
       - ./logs:/opt/hertzbeat/logs
+      - ./ext-lib:/opt/hertzbeat/ext-lib
     ports:
       - "1157:1157"
       - "1158:1158"


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
Place ./ext-lib:/opt/hertzbeat/ext-lib in the mount under hertzbeat

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
