### PR TITLE
[feature] Add alerter_zh_TW.properties configuration to adapt to mult…

### DIFF
--- a/hertzbeat-alerter/src/main/resources/alerter_zh_TW.properties
+++ b/hertzbeat-alerter/src/main/resources/alerter_zh_TW.properties
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+alerter.availability.recover = 可用性警報已解決，監視狀態現在正常
+alerter.alarm.recover = 警報解決通知
+alerter.notify.title = HertzBeat 警報通知
+alerter.notify.target = 監視目標
+alerter.notify.monitorId = 監視 ID
+alerter.notify.monitorName = 監視名稱
+alerter.notify.monitorHost = 監視主機
+alerter.notify.priority = 警報優先級
+alerter.notify.triggerTime = 警報觸發時間
+alerter.notify.restoreTime = 警報恢復時間
+alerter.notify.times = 警報觸發次數
+alerter.notify.tags = 警報標籤
+alerter.notify.content = 警報內容
+alerter.notify.console = 控制台登錄
+alerter.priority.0 = 緊急警報
+alerter.priority.1 = 嚴重警報
+alerter.priority.2 = 警告警報


### PR DESCRIPTION
## What's changed?

Add alerter_zh_TW.properties configuration to adapt to multiple languages

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
