### PR TITLE
[PR] [bugfix] Set the prometheus monitoring time and correct historical da…

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/prometheus/PrometheusAutoCollectImpl.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/prometheus/PrometheusAutoCollectImpl.java
@@ -156,6 +156,8 @@ public class PrometheusAutoCollectImpl {
     }
     
     private List<CollectRep.MetricsData> parseResponseByPrometheusExporter(InputStream inputStream, CollectRep.MetricsData.Builder builder) throws IOException {
+        long endTime = System.currentTimeMillis();
+        builder.setTime(endTime);
         Map<String, MetricFamily> metricFamilyMap = OnlineParser.parseMetrics(inputStream);
         List<CollectRep.MetricsData> metricsDataList = new LinkedList<>();
         if (metricFamilyMap == null) {

--- a/hertzbeat-warehouse/src/main/java/org/apache/hertzbeat/warehouse/store/history/jpa/JpaDatabaseDataStorage.java
+++ b/hertzbeat-warehouse/src/main/java/org/apache/hertzbeat/warehouse/store/history/jpa/JpaDatabaseDataStorage.java
@@ -201,6 +201,9 @@ public class JpaDatabaseDataStorage extends AbstractHistoryDataStorage {
             List<Predicate> andList = new ArrayList<>();
             Predicate predicateMonitorId = criteriaBuilder.equal(root.get("monitorId"), monitorId);
             Predicate predicateMonitorType = criteriaBuilder.equal(root.get("app"), app);
+            if (CommonConstants.PROMETHEUS.equals(app)) {
+                predicateMonitorType = criteriaBuilder.like(root.get("app"), CommonConstants.PROMETHEUS_APP_PREFIX + "%");
+            }
             Predicate predicateMonitorMetrics = criteriaBuilder.equal(root.get("metrics"), metrics);
             Predicate predicateMonitorMetric = criteriaBuilder.equal(root.get("metric"), metric);
             andList.add(predicateMonitorId);


### PR DESCRIPTION


## What's changed?

<!-- Describe Your PR Here -->
**PrometheusAuto 监控未设置指标监控时间**

非 PrometheusAuto 监控在验证指标值时`MetricsCollect # validateResponse`设置了指标监控时间，而 PrometheusAuto 监控并未设置该时间，由于 Prometheus 返回的指标类型不一致，故在`PrometheusAutoCollectImpl # parseResponseByPrometheusExporter`方法正确获取到响应指标时设置该指标监控时间。

-----

**PrometheusAuto 监控在 jpa 下的历史数据查询为空的问题解决**

启用 jpa 存储历史数据，在 PrometheusAuto 监控下，`hzb_history`表的 app 字段存放的是 `CommonConstants.PROMETHEUS_APP_PREFIX + monitor.getName()`值，而查询时的过滤条件为：
```sql
WHERE app = "prometheus"  -- Modify: WHERE app LIKE '_prometheus_%'  
```
在不改动写入数据的情况下，修改查询为符合 PROMETHEUS_APP_PREFIX 前缀的模糊查询，可正常查询到数据，并在历史图表中恢复展现。

![](https://raw.githubusercontent.com/Cyanty/images/main/collect/Snipaste_2025-04-18_16-08-06.png)

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
