### PR TITLE
[bugfix]  Corrected case 'DashBoard' is a lower case 'B'

### DIFF
--- a/web-app/src/assets/i18n/en-US.json
+++ b/web-app/src/assets/i18n/en-US.json
@@ -2,7 +2,7 @@
   "menu": {
     "main": "Main",
     "lang": "Language",
-    "dashboard": "DashBoard",
+    "dashboard": "Dashboard",
     "search.placeholder": "Search：Monitoring Task: Name、Host etc",
     "fullscreen": "Full Screen",
     "fullscreen.exit": "Exit",


### PR DESCRIPTION
## What's changed?

I noticed the dashboard has 'DashBoard' .. the 'B' should be lower case 'b' . 


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
