### PR TITLE
[feature] Support Uptime Kuma alert source

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/dto/UptimeKumaExternAlert.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/dto/UptimeKumaExternAlert.java
@@ -1,0 +1,119 @@
+package org.apache.hertzbeat.alert.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * uptime-kuma alert content entity
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class UptimeKumaExternAlert {
+
+    private Heartbeat heartbeat;
+
+    private Monitor monitor;
+
+    private String msg;
+
+    /**
+     * Monitor information
+     */
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Heartbeat {
+        @JsonProperty("monitorID")
+        private int monitorId;
+        private int status;
+        private String time;
+        private String msg;
+        private boolean important;
+        private int duration;
+        private String timezone;
+        private String timezoneOffset;
+        private String localDateTime;
+    }
+
+    /**
+     * Monitor information
+     */
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Monitor {
+        private int id;
+        private String name;
+        private String description;
+        private String pathName;
+        private String parent;
+        @JsonProperty("childrenIDs")
+        private List<String> childrenIds;
+        private String url;
+        private String method;
+        private String hostname;
+        private String port;
+        @JsonProperty("maxretries")
+        private int maxRetries;
+        private int weight;
+        private boolean active;
+        private boolean forceInactive;
+        private String type;
+        private int timeout;
+        private int interval;
+        private int retryInterval;
+        private int resendInterval;
+        private String keyword;
+        private boolean invertKeyword;
+        private boolean expiryNotification;
+        private boolean ignoreTls;
+        private boolean upsideDown;
+        private int packetSize;
+        @JsonProperty("maxredirects")
+        private int maxRedirects;
+        @JsonProperty("accepted_statuscodes")
+        private List<String> acceptedStatusCodes;
+        private String dnsResolveType;
+        private String dnsResolveServer;
+        private String dnsLastResult;
+        private String dockerContainer;
+        private String dockerHost;
+        private String proxyId;
+        private Map<String, Object> notificationIDList;
+        private List<String> tags;
+        private boolean maintenance;
+        private String mqttTopic;
+        private String mqttSuccessMessage;
+        private String databaseQuery;
+        private String authMethod;
+        private String grpcUrl;
+        private String grpcProtobuf;
+        private String grpcMethod;
+        private String grpcServiceName;
+        private boolean grpcEnableTls;
+        private String radiusCalledStationId;
+        private String radiusCallingStationId;
+        private String game;
+        private boolean gamedigGivenPortOnly;
+        private String httpBodyEncoding;
+        private String jsonPath;
+        private String expectedValue;
+        private String kafkaProducerTopic;
+        private List<String> kafkaProducerBrokers;
+        private boolean kafkaProducerSsl;
+        private boolean kafkaProducerAllowAutoTopicCreation;
+        private String kafkaProducerMessage;
+        private String screenshot;
+        private boolean includeSensitiveData;
+    }
+}

--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/impl/UptimeKumaExternAlertServiceImpl.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/impl/UptimeKumaExternAlertServiceImpl.java
@@ -1,0 +1,101 @@
+package org.apache.hertzbeat.alert.service.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hertzbeat.alert.dto.UptimeKumaExternAlert;
+import org.apache.hertzbeat.alert.reduce.AlarmCommonReduce;
+import org.apache.hertzbeat.alert.service.ExternAlertService;
+import org.apache.hertzbeat.common.constants.CommonConstants;
+import org.apache.hertzbeat.common.entity.alerter.SingleAlert;
+import org.apache.hertzbeat.common.util.JsonUtil;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * uptime-kuma external alarm service impl
+ */
+@Slf4j
+@Service
+public class UptimeKumaExternAlertServiceImpl implements ExternAlertService {
+
+    @Autowired
+    private AlarmCommonReduce alarmCommonReduce;
+
+    @Override
+    public void addExternAlert(String content) {
+        UptimeKumaExternAlert alert = JsonUtil.fromJson(content, UptimeKumaExternAlert.class);
+        if (alert == null) {
+            log.warn("parse extern alert content failed! content: {}", content);
+            return;
+        }
+        SingleAlert singleAlert = new UptimeKumaAlertConverter().convert(alert);
+        alarmCommonReduce.reduceAndSendAlarm(singleAlert);
+    }
+
+    /**
+     * Converter: UptimeKuma alert to SingleAlert
+     */
+    public static class UptimeKumaAlertConverter {
+
+        /**
+         * Convert UptimeKuma alert to SingleAlert
+         */
+        public SingleAlert convert(UptimeKumaExternAlert alert) {
+            // 构建基本信息
+            SingleAlert.SingleAlertBuilder builder = SingleAlert.builder()
+                    .status(convertStatus(alert.getHeartbeat().getStatus()))
+                    .startAt(parseTime(alert.getHeartbeat().getTime()))
+                    .activeAt(parseTime(alert.getHeartbeat().getTime()))
+                    .triggerTimes(1);
+
+            // 构建标签
+            Map<String, String> labels = new HashMap<>();
+            labels.put("__source__", "uptime_kuma");
+            labels.put("monitor_id", String.valueOf(alert.getMonitor().getId()));
+            labels.put("monitor_name", alert.getMonitor().getName());
+
+            // 构建注解
+            Map<String, String> annotations = new HashMap<>();
+            annotations.put("description", alert.getMonitor().getDescription());
+            annotations.put("message", alert.getHeartbeat().getMsg());
+            annotations.put("important", String.valueOf(alert.getHeartbeat().isImportant()));
+
+            return builder
+                    .labels(labels)
+                    .annotations(annotations)
+                    .content(buildContent(alert))
+                    .build();
+        }
+
+        private String buildContent(UptimeKumaExternAlert alert) {
+            return String.format("Monitor [%s] %s: %s",
+                    alert.getMonitor().getName(),
+                    alert.getMonitor().getDescription(),
+                    alert.getHeartbeat().getMsg());
+        }
+
+        private String convertStatus(int status) {
+            // uptime-kuma status: 1-up, 0-down, 2-pending
+            return status == 1 ? CommonConstants.ALERT_STATUS_RESOLVED : CommonConstants.ALERT_STATUS_FIRING;
+        }
+
+        private Long parseTime(String timeStr) {
+            try {
+                SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+                return sdf.parse(timeStr).getTime();
+            } catch (ParseException e) {
+                log.error("Failed to parse time: {}", timeStr);
+                throw new IllegalArgumentException("Failed to parse time: " + timeStr, e);
+            }
+        }
+    }
+
+    @Override
+    public String supportSource() {
+        return "uptime-kuma";
+    }
+}

--- a/web-app/src/app/routes/alert/alert-integration/alert-integration.component.ts
+++ b/web-app/src/app/routes/alert/alert-integration/alert-integration.component.ts
@@ -72,6 +72,11 @@ export class AlertIntegrationComponent implements OnInit {
       id: 'tencent',
       name: this.i18nSvc.fanyi('alert.integration.source.tencent'),
       icon: 'assets/img/integration/tencent.svg'
+    },
+    {
+      id: 'uptime-kuma',
+      name: this.i18nSvc.fanyi('alert.integration.source.uptime-kuma'),
+      icon: 'assets/img/integration/uptime-kuma.svg'
     }
   ];
 

--- a/web-app/src/assets/doc/alert-integration/uptime-kuma.zh-CN.md
+++ b/web-app/src/assets/doc/alert-integration/uptime-kuma.zh-CN.md
@@ -1,0 +1,26 @@
+>将 Uptime-Kuma 的告警通过 Webhook 方式发送到 HertzBeat 告警平台。
+
+### 配置 Uptime Kuma 告警回调
+
+#### 进入通知配置
+1. 登录 Uptime Kuma web 管理界面
+2. 进入 **设置** > **通知** > **设置通知**
+3. 选择 **Webhook** 通知类型
+4. 在 **Post URL** 中，填写 HertzBeat 提供的 Webhook 接口地址 URL：
+   ```
+   http://{your_system_host}/api/report/uptime-kuma
+   ```
+5. 在 **请求体** 选择 **预设-application/json**,其他请按需配置
+6. 保存设置通知
+
+
+### 常见问题
+
+#### 未收到告警
+- 确保 Webhook URL 可以被 uptime kuma 服务访问
+- 检查服务器日志是否有请求记录
+
+#### 告警未触发
+- 确保告警策略的条件正确，并已绑定通知
+
+更多信息请参考 [Uptime Kuma Wiki](https://github.com/louislam/uptime-kuma/wiki)

--- a/web-app/src/assets/doc/alert-integration/uptime-kuma.zh-TW.md
+++ b/web-app/src/assets/doc/alert-integration/uptime-kuma.zh-TW.md
@@ -1,0 +1,26 @@
+>將 Uptime-Kuma 的告警通過 Webhook 方式發送到 HertzBeat 告警平台。
+
+### 配置 Uptime Kuma 告警回調
+
+#### 進入通知配置
+1. 登錄 Uptime Kuma web 管理界面
+2. 進入 **設置** > **通知** > **設置通知**
+3. 選擇 **Webhook** 通知類型
+4. 在 **Post URL** 中，填寫 HertzBeat 提供的 Webhook 接口地址 URL：
+   ```
+   http://{your_system_host}/api/report/uptime-kuma
+   ```
+5. 在 **請求體** 選擇 **預設-application/json**，其他請按需配置
+6. 保存設置通知
+
+
+### 常見問題
+
+#### 未收到告警
+- 確保 Webhook URL 可以被 uptime kuma 服務訪問
+- 檢查服務器日誌是否有請求記錄
+
+#### 告警未觸發
+- 確保告警策略的條件正確，並已綁定通知
+
+更多信息請參考 

--- a/web-app/src/assets/i18n/en-US.json
+++ b/web-app/src/assets/i18n/en-US.json
@@ -98,6 +98,7 @@
   "alert.integration.source.tencent": "Tencent Cloud",
   "alert.integration.source.webhook": "Default Webhook",
   "alert.integration.source.skywalking": "SkyWalking",
+  "alert.integration.source.uptime-kuma": "Uptime Kuma",
   "alert.integration.token.desc": "Token you generated that can be used to access the HertzBeat API.",
   "alert.integration.token.new": "Click to Generate Token",
   "alert.integration.token.notice": "Token only be displayed once. Please keep your token secure. Do not share it with others.",

--- a/web-app/src/assets/i18n/ja-JP.json
+++ b/web-app/src/assets/i18n/ja-JP.json
@@ -98,6 +98,7 @@
   "alert.integration.source.tencent": "Tencent Cloud",
   "alert.integration.source.webhook": "デフォルトWebhook",
   "alert.integration.source.skywalking": "SkyWalking",
+  "alert.integration.source.uptime-kuma": "Uptime Kuma",
   "alert.integration.token.desc": "HertzBeat APIにアクセスするために生成したトークン。",
   "alert.integration.token.new": "トークンを生成するにはクリック",
   "alert.integration.token.notice": "トークンは一度だけ表示されます。トークンを安全に保管し、他人と共有しないでください。",

--- a/web-app/src/assets/i18n/pt-BR.json
+++ b/web-app/src/assets/i18n/pt-BR.json
@@ -1123,6 +1123,7 @@
   "alert.export.switch-type": "Selecione o formato do arquivo de exportação!",
   "alert.export.use-type": "Exportar regras no formato de arquivo {{type}}",
   "alert.integration.source.skywalking": "SkyWalking",
+  "alert.integration.source.uptime-kuma": "Uptime Kuma",
   "dashboard.alerts.title": "Lista de Alarmes Recentes",
   "dashboard.alerts.title-no": "Alarmes Pendentes Recentes",
   "dashboard.alerts.no": "Nenhum Alarme Pendente",

--- a/web-app/src/assets/i18n/zh-CN.json
+++ b/web-app/src/assets/i18n/zh-CN.json
@@ -98,6 +98,7 @@
   "alert.integration.source.tencent": "腾讯云监控",
   "alert.integration.source.webhook": "默认Webhook",
   "alert.integration.source.skywalking": "SkyWalking",
+  "alert.integration.source.uptime-kuma": "Uptime Kuma",
   "alert.integration.token.desc": "生成的 Token 可用于访问 HertzBeat API",
   "alert.integration.token.new": "点击生成 Token",
   "alert.integration.token.notice": "此内容只会展示一次，请妥善保管您的 Token，不要泄露给他人",

--- a/web-app/src/assets/i18n/zh-TW.json
+++ b/web-app/src/assets/i18n/zh-TW.json
@@ -98,6 +98,7 @@
   "alert.integration.source.tencent": "腾讯云监控",
   "alert.integration.source.webhook": "默认Webhook",
   "alert.integration.source.skywalking": "SkyWalking",
+  "alert.integration.source.uptime-kuma": "Uptime Kuma",
   "alert.integration.token.desc": "生成的 Token 可用于访问 HertzBeat API",
   "alert.integration.token.new": "点击生成 Token",
   "alert.integration.token.notice": "此内容只会展示一次，请妥善保管您的 Token，不要泄露给他人",

--- a/web-app/src/assets/img/integration/uptime-kuma.svg
+++ b/web-app/src/assets/img/integration/uptime-kuma.svg
@@ -1,0 +1,9 @@
+<svg width="640" height="640" viewBox="0 0 640 640" xml:space="preserve" xmlns="http://www.w3.org/2000/svg">
+<g transform="matrix(1 0 0 1 320 320)">
+<linearGradient id="S3" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1 0 0 1 -319.99875 -320.0001577393)"  x1="259.78" y1="261.15" x2="463.85" y2="456.49">
+<stop stop-color="#5CDD8B"/>
+<stop offset="1" stop-color="#86E6A9"/>
+</linearGradient>
+<path style="stroke: rgb(242,242,242); stroke-opacity: 0.51; stroke-width: 200; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: url(#S3); fill-rule: nonzero; opacity: 1;"  transform=" translate(0, 0)" d="M 170.40125 -84.36016 C 224.09125 38.37984 224.09125 115.33984 170.40125 146.49984 C 89.85125000000001 193.23984000000002 -120.03875 207.48984000000002 -180.45875 135.63984 C -220.73875 87.73983999999999 -220.73875 14.399839999999998 -180.45875 -84.36016000000001 C -139.49875 -151.82016 -81.28875000000001 -185.55016 -5.828750000000014 -185.55016 C 69.64124999999999 -185.55016 128.38125 -151.82016000000002 170.40124999999998 -84.36016000000001 z" stroke-linecap="round" />
+</g>
+</svg>


### PR DESCRIPTION
## What's changed?
#3110 Support Uptime Kuma  alert source: Send alert data to hertzbeat via Uptime Kuma alert webhook

1.Uptime Kuma Alert source
2.Add user guide

User guide
<img width="2548" alt="image" src="https://github.com/user-attachments/assets/15e219da-0b57-4e50-a6a7-80f1d8627bd1" />

Alert notify
<img width="2544" alt="image" src="https://github.com/user-attachments/assets/a50f4561-3702-464d-b282-d86405182a99" />


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
