### PR TITLE
[update] upgrade actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -73,7 +73,7 @@ jobs:
       
       # upload application logs
       - name: Upload logs & API test reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: hz-logs-${{ github.run_id }}

--- a/.github/workflows/doc-pdf-builder.yml
+++ b/.github/workflows/doc-pdf-builder.yml
@@ -39,7 +39,7 @@ jobs:
         run: npx docusaurus-prince-pdf -u https://hertzbeat.apache.org/docs --output docs-en.pdf
   
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-cn-pdf
           path: docs-cn.pdf
@@ -47,7 +47,7 @@ jobs:
           retention-days: 1
           
       - name: Upload results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: docs-en-pdf
           path: docs-en.pdf


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
Upgrade `actions/upload-artifact` to v4 to fix errors in CI.  
[Reference documentation](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

![image](https://github.com/user-attachments/assets/97965417-d51f-4538-b5d0-76f3fc1a99fd)

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
