### PR TITLE
[Improve] Add more test cases for Kafka junit tests

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-kafka/src/test/java/org/apache/hertzbeat/collector/collect/kafka/KafkaCollectTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-kafka/src/test/java/org/apache/hertzbeat/collector/collect/kafka/KafkaCollectTest.java
@@ -78,12 +78,20 @@ public class KafkaCollectTest {
             collect.collect(builder, null);
         });
 
+        KafkaProtocol kafka = KafkaProtocol.builder().host("127.0.0.1").port("9092").build();
+        Metrics metrics = Metrics.builder().kclient(kafka).build();
+        //test if not kafka command
         assertDoesNotThrow(() -> {
             CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
-            KafkaProtocol kafka = KafkaProtocol.builder().host("127.0.0.1").port("9092").build();
-            Metrics metrics = Metrics.builder().kclient(kafka).build();
             collect.collect(builder, metrics);
         });
+        //test kafka command
+        assertDoesNotThrow(() -> {
+            CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
+            metrics.getKclient().setCommand("topic-list");
+            collect.collect(builder, metrics);
+        });
+
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

For `KafkaCollectTest`,in the previous test cases, we did not set the value of the `command`, so it was left `null`. 

This PR aims to add new test cases where `command` is not null.


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
