### PR TITLE
[bugfix] fix alert sse illegal state exception

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/config/AlertSseManager.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/config/AlertSseManager.java
@@ -19,6 +19,7 @@
 
 package org.apache.hertzbeat.alert.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -30,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * SSE manager for alert
  */
+@Slf4j
 @Component
 public class AlertSseManager {
     private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
@@ -38,6 +40,7 @@ public class AlertSseManager {
         SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
         emitter.onCompletion(() -> removeEmitter(clientId));
         emitter.onTimeout(() -> removeEmitter(clientId));
+        emitter.onError((ex) -> removeEmitter(clientId));
         emitters.put(clientId, emitter);
         return emitter;
     }
@@ -50,7 +53,11 @@ public class AlertSseManager {
                         .id(String.valueOf(System.currentTimeMillis()))
                         .name("ALERT_EVENT")
                         .data(data));
-            } catch (IOException e) {
+            } catch (IOException | IllegalStateException e) {
+                emitter.complete();
+                removeEmitter(clientId);
+            } catch (Exception exception) {
+                log.error("Failed to broadcast alert data to client: {}", exception.getMessage());
                 emitter.complete();
                 removeEmitter(clientId);
             }


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

fix alert sse illegal state exception

```
2025-02-25 11:11:07.420 [task-148] ERROR org.springframework.aop.interceptor.SimpleAsyncUncaughtExceptionHandler Line:39  - Unexpected exception occurred invoking async method: public void org.apache.hertzbeat.alert.config.AlertSseManager.broadcast(java.lang.String)
java.lang.IllegalStateException: ResponseBodyEmitter has already completed
	at org.springframework.util.Assert.state(Assert.java:97)
	at org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter.send(ResponseBodyEmitter.java:223)
	at org.springframework.web.servlet.mvc.method.annotation.SseEmitter.send(SseEmitter.java:135)
	at org.apache.hertzbeat.alert.config.AlertSseManager.lambda$broadcast$2(AlertSseManager.java:49)
	at java.base/java.util.concurrent.ConcurrentHashMap.forEach(ConcurrentHashMap.java:1603)
	at org.apache.hertzbeat.alert.config.AlertSseManager.broadcast(AlertSseManager.java:47)
	at jdk.internal.reflect.GeneratedMethodAccessor407.invoke(Unknown Source)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:351)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:765)
	at org.springframework.aop.interceptor.AsyncExecutionInterceptor.lambda$invoke$0(AsyncExecutionInterceptor.java:113)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
