### PR TITLE
[bugfix] fix status page unknowing status value

### DIFF
--- a/web-app/src/app/pojo/StatusPageHistory.ts
+++ b/web-app/src/app/pojo/StatusPageHistory.ts
@@ -24,7 +24,7 @@ export class StatusPageHistory {
   timestamp!: number;
   uptime!: number;
   abnormal!: number;
-  unknown!: number;
+  unknowing!: number;
   normal!: number;
   creator!: string;
   modifier!: string;

--- a/web-app/src/app/routes/status-public/status-public.component.html
+++ b/web-app/src/app/routes/status-public/status-public.component.html
@@ -119,7 +119,7 @@
                 <p>Uptime {{ (100 * historyItem.uptime).toFixed(2) }}%</p>
                 <p>{{ 'status.component.state.0' | i18n }} {{ historyItem.normal }}s</p>
                 <p>{{ 'status.component.state.1' | i18n }} {{ historyItem.abnormal }}s</p>
-                <p>{{ 'status.component.state.2' | i18n }} {{ historyItem.unknown }}s</p>
+                <p>{{ 'status.component.state.2' | i18n }} {{ historyItem.unknowing }}s</p>
               </div>
             </ng-template>
           </div>


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
fix status page unknowing status value
value key mismatch
<img width="253" alt="image" src="https://github.com/user-attachments/assets/8e927540-3ba7-4b73-b560-cffcb458fe98">
<img width="384" alt="image" src="https://github.com/user-attachments/assets/ab038030-55a8-4984-bd46-4a831a33b56f">

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
