### PR TITLE
[bugfix] filter dashboard metrics

### DIFF
--- a/manager/src/main/java/org/apache/hertzbeat/manager/service/impl/BulletinServiceImpl.java
+++ b/manager/src/main/java/org/apache/hertzbeat/manager/service/impl/BulletinServiceImpl.java
@@ -208,7 +208,7 @@ public class BulletinServiceImpl implements BulletinService {
                                     for (int i = 0; i < fieldList.size(); i++) {
                                         fieldList.get(i).setValue(valueRow.getColumns(i));
                                     }
-                                    return fieldList;
+                                    return fieldList.stream().filter(field -> fields.contains(field.getKey())).toList();
                                 })
                                 .toList();
                     } else {


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

filter dashboard metrics
fix this:
create dashboard select one metric, flush to more than one metrics
<img width="1500" alt="image" src="https://github.com/user-attachments/assets/87dac560-b75c-4eaf-8db0-8481e8fb3217">
<img width="1681" alt="image" src="https://github.com/user-attachments/assets/3c1f020a-d38a-43c1-9942-68053c8e3e5e">


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
