### PR TITLE
[bugfix] fix custom dashboard show metrics error

### DIFF
--- a/common/src/main/java/org/apache/hertzbeat/common/entity/manager/bulletin/Bulletin.java
+++ b/common/src/main/java/org/apache/hertzbeat/common/entity/manager/bulletin/Bulletin.java
@@ -70,7 +70,7 @@ public class Bulletin {
 
 
     @Schema(description = "Monitor Fields")
-    @Column(length = 4096, columnDefinition = "json")
+    @Column(length = 4096)
     private String fields;
 
     @Schema(description = "Tags(status:success,env:prod)", example = "{name: key1, value: value1}",


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
fix custom dashboard show metrics error

use h2 database. 

when create a custom kanban, select some metrics, it shows ok

but after restart server, the fields querys error

h2 database supports json field not good

<img width="1228" alt="image" src="https://github.com/user-attachments/assets/c3cf3880-270b-4b4f-943f-f979d889f479">

<img width="643" alt="image" src="https://github.com/user-attachments/assets/5513438b-2de8-4b48-8479-d750933f95a4">


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
