### PR TITLE
[bugfix] fix bind Labels are not updated when the Alarm Severity switches

### DIFF
--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.ts
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.ts
@@ -848,7 +848,7 @@ export class AlertSettingComponent implements OnInit {
     if (!this.define.labels) {
       this.define.labels = {};
     }
-    this.define.labels['severity'] = this.severity;
+    this.define.labels = { ...this.define.labels, severity: this.severity };
   }
 
   onManageModalCancel() {


### PR DESCRIPTION


## What's changed?

<!-- Describe Your PR Here -->
#3169 fix bind Labels are not updated when the Alarm Severity switches

![fixed_bug-ezgif com-video-to-gif-converter (2)](https://github.com/user-attachments/assets/60e5c2f1-c46d-4fd9-aa9e-78b202f41934)



## Checklist

- [X]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
