### PR TITLE
[improve]Remove stack property from line charts

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-data-chart/monitor-data-chart.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-data-chart/monitor-data-chart.component.ts
@@ -273,7 +273,6 @@ export class MonitorDataChartComponent implements OnInit {
                 this.lineHistoryTheme.series.push({
                   name: key,
                   type: 'line',
-                  stack: 'Total',
                   smooth: true,
                   showSymbol: false,
                   areaStyle: {},
@@ -314,7 +313,6 @@ export class MonitorDataChartComponent implements OnInit {
                 type: 'line',
                 smooth: true,
                 showSymbol: false,
-                stack: 'Total',
                 areaStyle: {},
                 emphasis: {
                   focus: 'series'
@@ -326,7 +324,6 @@ export class MonitorDataChartComponent implements OnInit {
                 type: 'line',
                 smooth: true,
                 showSymbol: false,
-                stack: 'Total',
                 areaStyle: {},
                 emphasis: {
                   focus: 'series'
@@ -338,7 +335,6 @@ export class MonitorDataChartComponent implements OnInit {
                 type: 'line',
                 smooth: true,
                 showSymbol: false,
-                stack: 'Total',
                 areaStyle: {},
                 emphasis: {
                   focus: 'series'


### PR DESCRIPTION
- Removed the 'stack: 'Total'' property from multiple line chart configurations
- This change improves the visual representation of data by removing stacked areas



## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
