### PR TITLE
[improve] Optimize the progress display of monitoring imports

### DIFF
--- a/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/constants/ImExportTaskConstant.java
+++ b/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/constants/ImExportTaskConstant.java
@@ -24,7 +24,7 @@ package org.apache.hertzbeat.common.constants;
 public interface ImExportTaskConstant {
 
     /**
-     * Import task Process bar threshold
+     * If the number of tasks exceeds 100, progress information will broadcast
      */
-    Integer ImportProcessThreshold = 100;
+    Integer IMPORT_TASK_PROCESS_THRESHOLD = 100;
 }

--- a/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/constants/ImExportTaskConstant.java
+++ b/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/constants/ImExportTaskConstant.java
@@ -17,23 +17,14 @@
 
 package org.apache.hertzbeat.common.constants;
 
-
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.ToString;
-
 /**
- * Manager Event Type Enum
+ * Import/Export task constants
  */
-@Getter
-@AllArgsConstructor
-@ToString
-public enum ManagerEventTypeEnum {
+
+public interface ImExportTaskConstant {
 
     /**
-     * IMPORT_TASK_EVENT
+     * Import task Process bar threshold
      */
-    IMPORT_TASK_EVENT("IMPORT_TASK_EVENT");
-
-    private final String value;
+    Integer ImportProcessThreshold = 100;
 }

--- a/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/constants/ManagerEventTypeEnum.java
+++ b/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/constants/ManagerEventTypeEnum.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.common.constants;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Manager Event Type Enum
+ */
+@Getter
+@AllArgsConstructor
+@ToString
+public enum ManagerEventTypeEnum {
+
+    /**
+     * IMPORT_TASK
+     */
+    importTask("IMPORT_TASK");
+
+    private final String value;
+}

--- a/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/constants/NotifyLevelEnum.java
+++ b/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/constants/NotifyLevelEnum.java
@@ -15,42 +15,26 @@
  * limitations under the License.
  */
 
-package org.apache.hertzbeat.manager.service;
+package org.apache.hertzbeat.common.constants;
 
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
 
 /**
- * Configuration Import Export
- * Created by gcdd1993 on 2023/3/31
+ * Notify Level Enum
  */
-public interface ImExportService {
+@Getter
+@AllArgsConstructor
+@ToString
+public enum NotifyLevelEnum {
 
-    /**
-     * Import Configuration
-     * @param taskName task name
-     * @param is input stream
-     */
-    void importConfig(String taskName, InputStream is);
+    SUCCESS("SUCCESS"),
+    ERROR("ERROR"),
+    INFO("INFO"),
+    WARNING("WARNING"),
+    BLANK("BLANK");
 
-    /**
-     * Export Configuration
-     * @param os         output stream
-     * @param configList configuration list
-     */
-    void exportConfig(OutputStream os, List<Long> configList);
-
-    /**
-     * Export file type
-     * @return file type
-     */
-    String type();
-
-    /**
-     * Get Export File Name
-     * @return file name
-     */
-    String getFileName();
-
+    private final String value;
 }

--- a/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/entity/manager/ManagerMessage.java
+++ b/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/entity/manager/ManagerMessage.java
@@ -1,0 +1,28 @@
+package org.apache.hertzbeat.common.entity.manager;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Manager Message Entity
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ManagerMessage {
+    /**
+     * Notify Level {@see NotifyLevelEnum}
+     */
+    private String notifyLevel;
+
+    /**
+     * Manager Event Type {@see ManagerEventTypeEnum}
+     */
+    private String managerEventType;
+
+    /**
+     * Message Content
+     */
+    private String content;
+}

--- a/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/entity/manager/TaskProcess.java
+++ b/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/entity/manager/TaskProcess.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.common.entity.manager;
+
+import lombok.*;
+
+/**
+ * Task Process
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TaskProcess {
+
+    private Long id;
+
+    private String taskName;
+
+    private Status status;
+
+    private String info;
+
+    /**
+     * Task Process Status
+     */
+    @Getter
+    public enum Status {
+        /**
+         * collect success
+         */
+        SUCCESS(0),
+
+        FAIL(1),
+
+        IN_PROCESS(2);
+
+        private final int value;
+
+        Status(int value) {
+            this.value = value;
+        }
+    }
+}

--- a/hertzbeat-common/src/main/resources/msg.properties
+++ b/hertzbeat-common/src/main/resources/msg.properties
@@ -13,4 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-hello=你好
+manager_import_task_progress=导入任务[%s]进度: %d%%
+manager_import_task_success=导入任务[%s]完成
+manager_import_task_fail=导入任务[%s]失败: %s

--- a/hertzbeat-common/src/main/resources/msg_en.properties
+++ b/hertzbeat-common/src/main/resources/msg_en.properties
@@ -13,4 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-hello=你好
+manager_import_task_progress=Import task[%s], process: %d%%
+manager_import_task_success=Import task[%s] completed
+manager_import_task_fail=Import task[%s] failed: %s

--- a/hertzbeat-common/src/test/resources/msg.properties
+++ b/hertzbeat-common/src/test/resources/msg.properties
@@ -14,3 +14,6 @@
 # limitations under the License.
 
 hello=你好
+import_task_progress=导入任务[%s]进度: %d%
+import_task_completed=导入任务[%s]完成
+import_task_fail=导入任务[%s]失败: %s

--- a/hertzbeat-common/src/test/resources/msg_en.properties
+++ b/hertzbeat-common/src/test/resources/msg_en.properties
@@ -14,3 +14,6 @@
 # limitations under the License.
 
 hello=Hello, World!
+import_task_progress=Import task[%s], process: %d%
+import_task_completed=Import task[%s] completed
+import_task_fail=Import task[%s] failed: %s

--- a/hertzbeat-common/src/test/resources/msg_en.properties
+++ b/hertzbeat-common/src/test/resources/msg_en.properties
@@ -14,6 +14,3 @@
 # limitations under the License.
 
 hello=Hello, World!
-import_task_progress=Import task[%s], process: %d%
-import_task_completed=Import task[%s] completed
-import_task_fail=Import task[%s] failed: %s

--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/config/ManagerSseManager.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/config/ManagerSseManager.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hertzbeat.manager.config;
+
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class ManagerSseManager {
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter createEmitter(Long clientId) {
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+        emitter.onCompletion(() -> removeEmitter(clientId));
+        emitter.onTimeout(() -> removeEmitter(clientId));
+        emitters.put(clientId, emitter);
+        return emitter;
+    }
+
+    @Async
+    public void broadcast(String eventName, String data) {
+        emitters.forEach((clientId, emitter) -> {
+            try {
+                emitter.send(SseEmitter.event()
+                        .id(String.valueOf(System.currentTimeMillis()))
+                        .name(eventName)
+                        .data(data));
+            } catch (IOException e) {
+                emitter.complete();
+                removeEmitter(clientId);
+            }
+        });
+    }
+
+    private void removeEmitter(Long clientId) {
+        emitters.remove(clientId);
+    }
+}

--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/config/ManagerSseManager.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/config/ManagerSseManager.java
@@ -34,7 +34,7 @@ import java.util.ResourceBundle;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Manager SSE Manager
+ * Manager SSE
  */
 @Component
 public class ManagerSseManager {

--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/config/ManagerSseManager.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/config/ManagerSseManager.java
@@ -19,17 +19,27 @@
 
 package org.apache.hertzbeat.manager.config;
 
+import org.apache.hertzbeat.common.constants.ManagerEventTypeEnum;
+import org.apache.hertzbeat.common.constants.NotifyLevelEnum;
+import org.apache.hertzbeat.common.entity.manager.ManagerMessage;
+import org.apache.hertzbeat.common.util.JsonUtil;
+import org.apache.hertzbeat.common.util.ResourceBundleUtil;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.ResourceBundle;
 import java.util.concurrent.ConcurrentHashMap;
 
+/**
+ * Manager SSE Manager
+ */
 @Component
 public class ManagerSseManager {
     private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final ResourceBundle bundle = ResourceBundleUtil.getBundle("msg");
 
     public SseEmitter createEmitter(Long clientId) {
         SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
@@ -52,6 +62,24 @@ public class ManagerSseManager {
                 removeEmitter(clientId);
             }
         });
+    }
+
+    public void broadcastImportTaskProcess(String taskName, Integer process){
+        ManagerMessage managerMessage = new ManagerMessage(NotifyLevelEnum.INFO.getValue(), ManagerEventTypeEnum.IMPORT_TASK_EVENT.getValue(),
+                String.format(bundle.getString("manager_import_task_progress"), taskName, process));
+        broadcast(ManagerEventTypeEnum.IMPORT_TASK_EVENT.getValue(), JsonUtil.toJson(managerMessage));
+    }
+
+    public void broadcastImportTaskSuccess(String taskName){
+        ManagerMessage managerMessage = new ManagerMessage(NotifyLevelEnum.SUCCESS.getValue(), ManagerEventTypeEnum.IMPORT_TASK_EVENT.getValue(),
+                String.format(bundle.getString("manager_import_task_success"), taskName));
+        broadcast(ManagerEventTypeEnum.IMPORT_TASK_EVENT.getValue(), JsonUtil.toJson(managerMessage));
+    }
+
+    public void broadcastImportTaskFail(String taskName, String errMsg){
+        ManagerMessage managerMessage = new ManagerMessage(NotifyLevelEnum.ERROR.getValue(), ManagerEventTypeEnum.IMPORT_TASK_EVENT.getValue(),
+                String.format(bundle.getString("manager_import_task_fail"), taskName, errMsg));
+        broadcast(ManagerEventTypeEnum.IMPORT_TASK_EVENT.getValue(), JsonUtil.toJson(managerMessage));
     }
 
     private void removeEmitter(Long clientId) {

--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/controller/ManagerSseController.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/controller/ManagerSseController.java
@@ -29,6 +29,9 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
 
 
+/**
+ * SSE controller for manager
+ */
 @RestController
 @RequestMapping(path = "/api/manager/sse", produces = {TEXT_EVENT_STREAM_VALUE})
 public class ManagerSseController {

--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/controller/ManagerSseController.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/controller/ManagerSseController.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hertzbeat.manager.controller;
+
+import org.apache.hertzbeat.common.util.SnowFlakeIdGenerator;
+import org.apache.hertzbeat.manager.config.ManagerSseManager;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.springframework.http.MediaType.TEXT_EVENT_STREAM_VALUE;
+
+
+@RestController
+@RequestMapping(path = "/api/manager/sse", produces = {TEXT_EVENT_STREAM_VALUE})
+public class ManagerSseController {
+
+    private final ManagerSseManager emitterManager;
+
+    public ManagerSseController(ManagerSseManager emitterManager) {
+        this.emitterManager = emitterManager;
+    }
+
+    @GetMapping(path = "/subscribe")
+    public SseEmitter subscribe() {
+        Long clientId = SnowFlakeIdGenerator.generateId();
+        return emitterManager.createEmitter(clientId);
+    }
+}

--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/ImExportService.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/ImExportService.java
@@ -29,9 +29,10 @@ public interface ImExportService {
 
     /**
      * Import Configuration
+     * @param taskName task name
      * @param is input stream
      */
-    void importConfig(InputStream is);
+    void importConfig(String taskName, InputStream is) throws Exception;
 
     /**
      * Export Configuration

--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/AbstractImExportServiceImpl.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/AbstractImExportServiceImpl.java
@@ -72,7 +72,7 @@ public abstract class AbstractImExportServiceImpl implements ImExportService {
                 MonitorDto monitorDto = formList.get(i);
                 monitorService.validate(monitorDto, false);
                 monitorService.addMonitor(monitorDto.getMonitor(), monitorDto.getParams(), monitorDto.getCollector(), monitorDto.getGrafanaDashboard());
-                if (totalElements >= ImExportTaskConstant.ImportProcessThreshold && (i + 1) % progressInterval == 0) {
+                if (totalElements >= ImExportTaskConstant.IMPORT_TASK_PROCESS_THRESHOLD && ((i + 1) % progressInterval == 0) && (i + 1 < totalElements)) {
                     managerSseManager.broadcastImportTaskProcess(taskName, (int) ((i + 1) * 100.0 / totalElements));
                 }
             }

--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/MonitorServiceImpl.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/MonitorServiceImpl.java
@@ -166,7 +166,6 @@ public class MonitorServiceImpl implements MonitorService {
         try {
             if (!imExportServiceMap.containsKey(type)) {
                 String errMsg = ExportFileConstants.FILE + " " + fileName + " is not supported.";
-                managerSseManager.broadcastImportTaskFail(fileName, errMsg);
                 throw new RuntimeException(errMsg);
             }
             var imExportService = imExportServiceMap.get(type);

--- a/hertzbeat-manager/src/main/resources/sureness.yml
+++ b/hertzbeat-manager/src/main/resources/sureness.yml
@@ -78,6 +78,7 @@ excludedResource:
   - /api/apps/hierarchy===get
   - /api/push/**===*
   - /api/status/page/public/**===*
+  - /api/manager/sse/**===*
   # web ui resource
   - /===get
   - /assets/**===get

--- a/script/docker-compose/hertzbeat-mysql-iotdb/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-mysql-iotdb/conf/sureness.yml
@@ -78,6 +78,7 @@ excludedResource:
   - /api/apps/hierarchy===get
   - /api/push/**===*
   - /api/status/page/public/**===*
+  - /api/manager/sse/**===*
   # web ui resource
   - /===get
   - /assets/**===get

--- a/script/docker-compose/hertzbeat-mysql-tdengine/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-mysql-tdengine/conf/sureness.yml
@@ -78,6 +78,7 @@ excludedResource:
   - /api/apps/hierarchy===get
   - /api/push/**===*
   - /api/status/page/public/**===*
+  - /api/manager/sse/**===*
   # web ui resource
   - /===get
   - /assets/**===get

--- a/script/docker-compose/hertzbeat-mysql-victoria-metrics/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-mysql-victoria-metrics/conf/sureness.yml
@@ -22,6 +22,7 @@
 resourceRole:
   - /api/account/auth/refresh===post===[admin,user,guest]
   - /api/apps/**===get===[admin,user,guest]
+  - /api/manager/**===get===[admin,user,guest]
   - /api/monitor/**===get===[admin,user,guest]
   - /api/monitor/**===post===[admin,user]
   - /api/monitor/**===put===[admin,user]

--- a/script/docker-compose/hertzbeat-mysql-victoria-metrics/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-mysql-victoria-metrics/conf/sureness.yml
@@ -22,7 +22,6 @@
 resourceRole:
   - /api/account/auth/refresh===post===[admin,user,guest]
   - /api/apps/**===get===[admin,user,guest]
-  - /api/manager/**===get===[admin,user,guest]
   - /api/monitor/**===get===[admin,user,guest]
   - /api/monitor/**===post===[admin,user]
   - /api/monitor/**===put===[admin,user]
@@ -79,6 +78,7 @@ excludedResource:
   - /api/apps/hierarchy===get
   - /api/push/**===*
   - /api/status/page/public/**===*
+  - /api/manager/sse/**===*
   # web ui resource
   - /===get
   - /assets/**===get

--- a/script/docker-compose/hertzbeat-postgresql-victoria-metrics/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-postgresql-victoria-metrics/conf/sureness.yml
@@ -78,6 +78,7 @@ excludedResource:
   - /api/apps/hierarchy===get
   - /api/push/**===*
   - /api/status/page/public/**===*
+  - /api/manager/sse/**===*
   # web ui resource
   - /===get
   - /assets/**===get

--- a/script/sureness.yml
+++ b/script/sureness.yml
@@ -78,6 +78,7 @@ excludedResource:
   - /api/apps/hierarchy===get
   - /api/push/**===*
   - /api/status/page/public/**===*
+  - /api/manager/sse/**===*
   # web ui resource
   - /===get
   - /assets/**===get

--- a/web-app/src/app/layout/basic/widgets/notify.component.ts
+++ b/web-app/src/app/layout/basic/widgets/notify.component.ts
@@ -8,6 +8,7 @@ import { finalize } from 'rxjs/operators';
 
 import { Mute } from '../../../pojo/Mute';
 import { SingleAlert } from '../../../pojo/SingleAlert';
+import { ManagerMessage } from '../../../pojo/ManagerMessage';
 import { AlertSoundService } from '../../../service/alert-sound.service';
 import { AlertService } from '../../../service/alert.service';
 import { GeneralConfigService } from '../../../service/general-config.service';
@@ -321,28 +322,18 @@ export class HeaderNotifyComponent implements OnInit, OnDestroy {
 
   private initManagerSSEConnection(): void {
     const sseUrl = '/api/manager/sse/subscribe';
-
     this.eventSource = new EventSource(sseUrl);
-
     this.eventSource.addEventListener('IMPORT_TASK_EVENT', (evt: MessageEvent) => {
-      let list: any[] = [];
-      let alert: SingleAlert = JSON.parse(evt.data);
-      let item = {
-        id: alert.id,
-        avatar: '/assets/img/notification.svg',
-        title: alert.content,
-        datetime: new Date(alert.activeAt).toLocaleString(),
-        color: 'blue',
-        status: alert.status,
-        type: this.i18nSvc.fanyi('dashboard.alerts.title-no')
-      };
-      list.push(item);
-
-      this.data = this.updateNoticeData(list);
-      if (!this.mute.mute) {
-        this.alertSound.playAlertSound(this.i18nSvc.currentLang);
+      let msg = JSON.parse(evt.data);
+      if(msg.notifyLevel === 'SUCCESS'){
+        this.notifySvc.success(msg.content, '');
+      }else if(msg.notifyLevel === 'ERROR'){
+        this.notifySvc.error(msg.content, '');
+      }else if(msg.notifyLevel === 'INFO'){
+        this.notifySvc.info(msg.content, '');
+      }else{
+        this.notifySvc.blank(msg.content, '');
       }
-      this.cdr.detectChanges();
     });
     this.eventSource.onerror = error => {
       console.error('Manager SSE connection error:', error);

--- a/web-app/src/app/layout/basic/widgets/notify.component.ts
+++ b/web-app/src/app/layout/basic/widgets/notify.component.ts
@@ -326,13 +326,13 @@ export class HeaderNotifyComponent implements OnInit, OnDestroy {
     this.eventSource.addEventListener('IMPORT_TASK_EVENT', (evt: MessageEvent) => {
       let msg = JSON.parse(evt.data);
       if(msg.notifyLevel === 'SUCCESS'){
-        this.notifySvc.success(msg.content, '');
+        this.notifySvc.success(this.i18nSvc.fanyi('common.notice'), msg.content);
       }else if(msg.notifyLevel === 'ERROR'){
-        this.notifySvc.error(msg.content, '');
+        this.notifySvc.error(this.i18nSvc.fanyi('common.notice'), msg.content);
       }else if(msg.notifyLevel === 'INFO'){
-        this.notifySvc.info(msg.content, '');
+        this.notifySvc.info(this.i18nSvc.fanyi('common.notice'), msg.content);
       }else{
-        this.notifySvc.blank(msg.content, '');
+        this.notifySvc.blank(this.i18nSvc.fanyi('common.notice'), msg.content);
       }
     });
     this.eventSource.onerror = error => {

--- a/web-app/src/app/pojo/ManagerMessage.ts
+++ b/web-app/src/app/pojo/ManagerMessage.ts
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+export class ManagerMessage {
+  managerEventType!: string;
+  content!: string;
+}

--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.ts
@@ -273,15 +273,17 @@ export class MonitorListComponent implements OnInit, OnDestroy {
   }
 
   onImportMonitors(info: NzUploadChangeParam): void {
-    if (info.file.response) {
+    console.log(info.type);
+    if(info.type === 'start'){
+      this.notifySvc.info(this.i18nSvc.fanyi('common.notice'), this.i18nSvc.fanyi('common.notify.import-submit', { 'taskName': info.file.name }));
+    }
+    if (info.type === 'success' && info.file.response) {
       this.tableLoading = true;
       const message = info.file.response;
       if (message.code === 0) {
-        this.notifySvc.success(this.i18nSvc.fanyi('common.notify.import-success'), '');
         this.loadMonitorTable();
       } else {
         this.tableLoading = false;
-        this.notifySvc.error(this.i18nSvc.fanyi('common.notify.import-fail'), message.msg);
       }
     }
   }

--- a/web-app/src/assets/i18n/en-US.json
+++ b/web-app/src/assets/i18n/en-US.json
@@ -451,6 +451,7 @@
   "common.notify.export-success": "Export Success!",
   "common.notify.import-fail": "Import Failed!",
   "common.notify.import-success": "Import Success!",
+  "common.notify.import-submit": "Import Task {{taskName}} submitted!",
   "common.notify.mark-fail": "Mark Failed!",
   "common.notify.mark-success": "Mark Success!",
   "common.notify.new-fail": "Add Failed!",

--- a/web-app/src/assets/i18n/ja-JP.json
+++ b/web-app/src/assets/i18n/ja-JP.json
@@ -451,6 +451,7 @@
   "common.notify.export-success": "エクスポートに成功しました！",
   "common.notify.import-fail": "インポートに失敗しました！",
   "common.notify.import-success": "インポートに成功しました！",
+  "common.notify.import-submit": "タスク「{{taskName}}」のインポートが提出されました！",
   "common.notify.mark-fail": "マークに失敗しました！",
   "common.notify.mark-success": "マークに成功しました！",
   "common.notify.new-fail": "追加に失敗しました！",

--- a/web-app/src/assets/i18n/zh-CN.json
+++ b/web-app/src/assets/i18n/zh-CN.json
@@ -451,6 +451,7 @@
   "common.notify.export-success": "导出成功!",
   "common.notify.import-fail": "导入失败!",
   "common.notify.import-success": "导入成功!",
+  "common.notify.import-submit": "导入任务{{taskName}}已提交!",
   "common.notify.mark-fail": "标记失败!",
   "common.notify.mark-success": "标记成功!",
   "common.notify.new-fail": "新增失败!",

--- a/web-app/src/assets/i18n/zh-TW.json
+++ b/web-app/src/assets/i18n/zh-TW.json
@@ -451,6 +451,7 @@
   "common.notify.export-success": "導出成功!",
   "common.notify.import-fail": "導入失敗!",
   "common.notify.import-success": "導入成功!",
+  "common.notify.import-submit": "導入任務 {{taskName}} 已提交!",
   "common.notify.mark-fail": "標記失敗!",
   "common.notify.mark-success": "標記成功!",
   "common.notify.new-fail": "新增失敗!",


### PR DESCRIPTION
## What's changed?
about #3003 
1.Add manager see to broadcast system message. (maybe it should be merged with alert sse?)
2.Add front process notify for monitor import task,including: process,success,fail.
3.When the number of monitoring imported files sums >= 100 and complted the number of imports per 10% will broadcast 
Please check code and give me some suggest!

The task process
Start/submit:
<img width="1433" alt="start" src="https://github.com/user-attachments/assets/f1d73cb3-ed59-4a13-a30c-b7da092b5072" />

Process:
<img width="1435" alt="process" src="https://github.com/user-attachments/assets/64b478ea-41ef-4ee0-a650-941740944abb" />

Success:
<img width="1432" alt="success" src="https://github.com/user-attachments/assets/4bd6f124-4acb-412a-b627-5a92ef152755" />

Fail:
<img width="1437" alt="fail" src="https://github.com/user-attachments/assets/485de3b0-b0dc-4270-9d11-6209f744ef87" />


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
