### PR TITLE
[improve] add kanban auto refresh

### DIFF
--- a/web-app/src/app/routes/bulletin/bulletin.component.ts
+++ b/web-app/src/app/routes/bulletin/bulletin.component.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Component, Inject, OnInit } from '@angular/core';
+import { Component, Inject, OnInit, OnDestroy } from '@angular/core';
 import { I18NService } from '@core';
 import { ALAIN_I18N_TOKEN } from '@delon/theme';
 import { NzModalService } from 'ng-zorro-antd/modal';
@@ -39,7 +39,7 @@ import { MonitorService } from '../../service/monitor.service';
   templateUrl: './bulletin.component.html',
   styleUrls: ['./bulletin.component.less']
 })
-export class BulletinComponent implements OnInit {
+export class BulletinComponent implements OnInit, OnDestroy {
   constructor(
     private modal: NzModalService,
     private notifySvc: NzNotificationService,
@@ -68,9 +68,19 @@ export class BulletinComponent implements OnInit {
   pageIndex: number = 1;
   pageSize: number = 8;
   total: number = 0;
+  refreshInterval: any;
 
   ngOnInit() {
     this.loadTabs();
+    this.refreshInterval = setInterval(() => {
+      this.loadTabs();
+    }, 30000); // every 30 seconds refresh the tabs
+  }
+
+  ngOnDestroy() {
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval);
+    }
   }
 
   sync() {


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
add kanban auto refresh:
if we create a new kanban, and the metrics data will not auto refresh itself

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
