### PR TITLE
[bugfix]Fix division by zero in windows storage usage calculation

### DIFF
--- a/hertzbeat-manager/src/main/resources/define/app-windows.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-windows.yml
@@ -403,7 +403,7 @@ metrics:
       - size=hrStorageSize * hrStorageAllocationUnits
       - free=(hrStorageSize - hrStorageUsed) * hrStorageAllocationUnits
       - used=hrStorageUsed * hrStorageAllocationUnits
-      - usage= hrStorageUsed / hrStorageSize * 100
+      - usage= hrStorageUsed / (hrStorageSize + 0.001) * 100
     units:
       - size=B->Mb
       - used=B->Mb


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
During monitoring and logging, numerous error logs have been identified, which are caused by division by zero in the storage usage calculation.
`2025-01-10 08:36:34.485 [alerter-worker-3] ERROR org.apache.hertzbeat.alert.calculate.CalculateAlarm Line:337 - Alarm Rule: ((usage > 90) and (used > 1
0240) and !contains(descr,"Memory")) Run Error: org.apache.hertzbeat.common.util.JexlExpressionRunner.compile:79 variable 'usage' is undefined.
2025-01-10 08:37:34.679 [alerter-worker-4] ERROR org.apache.hertzbeat.alert.calculate.CalculateAlarm Line:337 - Alarm Rule: ((usage > 90) and (used > 1
0240) and !contains(descr,"Memory")) Run Error: org.apache.hertzbeat.common.util.JexlExpressionRunner.compile:79 variable 'usage' is undefined.`
* after fix
![image](https://github.com/user-attachments/assets/603df02f-5815-4e0a-a661-19a3b542f811)
## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
