### PR TITLE
[fix](flink): update calculate metrics definitions

### DIFF
--- a/hertzbeat-manager/src/main/resources/define/app-flink.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-flink.yml
@@ -171,11 +171,11 @@ metrics:
       - jobs-cancelled
       - jobs-failed
     calculates:
-      - slots_total=slots-total
-      - slots_used=slots-total-slots-available
-      - task_total=jobs-running+jobs-finished+jobs-cancelled+jobs-failed
-      - jobs_running=jobs-running
-      - jobs_failed=jobs-failed
+      - slots_total=get('slots-total')
+      - slots_used=get('slots-total')-get('slots-available')
+      - task_total=get('jobs-running')+get('jobs-finished')+get('jobs-cancelled')+get('jobs-failed')
+      - jobs_running=get('jobs-running')
+      - jobs_failed=get('jobs-failed')
     protocol: http
     http:
       host: ^_^host^_^


### PR DESCRIPTION
- Replace direct metric references with get() function for dynamic value retrieval
- Correct calculation logic for slots_used and task_total metrics
- Ensure consistent naming and improve error tolerance in metric calculations
![image](https://github.com/user-attachments/assets/3102d24e-e191-44ba-91e8-4101f3cdeb7d)


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
