### PR TITLE
[improve] init default theme

### DIFF
--- a/manager/src/main/java/org/apache/hertzbeat/manager/config/ConfigInitializer.java
+++ b/manager/src/main/java/org/apache/hertzbeat/manager/config/ConfigInitializer.java
@@ -91,7 +91,7 @@ public class ConfigInitializer implements SmartLifecycle {
                     .setDateFormat(simpleDateFormat);
         } else {
             // init system config data
-            systemConfig = SystemConfig.builder().timeZoneId(TimeZone.getDefault().getID())
+            systemConfig = SystemConfig.builder().timeZoneId(TimeZone.getDefault().getID()).theme("default")
                                    .locale(Locale.getDefault().getLanguage() + CommonConstants.LOCALE_SEPARATOR
                                                    + Locale.getDefault().getCountry())
                                    .build();


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
init default theme

fix:

when first start, the theme will be this 
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/d7ce062d-94bd-4ce4-a5e1-0660bca27e5e">


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
