### PR TITLE
[bugfix] Fixed the bug in the threshold rules search box.

### DIFF
--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.html
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.html
@@ -70,6 +70,7 @@
       [placeholder]="'alert.setting.search' | i18n"
       [(value)]="search"
       (keydown.enter)="onFilterChange()"
+      (cleared)="onFilterChange()"
     />
   </ng-template>
 </app-toolbar>

--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.ts
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.ts
@@ -200,7 +200,7 @@ export class AlertSettingComponent implements OnInit {
     this.tableLoading = true;
     const translationSearchList: string[] = [];
     let trimSearch = '';
-    if (this.search !== undefined && this.search.trim() !== '') {
+    if (this.search && this.search.trim() !== '') {
       trimSearch = this.search.trim();
     }
     // Filter entries based on search input

--- a/web-app/src/app/shared/components/multi-func-input/multi-func-input.component.ts
+++ b/web-app/src/app/shared/components/multi-func-input/multi-func-input.component.ts
@@ -52,6 +52,7 @@ export class MultiFuncInputComponent implements ControlValueAccessor {
   @Input() type: string = 'text';
   @Input() size: NzSizeLDSType = 'default';
   @Output() readonly valueChange = new EventEmitter<string>();
+  @Output() readonly cleared = new EventEmitter<void>();
 
   disabled: boolean = false;
   passwordVisible: boolean = false;
@@ -67,6 +68,7 @@ export class MultiFuncInputComponent implements ControlValueAccessor {
   onClear(event: any) {
     event.stopPropagation();
     this.onChange((this.value = null));
+    this.cleared.emit();
   }
 
   writeValue(value: any): void {


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
[Issue](https://github.com/apache/hertzbeat/issues/3033)
1. Fixed the bug where pressing Enter after clicking the ❌ would cause a continuous loading screen.  
2. Now, clicking the ❌ will automatically refresh without the need to press Enter.
## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
