### PR TITLE
[Imporve] Support Kafka internal topic configuration

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-kafka/src/main/java/org/apache/hertzbeat/collector/collect/kafka/KafkaCollectImpl.java
+++ b/hertzbeat-collector/hertzbeat-collector-kafka/src/main/java/org/apache/hertzbeat/collector/collect/kafka/KafkaCollectImpl.java
@@ -19,6 +19,8 @@ package org.apache.hertzbeat.collector.collect.kafka;
 
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hertzbeat.collector.collect.AbstractCollect;
+import org.apache.hertzbeat.collector.collect.kafka.constants.InternalTopic;
+import org.apache.hertzbeat.collector.collect.kafka.constants.SupportedCommand;
 import org.apache.hertzbeat.collector.dispatch.DispatchConstants;
 import org.apache.hertzbeat.common.entity.job.Metrics;
 import org.apache.hertzbeat.common.entity.job.protocol.KafkaProtocol;
@@ -39,6 +41,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.springframework.util.Assert;
+
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,6 +62,155 @@ public class KafkaCollectImpl extends AbstractCollect {
     private static final String LAG_NUM = "lag_num";
     private static final String PARTITION_OFFSET = "Partition_offset";
 
+    /**
+     * Collect the list of topics
+     *
+     * @param builder     The MetricsData builder
+     * @param adminClient The AdminClient
+     */
+    private static void collectTopicList(CollectRep.MetricsData.Builder builder, AdminClient adminClient, Boolean monitorInternalTopic) throws InterruptedException, ExecutionException {
+        ListTopicsOptions options = new ListTopicsOptions().listInternal(true);
+        Set<String> topicNames = adminClient.listTopics(options).names().get();
+        topicNames.forEach(topicName -> {
+            if (filterInternalTopics(topicName, monitorInternalTopic)) {
+                CollectRep.ValueRow valueRow = CollectRep.ValueRow.newBuilder().addColumn(topicName).build();
+                builder.addValueRow(valueRow);
+            }
+        });
+    }
+
+    /**
+     * Collect the description of each topic
+     *
+     * @param builder     The MetricsData builder
+     * @param adminClient The AdminClient
+     */
+    private static void collectTopicDescribe(CollectRep.MetricsData.Builder builder, AdminClient adminClient, Boolean monitorInternalTopic) throws InterruptedException, ExecutionException {
+        ListTopicsOptions options = new ListTopicsOptions();
+        options.listInternal(true);
+        ListTopicsResult listTopicsResult = adminClient.listTopics(options);
+        Set<String> names = listTopicsResult.names().get();
+        DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(names);
+        Map<String, TopicDescription> topicDescriptionMap = describeTopicsResult.all().get().entrySet().stream()
+                .filter(entry -> filterInternalTopics(entry.getKey(), monitorInternalTopic))
+                .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+        topicDescriptionMap.forEach((key, value) -> {
+            List<TopicPartitionInfo> listp = value.partitions();
+            listp.forEach(info -> {
+                CollectRep.ValueRow.Builder valueRowBuilder = CollectRep.ValueRow.newBuilder();
+                valueRowBuilder.addColumn(value.name());
+                valueRowBuilder.addColumn(String.valueOf(value.partitions().size()));
+                valueRowBuilder.addColumn(String.valueOf(info.partition()));
+                valueRowBuilder.addColumn(info.leader().host());
+                valueRowBuilder.addColumn(String.valueOf(info.leader().port()));
+                valueRowBuilder.addColumn(String.valueOf(info.replicas().size()));
+                valueRowBuilder.addColumn(String.valueOf(info.replicas()));
+                builder.addValueRow(valueRowBuilder.build());
+            });
+        });
+    }
+
+    /**
+     * Collect Topic ConsumerGroups Message
+     *
+     * @param builder     The MetricsData builder
+     * @param adminClient The AdminClient
+     */
+    private static void collectTopicConsumerGroups(CollectRep.MetricsData.Builder builder, AdminClient adminClient, Boolean monitorInternalTopic) throws InterruptedException, ExecutionException {
+        ListTopicsOptions options = new ListTopicsOptions();
+        options.listInternal(true);
+        // Get all consumer groups
+        ListConsumerGroupsResult consumerGroupsResult = adminClient.listConsumerGroups();
+        Collection<ConsumerGroupListing> consumerGroups = consumerGroupsResult.all().get();
+        // Get the list of consumer groups for each topic
+        Map<String, Set<String>> topicConsumerGroupsMap = getTopicConsumerGroupsMap(consumerGroups, adminClient);
+        topicConsumerGroupsMap.entrySet().stream()
+                .flatMap(entry -> entry.getValue().stream()
+                        .map(groupId -> {
+                            try {
+                                String topicName = entry.getKey();
+                                if (filterInternalTopics(topicName, monitorInternalTopic)) {
+                                    DescribeConsumerGroupsResult describeResult = adminClient.describeConsumerGroups(Collections.singletonList(groupId));
+                                    Map<String, ConsumerGroupDescription> consumerGroupDescriptions = describeResult.all().get();
+                                    ConsumerGroupDescription description = consumerGroupDescriptions.get(groupId);
+                                    Map<String, String> offsetAndLagNum = getConsumerGroupMetrics(topicName, groupId, adminClient);
+                                    return CollectRep.ValueRow.newBuilder()
+                                            .addColumn(groupId)
+                                            .addColumn(String.valueOf(description.members().size()))
+                                            .addColumn(topicName)
+                                            .addColumn(offsetAndLagNum.get(PARTITION_OFFSET))
+                                            .addColumn(offsetAndLagNum.get(LAG_NUM))
+                                            .build();
+                                }
+                            } catch (InterruptedException | ExecutionException e) {
+                                log.warn("group {} get message fail", groupId);
+                            }
+                            return null;
+                        })
+                )
+                .filter(Objects::nonNull)
+                .forEach(builder::addValueRow);
+    }
+
+    private static Map<String, Set<String>> getTopicConsumerGroupsMap(Collection<ConsumerGroupListing> consumerGroups,
+                                                                      AdminClient adminClient)
+            throws ExecutionException, InterruptedException {
+        Map<String, Set<String>> topicConsumerGroupsMap = new HashMap<>();
+        for (ConsumerGroupListing consumerGroup : consumerGroups) {
+            String groupId = consumerGroup.groupId();
+            // Get the offset information for the consumer group
+            ListConsumerGroupOffsetsResult consumerGroupOffsetsResult = adminClient.listConsumerGroupOffsets(groupId);
+            Map<TopicPartition, OffsetAndMetadata> topicOffsets = consumerGroupOffsetsResult.partitionsToOffsetAndMetadata().get();
+            // Iterate over all TopicPartitions consumed by the consumer group
+            for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : topicOffsets.entrySet()) {
+                String topic = entry.getKey().topic();
+                topicConsumerGroupsMap.computeIfAbsent(topic, k -> new HashSet<>()).add(groupId);
+            }
+        }
+        return topicConsumerGroupsMap;
+    }
+
+    private static Map<String, String> getConsumerGroupMetrics(String topic, String groupId, AdminClient adminClient)
+            throws ExecutionException, InterruptedException {
+        // Get the offset for each groupId for the specified topic
+        ListConsumerGroupOffsetsResult consumerGroupOffsetsResult = adminClient.listConsumerGroupOffsets(groupId);
+        Map<TopicPartition, OffsetAndMetadata> topicOffsets = consumerGroupOffsetsResult.partitionsToOffsetAndMetadata().get();
+        long totalLag = 0L;
+        for (Entry<TopicPartition, OffsetAndMetadata> topicPartitionOffsetAndMetadataEntry : topicOffsets.entrySet()) {
+            if (topicPartitionOffsetAndMetadataEntry.getKey().topic().equals(topic)) {
+                OffsetAndMetadata offsetMetadata = topicPartitionOffsetAndMetadataEntry.getValue();
+                TopicPartition partition = topicPartitionOffsetAndMetadataEntry.getKey();
+                // Get the latest offset for each TopicPartition
+                ListOffsetsResultInfo resultInfo = adminClient.listOffsets(
+                        Collections.singletonMap(partition, OffsetSpec.latest())).all().get().get(partition);
+                long latestOffset = resultInfo.offset();
+                // Accumulate the lag for each partition
+                long l = latestOffset - offsetMetadata.offset();
+                totalLag += l;
+            }
+        }
+        // Get all offsets and convert them to a string, joined by "、"
+        String partitionOffsets = topicOffsets.entrySet().stream()
+                .filter(entry -> entry.getKey().topic().equals(topic))
+                .map(entry -> String.valueOf(entry.getValue().offset()))
+                .collect(Collectors.collectingAndThen(
+                        Collectors.joining(","),
+                        result -> "[" + result + "]"
+                ));
+        Map<String, String> res = new HashMap<>();
+        res.put(LAG_NUM, String.valueOf(totalLag));
+        res.put(PARTITION_OFFSET, partitionOffsets);
+        return res;
+    }
+
+    private static boolean filterInternalTopics(String topic, Boolean monitorInternalTopic) {
+        if (monitorInternalTopic) {
+            return true;
+        } else {
+            return !InternalTopic.isInternalTopic(topic);
+        }
+    }
+
     @Override
     public void preCheck(Metrics metrics) throws IllegalArgumentException {
         KafkaProtocol kafkaProtocol = metrics.getKclient();
@@ -74,6 +226,7 @@ public class KafkaCollectImpl extends AbstractCollect {
         try {
             KafkaProtocol kafkaProtocol = metrics.getKclient();
             String command = kafkaProtocol.getCommand();
+            Boolean monitorInternalTopic = Boolean.valueOf(kafkaProtocol.getMonitorInternalTopic());
             boolean isKafkaCommand = SupportedCommand.isKafkaCommand(command);
             if (!isKafkaCommand) {
                 log.error("Unsupported command: {}", command);
@@ -86,16 +239,16 @@ public class KafkaCollectImpl extends AbstractCollect {
             // Execute the appropriate collection method based on the command
             switch (SupportedCommand.fromCommand(command)) {
                 case TOPIC_DESCRIBE:
-                    collectTopicDescribe(builder, adminClient);
+                    collectTopicDescribe(builder, adminClient, monitorInternalTopic);
                     break;
                 case TOPIC_LIST:
-                    collectTopicList(builder, adminClient);
+                    collectTopicList(builder, adminClient, monitorInternalTopic);
                     break;
                 case TOPIC_OFFSET:
-                    collectTopicOffset(builder, adminClient);
+                    collectTopicOffset(builder, adminClient, monitorInternalTopic);
                     break;
                 case CONSUMER_DETAIL:
-                    collectTopicConsumerGroups(builder, adminClient);
+                    collectTopicConsumerGroups(builder, adminClient, monitorInternalTopic);
                     break;
                 default:
                     log.error("Unsupported command: {}", command);
@@ -114,15 +267,17 @@ public class KafkaCollectImpl extends AbstractCollect {
      * @throws InterruptedException If the thread is interrupted
      * @throws ExecutionException   If an error occurs during execution
      */
-    private void collectTopicOffset(CollectRep.MetricsData.Builder builder, AdminClient adminClient) throws InterruptedException, ExecutionException {
+    private void collectTopicOffset(CollectRep.MetricsData.Builder builder, AdminClient adminClient, Boolean monitorInternalTopic) throws InterruptedException, ExecutionException {
         ListTopicsResult listTopicsResult = adminClient.listTopics(new ListTopicsOptions().listInternal(true));
-        Set<String> names = listTopicsResult.names().get();
-        names.forEach(name -> {
-            try {
-                Map<String, TopicDescription> map = adminClient.describeTopics(Collections.singleton(name)).all().get(3L, TimeUnit.SECONDS);
-                map.forEach((key, value) -> value.partitions().forEach(info -> extractedOffset(builder, adminClient, name, value, info)));
-            } catch (TimeoutException | InterruptedException | ExecutionException e) {
-                log.warn("Topic {} get offset fail", name);
+        Set<String> topicNames = listTopicsResult.names().get();
+        topicNames.forEach(topicName -> {
+            if (filterInternalTopics(topicName, monitorInternalTopic)) {
+                try {
+                    Map<String, TopicDescription> map = adminClient.describeTopics(Collections.singleton(topicName)).all().get(3L, TimeUnit.SECONDS);
+                    map.forEach((key, value) -> value.partitions().forEach(info -> extractedOffset(builder, adminClient, topicName, value, info)));
+                } catch (TimeoutException | InterruptedException | ExecutionException e) {
+                    log.warn("Topic {} get offset fail", topicName);
+                }
             }
         });
     }
@@ -176,142 +331,6 @@ public class KafkaCollectImpl extends AbstractCollect {
                 .get(topicPartition)
                 .offset();
     }
-
-    /**
-     * Collect the list of topics
-     *
-     * @param builder     The MetricsData builder
-     * @param adminClient The AdminClient
-     */
-    private static void collectTopicList(CollectRep.MetricsData.Builder builder, AdminClient adminClient) throws InterruptedException, ExecutionException {
-        ListTopicsOptions options = new ListTopicsOptions().listInternal(true);
-        Set<String> names = adminClient.listTopics(options).names().get();
-        names.forEach(name -> {
-            CollectRep.ValueRow valueRow = CollectRep.ValueRow.newBuilder().addColumn(name).build();
-            builder.addValueRow(valueRow);
-        });
-    }
-
-    /**
-     * Collect the description of each topic
-     *
-     * @param builder     The MetricsData builder
-     * @param adminClient The AdminClient
-     */
-    private static void collectTopicDescribe(CollectRep.MetricsData.Builder builder, AdminClient adminClient) throws InterruptedException, ExecutionException {
-        ListTopicsOptions options = new ListTopicsOptions();
-        options.listInternal(true);
-        ListTopicsResult listTopicsResult = adminClient.listTopics(options);
-        Set<String> names = listTopicsResult.names().get();
-        DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(names);
-        Map<String, TopicDescription> map = describeTopicsResult.all().get();
-        map.forEach((key, value) -> {
-            List<TopicPartitionInfo> listp = value.partitions();
-            listp.forEach(info -> {
-                CollectRep.ValueRow.Builder valueRowBuilder = CollectRep.ValueRow.newBuilder();
-                valueRowBuilder.addColumn(value.name());
-                valueRowBuilder.addColumn(String.valueOf(value.partitions().size()));
-                valueRowBuilder.addColumn(String.valueOf(info.partition()));
-                valueRowBuilder.addColumn(info.leader().host());
-                valueRowBuilder.addColumn(String.valueOf(info.leader().port()));
-                valueRowBuilder.addColumn(String.valueOf(info.replicas().size()));
-                valueRowBuilder.addColumn(String.valueOf(info.replicas()));
-                builder.addValueRow(valueRowBuilder.build());
-            });
-        });
-    }
-
-    /**
-     * Collect Topic ConsumerGroups Message
-     *
-     * @param builder     The MetricsData builder
-     * @param adminClient The AdminClient
-     */
-    private static void collectTopicConsumerGroups(CollectRep.MetricsData.Builder builder, AdminClient adminClient) throws InterruptedException, ExecutionException {
-        ListTopicsOptions options = new ListTopicsOptions();
-        options.listInternal(true);
-        // Get all consumer groups
-        ListConsumerGroupsResult consumerGroupsResult = adminClient.listConsumerGroups();
-        Collection<ConsumerGroupListing> consumerGroups = consumerGroupsResult.all().get();
-        // Get the list of consumer groups for each topic
-        Map<String, Set<String>> topicConsumerGroupsMap = getTopicConsumerGroupsMap(consumerGroups, adminClient);
-        topicConsumerGroupsMap.entrySet().stream()
-                .flatMap(entry -> entry.getValue().stream()
-                        .map(groupId -> {
-                            try {
-                                String topic = entry.getKey();
-                                DescribeConsumerGroupsResult describeResult = adminClient.describeConsumerGroups(Collections.singletonList(groupId));
-                                Map<String, ConsumerGroupDescription> consumerGroupDescriptions = describeResult.all().get();
-                                ConsumerGroupDescription description = consumerGroupDescriptions.get(groupId);
-                                Map<String, String> offsetAndLagNum = getConsumerGroupMetrics(topic, groupId, adminClient);
-                                return CollectRep.ValueRow.newBuilder()
-                                        .addColumn(groupId)
-                                        .addColumn(String.valueOf(description.members().size()))
-                                        .addColumn(topic)
-                                        .addColumn(offsetAndLagNum.get(PARTITION_OFFSET))
-                                        .addColumn(offsetAndLagNum.get(LAG_NUM))
-                                        .build();
-                            } catch (InterruptedException | ExecutionException e) {
-                                log.warn("group {} get message fail", groupId);
-                                return null;
-                            }
-                        })
-                )
-                .filter(Objects::nonNull)
-                .forEach(builder::addValueRow);
-    }
-
-    private static Map<String, Set<String>> getTopicConsumerGroupsMap(Collection<ConsumerGroupListing> consumerGroups,
-            AdminClient adminClient)
-            throws ExecutionException, InterruptedException {
-        Map<String, Set<String>> topicConsumerGroupsMap = new HashMap<>();
-        for (ConsumerGroupListing consumerGroup : consumerGroups) {
-            String groupId = consumerGroup.groupId();
-            // Get the offset information for the consumer group
-            ListConsumerGroupOffsetsResult consumerGroupOffsetsResult = adminClient.listConsumerGroupOffsets(groupId);
-            Map<TopicPartition, OffsetAndMetadata> topicOffsets = consumerGroupOffsetsResult.partitionsToOffsetAndMetadata().get();
-            // Iterate over all TopicPartitions consumed by the consumer group
-            for (Map.Entry<TopicPartition, OffsetAndMetadata> entry : topicOffsets.entrySet()) {
-                String topic = entry.getKey().topic();
-                topicConsumerGroupsMap.computeIfAbsent(topic, k -> new HashSet<>()).add(groupId);
-            }
-        }
-        return topicConsumerGroupsMap;
-    }
-
-    private static Map<String, String> getConsumerGroupMetrics(String topic, String groupId, AdminClient adminClient)
-            throws ExecutionException, InterruptedException {
-        // Get the offset for each groupId for the specified topic
-        ListConsumerGroupOffsetsResult consumerGroupOffsetsResult = adminClient.listConsumerGroupOffsets(groupId);
-        Map<TopicPartition, OffsetAndMetadata> topicOffsets = consumerGroupOffsetsResult.partitionsToOffsetAndMetadata().get();
-        long totalLag = 0L;
-        for (Entry<TopicPartition, OffsetAndMetadata> topicPartitionOffsetAndMetadataEntry : topicOffsets.entrySet()) {
-            if (topicPartitionOffsetAndMetadataEntry.getKey().topic().equals(topic)) {
-                OffsetAndMetadata offsetMetadata = topicPartitionOffsetAndMetadataEntry.getValue();
-                TopicPartition partition = topicPartitionOffsetAndMetadataEntry.getKey();
-                // Get the latest offset for each TopicPartition
-                ListOffsetsResultInfo resultInfo = adminClient.listOffsets(
-                        Collections.singletonMap(partition, OffsetSpec.latest())).all().get().get(partition);
-                long latestOffset = resultInfo.offset();
-                // Accumulate the lag for each partition
-                long l = latestOffset - offsetMetadata.offset();
-                totalLag += l;
-            }
-        }
-        // Get all offsets and convert them to a string, joined by "、"
-        String partitionOffsets = topicOffsets.entrySet().stream()
-                .filter(entry -> entry.getKey().topic().equals(topic))
-                .map(entry -> String.valueOf(entry.getValue().offset()))
-                .collect(Collectors.collectingAndThen(
-                        Collectors.joining(","),
-                        result -> "[" + result + "]"
-                ));
-        Map<String, String> res = new HashMap<>();
-        res.put(LAG_NUM, String.valueOf(totalLag));
-        res.put(PARTITION_OFFSET, partitionOffsets);
-        return res;
-    }
-
 
     @Override
     public String supportProtocol() {

--- a/hertzbeat-collector/hertzbeat-collector-kafka/src/main/java/org/apache/hertzbeat/collector/collect/kafka/constants/InternalTopic.java
+++ b/hertzbeat-collector/hertzbeat-collector-kafka/src/main/java/org/apache/hertzbeat/collector/collect/kafka/constants/InternalTopic.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.collector.collect.kafka.constants;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * SupportedCommand
+ */
+public enum InternalTopic {
+
+    CONSUMER_OFFSET("__consumer_offsets");
+
+    private static Set<String> INTERNAL_TOPIC = new HashSet<>();
+
+    static {
+        // O(1) complexity, using static to load all system placeholders
+        for (InternalTopic placeholder : InternalTopic.values()) {
+            INTERNAL_TOPIC.add(placeholder.getCommand());
+        }
+    }
+
+    private final String key;
+
+    InternalTopic(String command) {
+        this.key = command;
+    }
+
+    public String getCommand() {
+        return key;
+    }
+
+    public static boolean isInternalTopic(String str) {
+        return INTERNAL_TOPIC.contains(str);
+    }
+
+    public static InternalTopic fromCommand(String command) {
+        for (InternalTopic supportedCommand : InternalTopic.values()) {
+            if (supportedCommand.getCommand().equals(command)) {
+                return supportedCommand;
+            }
+        }
+        throw new IllegalArgumentException("No enum constant for command: " + command);
+    }
+}

--- a/hertzbeat-collector/hertzbeat-collector-kafka/src/main/java/org/apache/hertzbeat/collector/collect/kafka/constants/SupportedCommand.java
+++ b/hertzbeat-collector/hertzbeat-collector-kafka/src/main/java/org/apache/hertzbeat/collector/collect/kafka/constants/SupportedCommand.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.hertzbeat.collector.collect.kafka;
+package org.apache.hertzbeat.collector.collect.kafka.constants;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/entity/job/protocol/KafkaProtocol.java
+++ b/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/entity/job/protocol/KafkaProtocol.java
@@ -50,4 +50,9 @@ public class KafkaProtocol implements CommonRequestProtocol {
      * COMMAND
      */
     private String command;
+
+    /**
+     * Monitor internal topic
+     */
+    private String monitorInternalTopic = "false";
 }

--- a/hertzbeat-manager/src/main/resources/define/app-kafka_client.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-kafka_client.yml
@@ -43,6 +43,13 @@ params:
     range: '[0,65535]'
     required: true
     defaultValue: 9092
+  - field: monitorInternalTopic
+    name:
+      zh-CN: 是否监控内部主题
+      en-US: Monitor Internal Topic
+    type: boolean
+    required: true
+    defaultValue: false
 
 metrics:
   - name: topic_list
@@ -60,6 +67,7 @@ metrics:
     kclient:
       host: ^_^host^_^
       port: ^_^port^_^
+      monitorInternalTopic: ^_^monitorInternalTopic^_^
       command: topic-list
   - name: topic_detail
     i18n:
@@ -106,6 +114,7 @@ metrics:
     kclient:
       host: ^_^host^_^
       port: ^_^port^_^
+      monitorInternalTopic: ^_^monitorInternalTopic^_^
       command: topic-describe
   - name: topic_offset
     i18n:
@@ -141,6 +150,7 @@ metrics:
     kclient:
       host: ^_^host^_^
       port: ^_^port^_^
+      monitorInternalTopic: ^_^monitorInternalTopic^_^
       command: topic-offset
   - name: consumer_detail
     i18n:
@@ -181,4 +191,5 @@ metrics:
     kclient:
       host: ^_^host^_^
       port: ^_^port^_^
+      monitorInternalTopic: ^_^monitorInternalTopic^_^
       command: consumer-detail


### PR DESCRIPTION
## What's changed? 

Kafka internal topics do not need to be displayed in most cases, as they take up too much space. Because he has 50 partitions.
We use configuration items to set whether to monitor internal topics.

![image](https://github.com/user-attachments/assets/0e1c13af-eda2-420b-8acb-8b7f3b874203)


<img width="924" alt="image" src="https://github.com/user-attachments/assets/d4d17af3-078c-4661-b621-0b97e2c643b7" />
