### PR TITLE
[refactor] Remove the possible CVE-2025-30066 security vulnerability action and ignore the 500 code for link check

### DIFF
--- a/.github/workflows/doc-build-test.yml
+++ b/.github/workflows/doc-build-test.yml
@@ -46,20 +46,10 @@ jobs:
       - name: Check filenames
         run: python ./script/ci/docs/check_file_name.py ./script/ci/docs/check_file_name.json
 
-      - name: Get all changed markdown files
-        id: changed-markdown-files
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c
-        with:
-          files: |
-            ./home/**/*.md
-
       - name: Dead Link Check
-        if: steps.changed-markdown-files.outputs.any_changed == 'true'
-        env:
-          ALL_CHANGED_FILES: ${{ steps.changed-markdown-files.outputs.all_changed_files }}
         run: |
           sudo npm install -g markdown-link-check@3.8.7
-          for file in ${ALL_CHANGED_FILES}; do
+          for file in $(find ./home -name "*.md"); do
             if ! grep -Fxq "$file" ./script/ci/exclude_files.txt; then
               markdown-link-check -c ./script/ci/link_check.json -q "$file"
             fi

--- a/script/ci/link_check.json
+++ b/script/ci/link_check.json
@@ -5,6 +5,9 @@
     },
     {
       "pattern": "!\\[.*\\]\\((?!http).*\\)"
+    },
+    {
+      "pattern": "^https:\\/\\/github\\.com\\/apache\\/hertzbeat\\/pull\\/.*"
     }
   ],
   "timeout": "10s",


### PR DESCRIPTION
…action and ignore the 500 code for link check

## What's changed?

Remove the possible CVE-2025-30066 security vulnerability action and ignore the 500 code for link check


*tj-actions/changed-files has been found to have [security issues](https://www.wiz.io/blog/github-action-tj-actions-changed-files-supply-chain-attack-cve-2025-30066). Although the latest hash-pinned version is used. ( As of March 15, 2025, all versions of tj-actions/changed-files were found to be affected, as the attacker managed to modify existing version tags to make them all point to their malicious code. Customers who were using a hash-pinned version of tj-actions/changed-files would not be impacted, unless they had updated to an impacted hash during the exploitation timeframe. ), At present, it may still not permitted for use in GitHub Actions.*


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
