### PR TITLE
[bugfix] Resolve incorrect display of detailed information in Prometheus task history monitoring charts under VictoriaMetrics.

### DIFF
--- a/hertzbeat-warehouse/src/main/java/org/apache/hertzbeat/warehouse/store/history/vm/VictoriaMetricsClusterDataStorage.java
+++ b/hertzbeat-warehouse/src/main/java/org/apache/hertzbeat/warehouse/store/history/vm/VictoriaMetricsClusterDataStorage.java
@@ -254,7 +254,7 @@ public class VictoriaMetricsClusterDataStorage extends AbstractHistoryDataStorag
         }
         String timeSeriesSelector =
                 LABEL_KEY_NAME + "=\"" + labelName + "\"" + "," + LABEL_KEY_INSTANCE + "=\"" + monitorId + "\"" + ","
-                        + MONITOR_METRIC_KEY + "=\"" + metric + "\"";
+                        + (CommonConstants.PROMETHEUS.equals(app) ? "" : "," + MONITOR_METRIC_KEY + "=\"" + metric + "\"");
         Map<String, List<Value>> instanceValuesMap = new HashMap<>(8);
         try {
             HttpHeaders headers = new HttpHeaders();
@@ -349,7 +349,7 @@ public class VictoriaMetricsClusterDataStorage extends AbstractHistoryDataStorag
         }
         String timeSeriesSelector =
                 LABEL_KEY_NAME + "=\"" + labelName + "\"" + "," + LABEL_KEY_INSTANCE + "=\"" + monitorId + "\"" + ","
-                        + MONITOR_METRIC_KEY + "=\"" + metric + "\"";
+                        + (CommonConstants.PROMETHEUS.equals(app) ? "" : "," + MONITOR_METRIC_KEY + "=\"" + metric + "\"");
         Map<String, List<Value>> instanceValuesMap = new HashMap<>(8);
         try {
             HttpHeaders headers = new HttpHeaders();

--- a/hertzbeat-warehouse/src/main/java/org/apache/hertzbeat/warehouse/store/history/vm/VictoriaMetricsDataStorage.java
+++ b/hertzbeat-warehouse/src/main/java/org/apache/hertzbeat/warehouse/store/history/vm/VictoriaMetricsDataStorage.java
@@ -253,7 +253,7 @@ public class VictoriaMetricsDataStorage extends AbstractHistoryDataStorage {
         }
         String timeSeriesSelector = LABEL_KEY_NAME + "=\"" + labelName + "\""
                 + "," + LABEL_KEY_INSTANCE + "=\"" + monitorId + "\""
-                + "," + MONITOR_METRIC_KEY + "=\"" + metric + "\"";
+                + (CommonConstants.PROMETHEUS.equals(app) ? "" : "," + MONITOR_METRIC_KEY + "=\"" + metric + "\"");
         Map<String, List<Value>> instanceValuesMap = new HashMap<>(8);
         try {
             HttpHeaders headers = new HttpHeaders();
@@ -347,7 +347,7 @@ public class VictoriaMetricsDataStorage extends AbstractHistoryDataStorage {
         }
         String timeSeriesSelector = LABEL_KEY_NAME + "=\"" + labelName + "\""
                 + "," + LABEL_KEY_INSTANCE + "=\"" + monitorId + "\""
-                + "," + MONITOR_METRIC_KEY + "=\"" + metric + "\"";
+                + (CommonConstants.PROMETHEUS.equals(app) ? "" : "," + MONITOR_METRIC_KEY + "=\"" + metric + "\"");
         Map<String, List<Value>> instanceValuesMap = new HashMap<>(8);
         try {
             HttpHeaders headers = new HttpHeaders();


### PR DESCRIPTION
- reslove #3246
## What's changed?
Resolve incorrect display of detailed information in Prometheus task history monitoring charts under VictoriaMetrics.

![image](https://github.com/user-attachments/assets/3bd3bae0-3a01-4c7c-93fc-d19c4e769d9f)


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
