### PR TITLE
[bugfix] fix monitor detail display error

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-detail/monitor-detail.component.html
+++ b/web-app/src/app/routes/monitor/monitor-detail/monitor-detail.component.html
@@ -91,7 +91,7 @@
             ></app-monitor-data-chart>
           </div>
         </nz-tab>
-        <nz-tab *ngIf="monitor.grafanaDashboard.enabled" [nzTitle]="title3Template">
+        <nz-tab *ngIf="monitor.grafanaDashboard && monitor.grafanaDashboard.enabled" [nzTitle]="title3Template">
           <ng-template #title3Template>
             <i nz-icon nzType="line-chart" style="margin-left: 10px"></i>
             Grafana


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

fix monitor detail display error

when get grafana dashboard info null, this error will occers
<img width="317" alt="image" src="https://github.com/user-attachments/assets/1c8f30ce-659f-4e26-8fcb-fcf64d829e17">


<img width="668" alt="image" src="https://github.com/user-attachments/assets/10a1ab82-b5a6-4771-9e53-3d2d90c2a6f7">


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
