### PR TITLE
[Doc]:Add English version of documentation for Kafka Consumer Detail

### DIFF
--- a/home/docs/help/kafka_client.md
+++ b/home/docs/help/kafka_client.md
@@ -45,3 +45,13 @@ keywords: [open-source monitoring system, open-source message middleware monitor
 | PartitionNum  | None | Number of Partitions |
 | earliest      | None | Earliest Offset  |
 | latest        | None | Latest Offset    |
+
+#### Metric Set：consumer_detail
+
+|   Metric Name   | Unit | Help Description                   |
+|-----------|--|------------------------------------|
+| GroupId | None | Consumer Group Id                  |
+| Group Member Num     | None | 	Number of Consumer Instances      |
+| Subscribed Topic Name      | None | Topic Name Subscribed by the Group |
+| Offsets of Each Partition     | None | Offsets for Each Partition         |
+| Lag      | None | Lag of Consumer                       |

--- a/home/docs/help/kafka_client.md
+++ b/home/docs/help/kafka_client.md
@@ -51,7 +51,7 @@ keywords: [open-source monitoring system, open-source message middleware monitor
 |   Metric Name   | Unit | Help Description                   |
 |-----------|--|------------------------------------|
 | GroupId | None | Consumer Group Id                  |
-| Group Member Num     | None | 	Number of Consumer Instances      |
+| Group Member Num     | None | Number of Consumer Instances       |
 | Subscribed Topic Name      | None | Topic Name Subscribed by the Group |
 | Offsets of Each Partition     | None | Offsets for Each Partition         |
-| Lag      | None | Lag of Consumer                       |
+| Lag      | None | Lag of Consumer                    |


### PR DESCRIPTION
## What's changed?
 
Add English version of documentation for recently added Kafka consumer metrics,

<img width="637" alt="999" src="https://github.com/user-attachments/assets/b97c4df9-6b3f-4cfb-8755-dc4e64dc8d73" />

which previously only had a Chinese version.

<img width="493" alt="000" src="https://github.com/user-attachments/assets/27a0a463-a10d-49c8-b84e-b97863fb7002" />


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
