### PR TITLE
[bugfix] Fix exception thrown when searching for CollectRep.Field in the list

### DIFF
--- a/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/entity/message/CollectRep.java
+++ b/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/entity/message/CollectRep.java
@@ -567,6 +567,13 @@ public final class CollectRep {
             return new Builder();
         }
 
+        public boolean equals(Object o) {
+            if(!(o instanceof Field))
+                return false;
+            Field other = (Field)o;
+            return other.name.equals(this.name);
+        }
+
         public static class Builder {
             private final Field instance;
 

--- a/hertzbeat-common/src/test/java/org/apache/hertzbeat/common/entity/message/CollectRepTest.java
+++ b/hertzbeat-common/src/test/java/org/apache/hertzbeat/common/entity/message/CollectRepTest.java
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.hertzbeat.common.entity.message;
 
 import org.junit.jupiter.params.ParameterizedTest;

--- a/hertzbeat-common/src/test/java/org/apache/hertzbeat/common/entity/message/CollectRepTest.java
+++ b/hertzbeat-common/src/test/java/org/apache/hertzbeat/common/entity/message/CollectRepTest.java
@@ -11,9 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class CollectRepTest {
 
     @ParameterizedTest
-    @CsvSource({
-       "name, name, true",
-       "name1, name3, false",
+    @CsvSource(value = {
+            "name, name, true",
+            "name1, name3, false",
     })
     void testFieldEquals(String name1, String name2, boolean result) {
         CollectRep.Field field1 = new CollectRep.Field();

--- a/hertzbeat-common/src/test/java/org/apache/hertzbeat/common/entity/message/CollectRepTest.java
+++ b/hertzbeat-common/src/test/java/org/apache/hertzbeat/common/entity/message/CollectRepTest.java
@@ -1,0 +1,27 @@
+package org.apache.hertzbeat.common.entity.message;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test case for {@link CollectRep}
+ */
+public class CollectRepTest {
+
+    @ParameterizedTest
+    @CsvSource({
+       "name, name, true",
+       "name1, name3, false",
+    })
+    void testFieldEquals(String name1, String name2, boolean result) {
+        CollectRep.Field field1 = new CollectRep.Field();
+        field1.setName(name1);
+        CollectRep.Field field2 = new CollectRep.Field();
+        field2.setName(name2);
+       
+        assertEquals(field1.equals(field2), result);
+    }
+
+}


### PR DESCRIPTION
## What's changed?
#3102
I implemented the equals method in the CollectRep.Field class so that it can be found in the list by name.
For more details, you can check the comments I previously added in issue #3102, where I explained the specific cause of the bug, the possible solutions, and discussions on which approach to take.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
