### PR TITLE
[bugfix] correct instance filtering regex in RealTimeAlertCalculator

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/calculate/RealTimeAlertCalculator.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/calculate/RealTimeAlertCalculator.java
@@ -73,7 +73,7 @@ public class RealTimeAlertCalculator {
     private static final Pattern APP_PATTERN = Pattern.compile("equals\\(__app__,\"([^\"]+)\"\\)");
     private static final Pattern AVAILABLE_PATTERN = Pattern.compile("equals\\(__available__,\"([^\"]+)\"\\)");
     private static final Pattern LABEL_PATTERN = Pattern.compile("contains\\(__labels__,\\s*\"([^\"]+)\"\\)");
-    private static final Pattern INSTANCE_PATTERN = Pattern.compile("equals\\(__instance__,\"(\\d+)\"\\)");
+    private static final Pattern INSTANCE_PATTERN = Pattern.compile("equals\\(__instance__,\\s\"(\\d+)\"\\)");
     private static final Pattern METRICS_PATTERN = Pattern.compile("equals\\(__metrics__,\"([^\"]+)\"\\)");
 
     /**


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

#3220 

This PR fixes a bug where `RealTimeAlertCalculator` failed to properly filter unbound instances during threshold rule evaluation. The issue was caused by the backend regex not accounting for optional whitespace in alert expressions generated by the frontend.

Log-based verification was used to confirm correctness of the fix:

- Logs before and after filtering were printed.
- Only the bound instance was allowed to pass the filter, while unbound ones were filtered out as expected.

Sample log output:

```txt
filter before expr: equals(__app__,"redis") && equals(__available__,"down") && equals(__instance__, "501045327364864"), instance :501786917278464  
filter before expr: equals(__app__,"redis") && equals(__available__,"down") && equals(__instance__, "501045327364864"), instance :501045327364864  
filter after expr: equals(__app__,"redis") && equals(__available__,"down") && equals(__instance__, "501045327364864"), instance :501045327364864
```
Note:

The RealTimeAlertCalculator class is a passive-invocation component with only a public constructor. It registers tasks and starts threads during construction, while core logic resides in private methods triggered asynchronously. This makes unit testing difficult without reflection or design adjustments. 

## Checklist

- [X]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
