### PR TITLE
[Improve] add notification when port number changes automatically due to HTTPS toggle.(#2779)

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-form/monitor-form.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-form/monitor-form.component.ts
@@ -54,10 +54,7 @@ export class MonitorFormComponent implements OnChanges {
 
   hasAdvancedParams: boolean = false;
 
-  constructor(
-    private notifySvc: NzNotificationService,
-    @Inject(ALAIN_I18N_TOKEN) private i18nSvc: I18NService
-  ) {}
+  constructor(private notifySvc: NzNotificationService, @Inject(ALAIN_I18N_TOKEN) private i18nSvc: I18NService) {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.advancedParams && changes.advancedParams.currentValue !== changes.advancedParams.previousValue) {
@@ -158,8 +155,7 @@ export class MonitorFormComponent implements OnChanges {
       if (portParam) {
         if (booleanValue && (portParam.paramValue == null || parseInt(portParam.paramValue) === 80)) {
           portParam.paramValue = 443;
-          this.notifySvc.info(this.i18nSvc.fanyi('common.notice'), this.i18nSvc.fanyi('monitors.new.notify.change-to-https')
-          );
+          this.notifySvc.info(this.i18nSvc.fanyi('common.notice'), this.i18nSvc.fanyi('monitors.new.notify.change-to-https'));
         }
         if (!booleanValue && (portParam.paramValue == null || parseInt(portParam.paramValue) === 443)) {
           portParam.paramValue = 80;

--- a/web-app/src/app/routes/monitor/monitor-form/monitor-form.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-form/monitor-form.component.ts
@@ -17,8 +17,11 @@
  * under the License.
  */
 
-import { Component, EventEmitter, Input, Output, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, EventEmitter, Input, Output, OnChanges, SimpleChanges, Inject } from '@angular/core';
 import { FormGroup } from '@angular/forms';
+import { I18NService } from '@core';
+import { ALAIN_I18N_TOKEN } from '@delon/theme';
+import { NzNotificationService } from 'ng-zorro-antd/notification';
 
 import { Collector } from '../../../pojo/Collector';
 import { Param } from '../../../pojo/Param';
@@ -51,7 +54,10 @@ export class MonitorFormComponent implements OnChanges {
 
   hasAdvancedParams: boolean = false;
 
-  constructor() {}
+  constructor(
+    private notifySvc: NzNotificationService,
+    @Inject(ALAIN_I18N_TOKEN) private i18nSvc: I18NService
+  ) {}
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.advancedParams && changes.advancedParams.currentValue !== changes.advancedParams.previousValue) {
@@ -152,9 +158,12 @@ export class MonitorFormComponent implements OnChanges {
       if (portParam) {
         if (booleanValue && (portParam.paramValue == null || parseInt(portParam.paramValue) === 80)) {
           portParam.paramValue = 443;
+          this.notifySvc.info(this.i18nSvc.fanyi('common.notice'), this.i18nSvc.fanyi('monitors.new.notify.change-to-https')
+          );
         }
         if (!booleanValue && (portParam.paramValue == null || parseInt(portParam.paramValue) === 443)) {
           portParam.paramValue = 80;
+          this.notifySvc.info(this.i18nSvc.fanyi('common.notice'), this.i18nSvc.fanyi('monitors.new.notify.change-to-http'));
         }
       }
     }

--- a/web-app/src/assets/i18n/en-US.json
+++ b/web-app/src/assets/i18n/en-US.json
@@ -402,6 +402,8 @@
   "monitors.new-monitor": "New Monitor",
   "monitors.new.success": "New Monitor Success",
   "monitors.new.failed": "New Monitor Failed",
+  "monitors.new.notify.change-to-https": "HTTPS has been enabled, and the port number has been automatically changed to 443. Please take note.",
+  "monitors.new.notify.change-to-http": "HTTPS has been disabled, and the port number has been automatically changed to 80. Please take note.",
   "monitors.edit": "Edit",
   "monitors.edit.success": "Update Monitor Success",
   "monitors.edit.failed": "Update Monitor Failed",

--- a/web-app/src/assets/i18n/zh-CN.json
+++ b/web-app/src/assets/i18n/zh-CN.json
@@ -403,6 +403,8 @@
   "monitors.new-monitor": "新增监控",
   "monitors.new.success": "新增监控成功",
   "monitors.new.failed": "新增监控失败",
+  "monitors.new.notify.change-to-https": "已开启HTTPS，端口号自动更改为 443，请留意。",
+  "monitors.new.notify.change-to-http": "已关闭HTTPS，端口号自动更改为 80，请留意。",
   "monitors.edit": "编辑",
   "monitors.edit.success": "修改监控成功",
   "monitors.edit.failed": "修改监控失败",

--- a/web-app/src/assets/i18n/zh-TW.json
+++ b/web-app/src/assets/i18n/zh-TW.json
@@ -416,6 +416,8 @@
   "monitors.new-monitor": "新增監控",
   "monitors.new.success": "新增監控成功",
   "monitors.new.failed": "新增監控失敗",
+  "monitors.new.notify.change-to-https": "已啟用 HTTPS，連接埠號已自動更改為 443，請注意。",
+  "monitors.new.notify.change-to-http": "已停用 HTTPS，連接埠號已自動更改為 80，請注意。",
   "monitors.edit": "編輯",
   "monitors.edit.success": "修改監控成功",
   "monitors.edit.failed": "修改監控失敗",


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

[Issue](https://github.com/apache/hertzbeat/issues/2779)
启用和关闭https导致端口号自动变更时，增加提示
Add notification when port number changes automatically due to HTTPS toggle.
![image](https://github.com/user-attachments/assets/a4d9d4ca-6721-4bcb-ad04-8b4b11f53f9a)

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
