### PR TITLE
JDK17 does not exist in Huawei's mirror station, delete the descripti…

### DIFF
--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/package-deploy.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/package-deploy.md
@@ -121,7 +121,6 @@ HertzBeat Collector 是一个轻量级的数据采集器，用于采集并将数
 
    安装JAVA运行环境-可参考[官方网站](http://www.oracle.com/technetwork/java/javase/downloads/index.html)  
    要求：JAVA17环境  
-   下载JAVA安装包: [镜像站](https://repo.huaweicloud.com/java/jdk/)  
    安装后命令行检查是否成功安装
 
    ```shell

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/package-deploy.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/package-deploy.md
@@ -120,7 +120,8 @@ HertzBeat Collector 是一个轻量级的数据采集器，用于采集并将数
 1. 启动失败，需您提前准备JAVA运行环境
 
    安装JAVA运行环境-可参考[官方网站](http://www.oracle.com/technetwork/java/javase/downloads/index.html)  
-   要求：JAVA17环境  
+   要求：JAVA17环境
+   下载JAVA安装包: [镜像站](https://mirrors.huaweicloud.com/openjdk/)  
    安装后命令行检查是否成功安装
 
    ```shell
@@ -130,7 +131,7 @@ HertzBeat Collector 是一个轻量级的数据采集器，用于采集并将数
    Java HotSpot(TM) 64-Bit Server VM 17.0.9 (build 17.0.9+8-LTS-237, mixed mode)
    ```
 
-2. 按照流程部署，访问 <http://ip:1157/> 无界面
+3. 按照流程部署，访问 <http://ip:1157/> 无界面
    请参考下面几点排查问题：
 
    > 一：若切换了依赖服务MYSQL数据库，排查数据库是否成功创建，是否启动成功  

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/package-deploy.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/package-deploy.md
@@ -131,7 +131,7 @@ HertzBeat Collector 是一个轻量级的数据采集器，用于采集并将数
    Java HotSpot(TM) 64-Bit Server VM 17.0.9 (build 17.0.9+8-LTS-237, mixed mode)
    ```
 
-3. 按照流程部署，访问 <http://ip:1157/> 无界面
+2. 按照流程部署，访问 <http://ip:1157/> 无界面
    请参考下面几点排查问题：
 
    > 一：若切换了依赖服务MYSQL数据库，排查数据库是否成功创建，是否启动成功  


### PR DESCRIPTION
## What's changed?

JDK17 does not exist in Huawei's mirror station, delete the description in the document.

issue: [https://github.com/apache/hertzbeat/issues/2747](url)

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [X]  I have written the necessary doc or comment.
- [X]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [X] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
