### PR TITLE
[improve] optimize kafka collection logic and expand test coverage

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-kafka/src/main/java/org/apache/hertzbeat/collector/collect/kafka/KafkaCollectImpl.java
+++ b/hertzbeat-collector/hertzbeat-collector-kafka/src/main/java/org/apache/hertzbeat/collector/collect/kafka/KafkaCollectImpl.java
@@ -242,6 +242,7 @@ public class KafkaCollectImpl extends AbstractCollect {
             boolean isKafkaCommand = SupportedCommand.isKafkaCommand(command);
             if (!isKafkaCommand) {
                 log.error("Unsupported command: {}", command);
+                builder.setCode(CollectRep.Code.FAIL);
                 return;
             }
 


### PR DESCRIPTION
Previously, the test relied on `assertThrows` to verify behavior, but the actual system uses status codes. To align with the real system's behavior, we should verify the same way the system does. This PR fixes this issue.

Additionally, other tests (like `RocketmqSingleCollectTest`) follow the same pattern. If agreed, I’d be happy to help fix those as well.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
