### PR TITLE
[bugfix](web-app): update app menu visibility on monitor creation

### DIFF
--- a/web-app/src/app/routes/setting/define/define.component.ts
+++ b/web-app/src/app/routes/setting/define/define.component.ts
@@ -266,7 +266,7 @@ export class DefineComponent implements OnInit {
       .subscribe(
         message => {
           if (message.code === 0) {
-            this.loadMenus();
+            this.updateLocalAppState(app, hide);
             this.startUpSvc.loadConfigResourceViaHttp().subscribe(() => {});
             this.notifySvc.success(this.i18nSvc.fanyi('common.notify.apply-success'), '');
           } else {
@@ -277,6 +277,18 @@ export class DefineComponent implements OnInit {
           this.notifySvc.error(this.i18nSvc.fanyi('common.notify.apply-fail'), error.msg);
         }
       );
+  }
+
+  private updateLocalAppState(app: string, hide: boolean): void {
+    this.appMenusArr.forEach(([category, menuData]) => {
+      if (menuData.child) {
+        menuData.child.forEach((item: any) => {
+          if (item.value === app) {
+            item.hide = hide;
+          }
+        });
+      }
+    });
   }
 
   renderCategoryName(category: string): string {


### PR DESCRIPTION
- Add updateLocalAppState method to update app menu visibility
- Call updateLocalAppState when creating a new monitor

## What's changed?

<!-- Describe Your PR Here -->


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
