### PR TITLE
[bugfix] retain sorting state after monitor list auto-refresh

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.ts
@@ -72,6 +72,9 @@ export class MonitorListComponent implements OnInit, OnDestroy {
   appSearchOrigin: any[] = [];
   appSearchLoading = false;
   intervalId: any;
+  // save the current sorting status
+  currentSortField: string | null = null;
+  currentSortOrder: string | null = null;
 
   switchExportTypeModalFooter: ModalButtonOptions[] = [
     { label: this.i18nSvc.fanyi('common.button.cancel'), type: 'default', onClick: () => (this.isSwitchExportTypeModalVisible = false) }
@@ -149,7 +152,7 @@ export class MonitorListComponent implements OnInit, OnDestroy {
   }
 
   sync() {
-    this.loadMonitorTable();
+    this.loadMonitorTable(this.currentSortField, this.currentSortOrder);
   }
 
   getAppIconName(app: string | undefined): string {
@@ -499,9 +502,9 @@ export class MonitorListComponent implements OnInit, OnDestroy {
     this.pageIndex = pageIndex;
     this.pageSize = pageSize;
     const currentSort = sort.find(item => item.value !== null);
-    const sortField = (currentSort && currentSort.key) || null;
-    const sortOrder = (currentSort && currentSort.value) || null;
-    this.changeMonitorTable(sortField, sortOrder);
+    this.currentSortField = (currentSort && currentSort.key) || null;
+    this.currentSortOrder = (currentSort && currentSort.value) || null;
+    this.changeMonitorTable(this.currentSortField, this.currentSortOrder);
   }
 
   // begin: app type search filter


### PR DESCRIPTION
## What's changed?

Fixes https://github.com/apache/hertzbeat/issues/3154
Added state variables to track current sorting parameters

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
