### PR TITLE
[improve] Added automated browser end-to-end testing module

### DIFF
--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/pom.xml
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.hertzbeat</groupId>
+        <artifactId>hertzbeat-e2e</artifactId>
+        <version>2.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hertzbeat-automated-testing-e2e</artifactId>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <selenium.version>4.13.0</selenium.version>
+        <dflib.version>1.2.0</dflib.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>selenium</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>${selenium.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.dflib</groupId>
+            <artifactId>dflib</artifactId>
+            <version>${dflib.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/cases/BaseH2ToPostgresqlTest.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/cases/BaseH2ToPostgresqlTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.cases;
+
+import org.apache.hertzbeat.automated.testing.common.Constants;
+import org.apache.hertzbeat.automated.testing.common.HertzBeat;
+import org.apache.hertzbeat.automated.testing.core.MonitorsEditConfig;
+import org.apache.hertzbeat.automated.testing.pages.monitoring.MonitorsNavPage;
+import org.apache.hertzbeat.automated.testing.pages.monitoring.monitors.MonitorsDetailPage;
+import org.apache.hertzbeat.automated.testing.pages.monitoring.monitors.MonitorsEditPage;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+/**
+ * hertzbeat h2 mode monitors postgresql
+ */
+@HertzBeat(composeFiles = {
+        "docker/base/hertzbeat-h2-compose.yaml",
+        "docker/monitors/postgresql-compose.yaml"
+})
+public class BaseH2ToPostgresqlTest {
+
+    private NavBarPage navBarPage;
+
+    /**
+     * create new postgresql monitor task and verify the end-to-end real-time monitoring metrics
+     */
+    @Test
+    void testRealTimeMetricsDetails() {
+        MonitorsEditConfig monitorsEditConfig = MonitorsEditConfig.yamlLoadAs(Constants.POSTGRESQL);
+
+        List<Executable> executables = navBarPage
+                .goToTab(MonitorsNavPage.class)
+                .clickNewMonitorBtn(Constants.POSTGRESQL)
+                .goToInnerTab(MonitorsEditPage.class)
+                .edit(monitorsEditConfig)
+                .clickOkBtn()
+                .goToTab(MonitorsNavPage.class)
+                .forcedSleepWait(5) // wait for the task to be generated
+                .clickSyncBtn()
+                .clickSearchMonitorInput(monitorsEditConfig.getTaskName())
+                .clickSearchBtn()
+                .forcedSleepWait(10) // wait for the monitoring metrics to be generated
+                .clickTaskNameBtn(monitorsEditConfig.getTaskName())
+                .goToInnerTab(MonitorsDetailPage.class)
+                .addFilterMonitorOptions("Slow Sql")
+                .testRealTimeDetail(Constants.POSTGRESQL);
+
+        Awaitility.await()
+                .untilAsserted(() -> assertAll(executables));
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/common/ByBuilder.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/common/ByBuilder.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.common;
+
+import org.openqa.selenium.By;
+
+/**
+ * by builder functional interface
+ */
+@FunctionalInterface
+public interface ByBuilder {
+    By buildBy(String type);
+}
+

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/common/Constants.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/common/Constants.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.common;
+
+/**
+ * test monitors constant class
+ */
+public final class Constants {
+
+    // Hertzbeat default account
+    public static final String HERTZBEAT_USERNAME  = "admin";
+    public static final String HERTZBEAT_PASSWORD  = "hertzbeat";
+
+    // Hertzbeat compose config
+    public static final String COMPOSE_HERTZBEAT = "hertzbeat";
+    public static final int HERTZBEAT_PORT = 1157;
+
+    // Monitor type
+    public static final String POSTGRESQL  = "PostgreSQL";
+    public static final String MYSQL  = "Mysql";
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/common/HertzBeat.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/common/HertzBeat.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.common;
+
+import org.apache.hertzbeat.automated.testing.core.HertzBeatExtension;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.annotation.ElementType;
+
+/**
+ * test instance annotation
+ */
+@Inherited
+@Testcontainers
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@TestMethodOrder(OrderAnnotation.class)
+@ExtendWith(HertzBeatExtension.class)
+public @interface HertzBeat {
+    String[] composeFiles();
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/common/PageInfo.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/common/PageInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.common;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * system page entry parameters configuration
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface PageInfo {
+    String selector();
+    SelectorTypeEnum selectorType();
+    String[] urlPart();
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/common/SelectorTypeEnum.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/common/SelectorTypeEnum.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.common;
+
+/**
+ * selector type enum
+ */
+public enum SelectorTypeEnum {
+    CSS,
+    XPATH,
+    ID,
+    CLASS_NAME,
+    NONE
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/core/HertzBeatExtension.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/core/HertzBeatExtension.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.core;
+
+import org.apache.commons.lang3.ThreadUtils;
+import org.apache.hertzbeat.automated.testing.common.HertzBeat;
+import org.apache.hertzbeat.automated.testing.pages.login.LoginPage;
+import org.apache.hertzbeat.automated.testing.pages.more.SettingsNavPage;
+import org.apache.hertzbeat.automated.testing.pages.more.settings.SystemConfigurationPage;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import org.openqa.selenium.PageLoadStrategy;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.BrowserWebDriverContainer;
+import org.testcontainers.containers.ComposeContainer;
+import org.testcontainers.containers.VncRecordingContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.net.URL;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.hertzbeat.automated.testing.common.Constants.HERTZBEAT_PASSWORD;
+import static org.apache.hertzbeat.automated.testing.common.Constants.HERTZBEAT_USERNAME;
+import static org.apache.hertzbeat.automated.testing.common.Constants.HERTZBEAT_PORT;
+import static org.apache.hertzbeat.automated.testing.common.Constants.COMPOSE_HERTZBEAT;
+
+/**
+ * manage the lifecycle of test instances / containers
+ */
+public class HertzBeatExtension implements BeforeAllCallback, AfterAllCallback, TestInstancePostProcessor {
+    private static final Logger log = LoggerFactory.getLogger(HertzBeatExtension.class);
+
+    private String recordingPath = System.getProperty("user.dir") + File.separator + "target/videos/";
+    private BrowserWebDriverContainer<?> browser;
+    private RemoteWebDriver driver;
+    private ComposeContainer compose;
+    private NavBarPage navBarPage;
+
+    @Override
+    public void postProcessTestInstance(Object testInstance, ExtensionContext extensionContext) {
+        setRecordingPath(recordingPath);
+
+        setComposeContainer(extensionContext);
+        compose.start();
+
+        setBrowserWebDriverContainer();
+        browser.start();
+
+        Testcontainers.exposeHostPorts(compose.getServicePort(COMPOSE_HERTZBEAT, HERTZBEAT_PORT));
+        log.info("HertzBeat port started at: " + compose.getServicePort(COMPOSE_HERTZBEAT, HERTZBEAT_PORT));
+        ThreadUtils.sleepQuietly(Duration.ofSeconds(5));
+
+        ChromeOptions options = new ChromeOptions();
+        options.setExperimentalOption("excludeSwitches", Collections.singletonList("enable-automation"));
+        options.addArguments("--incognito");
+        options.setPageLoadStrategy(PageLoadStrategy.NORMAL);
+        driver = new RemoteWebDriver(browser.getSeleniumAddress(), options);
+        driver.manage().window().maximize();
+        driver.manage().timeouts().implicitlyWait(Duration.ZERO).pageLoadTimeout(Duration.ofSeconds(10));
+        /* Container network access domain name and port:
+         *   host.docker.internal / host.testcontainers.internal
+         *   HERTZBEAT_PORT / compose.getServicePort(COMPOSE_HERTZBEAT, HERTZBEAT_PORT)
+         */
+        driver.get("http://host.testcontainers.internal:" + compose.getServicePort(COMPOSE_HERTZBEAT, HERTZBEAT_PORT));
+
+        browser.beforeTest(new TestDescription(extensionContext));
+        log.info("HertzBeat page title: " + driver.getTitle());
+
+        setup();
+        Stream.of(testInstance.getClass().getDeclaredFields())
+                .filter(f -> NavBarPage.class.isAssignableFrom(f.getType()))
+                .forEach(page -> setNavBarPage(testInstance, page));
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        Awaitility.setDefaultTimeout(Duration.ofSeconds(30));
+        Awaitility.setDefaultPollInterval(Duration.ofSeconds(2));
+    }
+
+    private void setup() {
+        navBarPage = new LoginPage(driver)
+                .loginAs(HERTZBEAT_USERNAME, HERTZBEAT_PASSWORD)
+                .goToTab(SettingsNavPage.class)
+                .goToTab(SystemConfigurationPage.class)
+                .setSystemDefaultLanguage()
+                .confirmUpdate();
+    }
+
+    private void setNavBarPage(Object testInstance, Field page) {
+        try {
+            page.setAccessible(true);
+            page.set(testInstance, navBarPage);
+        } catch (IllegalAccessException e) {
+            log.error("Failed to inject page: {}", page.getName(), e);
+        }
+    }
+
+    private void setRecordingPath(String recordingPath) {
+        File recordingDir = new File(recordingPath);
+        try {
+            if (!recordingDir.exists()) {
+                boolean isCreated = recordingDir.mkdirs();
+                if (isCreated) {
+                    log.debug("Recording directory created: " + recordingDir.getAbsolutePath());
+                } else {
+                    createTempDirectory();
+                    log.info("Creation failed, use recording temporary directory: {}", recordingDir.getAbsolutePath());
+                }
+            } else {
+                log.debug("Recording directory already exists: " + recordingDir.getAbsolutePath());
+            }
+        } catch (Exception e) {
+            createTempDirectory();
+            log.error("Creation failed, use recording temporary directory: {}", recordingDir.getAbsolutePath(), e);
+        }
+    }
+
+    private void createTempDirectory() {
+        try {
+            recordingPath = Files.createTempDirectory("video-").toFile().getAbsolutePath();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void setBrowserWebDriverContainer() {
+        DockerImageName imageName = DockerImageName.parse("selenium/standalone-chrome:116.0-chromedriver-116.0-20250414")
+                .asCompatibleSubstituteFor("selenium/standalone-chrome:116.0-chromedriver-116.0");
+        int cdpPort = 4444;
+        int vncPort = 5900;
+
+        browser = new BrowserWebDriverContainer<>(imageName)
+                .withCapabilities(new ChromeOptions())
+                .withCreateContainerCmdModifier(cmd -> cmd.withUser("root"))
+                .withRecordingMode(
+                        BrowserWebDriverContainer.VncRecordingMode.RECORD_ALL,
+                        new File(recordingPath),
+                        VncRecordingContainer.VncRecordingFormat.FLV
+                )
+                .withExposedPorts(cdpPort, vncPort)
+                .withLogConsumer(outputFrame -> log.info(outputFrame.getUtf8String()))
+                .withStartupTimeout(Duration.ofMinutes(10))
+                .withAccessToHost(true);
+    }
+
+    private void setComposeContainer(ExtensionContext context) {
+        Class<?> clazz = context.getRequiredTestClass();
+        HertzBeat annotation = clazz.getAnnotation(HertzBeat.class);
+        List<File> files = Stream.of(annotation.composeFiles())
+                .map(it -> HertzBeat.class.getClassLoader().getResource(it))
+                .filter(Objects::nonNull)
+                .map(URL::getPath)
+                .map(File::new)
+                .collect(Collectors.toList());
+
+        compose = new ComposeContainer(files)
+                .withPull(true)
+                .withTailChildContainers(false)
+                .withLocalCompose(true)
+                .withStartupTimeout(Duration.ofMinutes(20))
+                .withExposedService(
+                        COMPOSE_HERTZBEAT,
+                        HERTZBEAT_PORT,
+                        Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(60)))
+                .withLogConsumer(COMPOSE_HERTZBEAT, outputFrame -> log.info(outputFrame.getUtf8String()));
+    }
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        if (browser != null) {
+            // Retain screen recordings for test.
+            browser.afterTest(new TestDescription(extensionContext), Optional.empty());
+            browser.stop();
+        }
+        if (compose != null) {
+            compose.stop();
+        }
+    }
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/core/MonitorsEditConfig.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/core/MonitorsEditConfig.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.core;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Builder;
+import org.apache.hertzbeat.automated.testing.pages.monitoring.monitors.MonitorsEditPage;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * generic configuration class for create monitor task,
+ * two ways: 1. create instance  2. load yaml file
+ */
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MonitorsEditConfig {
+    private String targetHost;
+    private String taskName;
+    private Integer port;
+    private String databaseName;
+    private String username;
+    private String password;
+    private Advanced advanced = new Advanced();
+    private Collector collector = new Collector();
+    private Integer intervals;
+    private String bindLabelsKey;
+    private String bindLabelsValue;
+    private String bindAnnotationKey;
+    private String bindAnnotationValue;
+    private String description;
+
+    /**
+     * advanced config
+     */
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class Advanced {
+        private Integer queryTimeout;
+        private String url;
+        private Boolean enableSshTunnel;
+        private String sshHost;
+        private Integer sshPort;
+        private Integer sshTimeout;
+        private String sshUsername;
+        private String sshPassword;
+        private Boolean shareSshConnection;
+        private String sshPrivateKey;
+        private String sshPrivateKeyPassPhrase;
+    }
+
+    /**
+     * collector config
+     */
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @ToString
+    public static class Collector {
+        private String collectorName;
+        private MonitorsEditPage.CollectorEnum collectorEnum;
+
+        public void setCollectorName(String collectorName) {
+            this.collectorName = collectorName;
+            this.collectorEnum = mappingCollectorEnum(collectorName);
+        }
+
+        private static MonitorsEditPage.CollectorEnum mappingCollectorEnum(String collectorName) {
+            for (MonitorsEditPage.CollectorEnum value : MonitorsEditPage.CollectorEnum.values()) {
+                if (value.getDesc().equals(collectorName)) {
+                    return value;
+                }
+            }
+            return null;
+        }
+
+        public static CollectorBuilder builder() {
+            return new CollectorBuilder();
+        }
+
+        /**
+         * collector builder
+         */
+        public static class CollectorBuilder {
+            private String collectorName;
+            private MonitorsEditPage.CollectorEnum collectorEnum;
+
+            public CollectorBuilder collectorName(String collectorName) {
+                this.collectorName = collectorName;
+                this.collectorEnum = mappingCollectorEnum(collectorName);
+                return this;
+            }
+
+            public Collector build() {
+                return new Collector(this.collectorName, this.collectorEnum);
+            }
+        }
+    }
+
+    /**
+     * load yaml file
+     */
+    public static MonitorsEditConfig yamlLoadAs(String monitorType) {
+        Yaml yaml = new Yaml();
+        try (InputStream inputStream = MonitorsEditConfig.class.getClassLoader()
+                .getResourceAsStream(String.format("edit/%s.yml", monitorType.toLowerCase()))) {
+            return yaml.loadAs(inputStream, MonitorsEditConfig.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/core/TestDescription.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/core/TestDescription.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.core;
+
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.net.URLEncoder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * test description
+ */
+@RequiredArgsConstructor
+final class TestDescription implements org.testcontainers.lifecycle.TestDescription {
+
+    private static final String UNKNOWN_NAME = "unknown";
+
+    private final ExtensionContext context;
+
+    @Override
+    public String getTestId() {
+        return context.getUniqueId();
+    }
+
+    @Override
+    public String getFilesystemFriendlyName() {
+        String contextId = context.getRequiredTestClass().getSimpleName();
+        return contextId.trim().isEmpty()
+            ? UNKNOWN_NAME
+            : URLEncoder.encode(contextId, UTF_8);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/advanced/CollectorNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/advanced/CollectorNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.advanced;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.COLLECTOR;
+
+/**
+ * Collector Nav-Page
+ */
+@PageInfo(
+        selector = COLLECTOR,
+        selectorType = CSS,
+        urlPart = "/setting/collector"
+)
+public class CollectorNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public CollectorNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/advanced/LabelsNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/advanced/LabelsNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.advanced;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.LABELS;
+
+/**
+ * Labels Nav-Page
+ */
+@PageInfo(
+        selector = LABELS,
+        selectorType = CSS,
+        urlPart = "/setting/labels"
+)
+public class LabelsNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public LabelsNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/advanced/PluginsNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/advanced/PluginsNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.advanced;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.PLUGINS;
+
+/**
+ * Plugins Nav-Page
+ */
+@PageInfo(
+        selector = PLUGINS,
+        selectorType = CSS,
+        urlPart = "/setting/plugins"
+)
+public class PluginsNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public PluginsNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/advanced/StatusNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/advanced/StatusNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.advanced;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.STATUS;
+
+/**
+ * Status Nav-Page
+ */
+@PageInfo(
+        selector = STATUS,
+        selectorType = CSS,
+        urlPart = "/setting/status"
+)
+public class StatusNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public StatusNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/AlarmsNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/AlarmsNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.alerting;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.ALARMS;
+
+/**
+ * Alarms Nav-Page
+ */
+@PageInfo(
+        selector = ALARMS,
+        selectorType = CSS,
+        urlPart = "/alert/center"
+)
+public class AlarmsNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public AlarmsNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/GroupNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/GroupNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.alerting;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.GROUP;
+
+/**
+ * Group Nav-Page
+ */
+@PageInfo(
+        selector = GROUP,
+        selectorType = CSS,
+        urlPart = "/alert/group"
+)
+public class GroupNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public GroupNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/InhibitNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/InhibitNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.alerting;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.INHIBIT;
+
+/**
+ * Inhibit Nav-Page
+ */
+@PageInfo(
+        selector = INHIBIT,
+        selectorType = CSS,
+        urlPart = "/alert/inhibit"
+)
+public class InhibitNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public InhibitNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/IntegrationNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/IntegrationNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.alerting;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.INTEGRATION;
+
+/**
+ * Integration Nav-Page
+ */
+@PageInfo(
+        selector = INTEGRATION,
+        selectorType = CSS,
+        urlPart = "/alert/integration/webhook"
+)
+public class IntegrationNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public IntegrationNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/NotificationNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/NotificationNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.alerting;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.NOTIFICATION;
+
+/**
+ * Notification Nav-Page
+ */
+@PageInfo(
+        selector = NOTIFICATION,
+        selectorType = CSS,
+        urlPart = "/alert/notice"
+)
+public class NotificationNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public NotificationNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/SilenceNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/SilenceNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.alerting;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.SILENCE;
+
+/**
+ * Silence Nav-Page
+ */
+@PageInfo(
+        selector = SILENCE,
+        selectorType = CSS,
+        urlPart = "/alert/silence"
+)
+public class SilenceNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public SilenceNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/ThresholdNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/alerting/ThresholdNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.alerting;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.THRESHOLD;
+
+/**
+ * Threshold Nav-Page
+ */
+@PageInfo(
+        selector = THRESHOLD,
+        selectorType = CSS,
+        urlPart = "/alert/setting"
+)
+public class ThresholdNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public ThresholdNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/login/DashboardNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/login/DashboardNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.login;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.DASHBOARD;
+
+/**
+ * Dashboard Nav-Page
+ */
+@PageInfo(
+        selector = DASHBOARD,
+        selectorType = CSS,
+        urlPart = "/dashboard"
+)
+public class DashboardNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public DashboardNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/login/LoginPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/login/LoginPage.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.login;
+
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+/**
+ * Login Page
+ */
+public class LoginPage extends NavBarPage {
+    private final By usernameInputBy = By.xpath("//*[@id=\"nz-tabs-0-tab-0\"]/nz-form-item[1]/nz-form-control/div/div/app-multi-func-input/nz-input-group/input");
+    private final By passwordInputBy = By.xpath("//*[@id=\"nz-tabs-0-tab-0\"]/nz-form-item[2]/nz-form-control/div/div/app-multi-func-input/nz-input-group/input");
+    private final By loginButtonBy = By.xpath("//button/span[@class='ng-star-inserted']");
+    private final By loginPopup = By.cssSelector("div.ant-modal-body");
+
+    public LoginPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    private LoginPage enterAccount(String username, String password) {
+        sendKeys(usernameInputBy, username);
+        sendKeys(passwordInputBy, password);
+        return this;
+    }
+
+    private NavBarPage clickLoginButton() {
+        waitForClickable(loginButtonBy).click();
+        waitForClickable(loginButtonBy).click();
+        waitForVisibility(loginPopup);
+        new Actions(driver).sendKeys(Keys.ESCAPE).perform();
+        return new NavBarPage(driver);
+    }
+
+    public NavBarPage loginAs(String username, String password) {
+        return this.enterAccount(username, password).clickLoginButton();
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/monitoring/BulletinNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/monitoring/BulletinNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.monitoring;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.BULLETIN;
+
+/**
+ * Bulletin Nav-Page
+ */
+@PageInfo(
+        selector = BULLETIN,
+        selectorType = CSS,
+        urlPart = "/bulletin"
+)
+public class BulletinNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public BulletinNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/monitoring/MonitorsNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/monitoring/MonitorsNavPage.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.monitoring;
+
+import org.apache.commons.lang3.ThreadUtils;
+import org.apache.hertzbeat.automated.testing.common.ByBuilder;
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.time.Duration;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.MONITORS;
+
+/**
+ * Monitors Nav-Page
+ */
+@PageInfo(
+        selector = MONITORS,
+        selectorType = CSS,
+        urlPart = "/monitors"
+)
+public class MonitorsNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public By syncBtn = By.xpath("//button[.//i[@nztype='sync']]");
+    public By newMonitorBtn = By.xpath("//button[.//i[@nztype='appstore-add']]");
+    public By otherMonitorBtn = By.xpath("//button[@class='ant-btn ant-dropdown-trigger ant-btn-icon-only ng-star-inserted']/span[@nz-icon]");
+    public By allStatusSe = By.xpath("//nz-select-item[@title='All Status' or @title='Up' or @title='Down' or @title='Paused']");
+    public By typeFilterInput = By.xpath("//input[@placeholder='Type Filter']");
+    public By labelFilterInput = By.xpath("//input[@placeholder='Label Filter']");
+    public By searchMonitorInput = By.xpath("//input[@placeholder='Search Monitor']");
+    public By searchBtn = By.xpath("//button/span[contains(text(), 'Search')]");
+
+    // Monitor task list page
+    public ByBuilder taskNameBtn = (taskName) -> By.xpath(String.format("//span[text()=' %s ']", taskName.trim()));
+
+    public MonitorsNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    public MonitorsNavPage clickSyncBtn() {
+        waitForClickable(syncBtn).click();
+        return this;
+    }
+
+    public MonitorsNavPage clickNewMonitorBtn(String monitorType) {
+        new SearchMonitorType(newMonitorBtn, monitorType);
+        return this;
+    }
+
+    public MonitorsNavPage clickOtherMonitorBtn(OtherMonitorEnum otherMonitorEnum) {
+        new OtherMonitor().setOtherMonitorOption(otherMonitorEnum);
+        return this;
+    }
+
+    public MonitorsNavPage clickAllStatusSe(AllStatusEnum allStatusEnum) {
+        new AllStatus().setAllStatusOption(allStatusEnum);
+        return this;
+    }
+
+    public MonitorsNavPage clickTypeFilterInput(String monitorType) {
+        new SearchMonitorType(typeFilterInput, monitorType);
+        return this;
+    }
+
+    public MonitorsNavPage clickLabelFilterInput(String label) {
+        sendKeys(labelFilterInput, label);
+        return this;
+    }
+
+    public MonitorsNavPage clickSearchMonitorInput(String monitor) {
+        sendKeys(searchMonitorInput, monitor);
+        return this;
+    }
+
+    public MonitorsNavPage clickSearchBtn() {
+        waitForClickable(searchBtn).click();
+        waitForClickable(searchBtn);
+        return this;
+    }
+
+    public MonitorsNavPage clickTaskNameBtn(String taskName) {
+        clickAction(taskNameBtn.buildBy(taskName));
+        return this;
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+    public <T extends MonitorsNavPage> T forcedSleepWait(int seconds) {
+        ThreadUtils.sleepQuietly(Duration.ofSeconds(seconds));
+        return (T) this;
+    }
+
+    private class SearchMonitorType{
+        public By searchMonitorTypeInput = By.xpath("//input[@nz-input and @type='search']");
+        public By searchMonitorFirstType = By.xpath("//span[text()='AUTO']");
+        public ByBuilder addMonitorTypeInput = (monitorType) -> By.xpath(
+                String.format("//span[@class='ant-menu-title-content']/span[@class='label' and contains(@title, '%s')]", monitorType));
+
+        public SearchMonitorType(By typeBy, String monitorType) {
+            waitForClickable(typeBy).click();
+            WebElement searchMonitorTypeInputElement = waitForClickable(searchMonitorTypeInput);
+            waitForVisibility(searchMonitorFirstType);
+            searchMonitorTypeInputElement.sendKeys(monitorType);
+            waitForClickable(addMonitorTypeInput.buildBy(monitorType)).click();
+        }
+    }
+
+    private class OtherMonitor{
+        private final By otherMonitorItems = By.xpath("//div[@class='cdk-overlay-pane']/div/ul/li");
+
+        public OtherMonitor() {
+            new Actions(driver).moveToElement(waitForVisibility(otherMonitorBtn)).perform();
+        }
+
+        private void setOtherMonitorOption(LimitedEnum limitedEnum) {
+            for (int i = 0; i < limitedEnum.getLength(); i++) {
+                waitForClickable(By.xpath(
+                        String.format("//div[@class='cdk-overlay-pane']/div/ul/li[%d]", i + 1)));
+            }
+            waitForVisibilityOfAll(otherMonitorItems).get(limitedEnum.ordinal()).click();
+        }
+    }
+
+    private class AllStatus{
+        private final By allStatusItems = By.xpath("//div[@class='cdk-virtual-scroll-content-wrapper']/nz-option-item");
+
+        public AllStatus() {
+            clickAction(allStatusSe);
+        }
+
+        private void setAllStatusOption(LimitedEnum limitedEnum) {
+            for (int i = 0; i < limitedEnum.getLength(); i++) {
+                waitForClickable(By.xpath(
+                        String.format("//div[@class='cdk-virtual-scroll-content-wrapper']/nz-option-item[%d]", i + 1)));
+            }
+            waitForVisibilityOfAll(allStatusItems).get(limitedEnum.ordinal()).click();
+        }
+    }
+
+    /**
+     * Other Monitor Enum
+     */
+    public enum OtherMonitorEnum implements LimitedEnum {
+        Resume_Monitor("Resume Monitor"),
+        Pause_Monitor("Pause Monitor"),
+        Delete_Monitor("Delete Monitor"),
+        Export_Monitor("Export Monitor"),
+        Import_Monitor("Import Monitor");
+
+        OtherMonitorEnum(String desc) {
+        }
+
+        @Override
+        public int getLength() {
+            return values().length;
+        }
+    }
+
+    /**
+     * All Status Enum
+     */
+    public enum AllStatusEnum implements LimitedEnum {
+        All_Status("All Status"),
+        Up("Up"),
+        Down("Down"),
+        Paused("Paused");
+
+        AllStatusEnum(String desc) {
+        }
+
+        @Override
+        public int getLength() {
+            return values().length;
+        }
+    }
+
+    /**
+     * Limited Enum
+     */
+    public interface LimitedEnum {
+        int getLength();
+
+        int ordinal();
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/monitoring/TemplateNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/monitoring/TemplateNavPage.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.monitoring;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.TEMPLATE;
+
+/**
+ * Template Nav-Page
+ */
+@PageInfo(
+        selector = TEMPLATE,
+        selectorType = CSS,
+        urlPart = "/setting/define"
+)
+public class TemplateNavPage extends NavBarPage implements NavBarPage.NavBarTab {
+
+    public TemplateNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/monitoring/monitors/MonitorsDetailPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/monitoring/monitors/MonitorsDetailPage.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.monitoring.monitors;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.monitoring.MonitorsNavPage;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.apache.hertzbeat.common.entity.job.Job;
+import org.apache.hertzbeat.common.entity.job.Metrics;
+import org.apache.hertzbeat.manager.service.impl.AppServiceImpl;
+import org.dflib.DataFrame;
+import org.dflib.Extractor;
+import org.dflib.Printers;
+import org.dflib.Series;
+import org.dflib.builder.SeriesAppender;
+import org.junit.jupiter.api.function.Executable;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.NONE;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.EMPTY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Monitors Detail Page
+ */
+@Slf4j
+@PageInfo(
+        selector = EMPTY,
+        selectorType = NONE,
+        urlPart = "/monitors/"
+)
+public class MonitorsDetailPage extends NavBarPage implements MonitorsNavPage.InnerTab {
+
+    public By monitorRealTimeDetailBtn  = By.xpath("//button[contains(text(), 'Monitor Real-Time Detail')]");
+    public By monitorHistoricalChartDetailBtn = By.xpath("//button[contains(text(), 'Monitor Historical Chart Detail')]");
+
+    private final List<String> filterMonitor = new ArrayList<>();
+
+    public MonitorsDetailPage addFilterMonitorOptions(String... filterMonitorOptions) {
+        this.filterMonitor.addAll(Arrays.asList(filterMonitorOptions));
+        return this;
+    }
+
+    public MonitorsDetailPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    public MonitorsDetailPage clickRealTimeDetailBtn() {
+        clickAction(monitorRealTimeDetailBtn);
+        return this;
+    }
+
+    public MonitorsDetailPage clickHistoricalChartDetailBtn() {
+        clickAction(monitorHistoricalChartDetailBtn);
+        return this;
+    }
+
+    public List<Executable> testRealTimeDetail(String app) {
+        Job job = loadAppDefines(app.toLowerCase());
+        List<Executable> assertions = new ArrayList<>();
+
+        List<Metrics> metricsList = job.getMetrics();
+        for (int i = 0; i < metricsList.size(); i++) {
+            Metrics metrics = metricsList.get(i);
+
+            String metricNameIndex = String.format("//app-monitor-data-table[%d]/nz-card/div[1]/div/div[1]/p", i + 2);
+            By metricNameBy = By.xpath(metricNameIndex);
+            String frontMetricName = waitForVisibility(metricNameBy).getText().trim();
+
+            boolean exists = metricsList.stream()
+                    .map(map -> map.getI18n().get("en-US"))
+                    .filter(Objects::nonNull)
+                    .anyMatch(map -> map.equals(frontMetricName));
+            assertions.add(() -> assertTrue(exists, frontMetricName + " monitor metric do not exist."));
+            if (!exists) {
+                log.info("The monitor metric do not exist: {}", frontMetricName);
+                continue;
+            }
+
+            boolean contains = filterMonitor.contains(frontMetricName);
+            if (contains) {
+                log.info("Manually filter the monitor metric: {}", frontMetricName);
+                continue;
+            }
+
+            ArrayList<String> headerList = new ArrayList<>();
+            ArrayList<Series<String>> seriesList = new ArrayList<>();
+            List<Metrics.Field> metricsFieldsList = metrics.getFields();
+
+            String headerFirstIndex = String.format("//app-monitor-data-table[%d]/nz-card/div[2]/nz-table/nz-spin"
+                    + "/div/div/nz-table-inner-scroll/div[1]/table/thead/tr/th[1]", i + 2);
+            String headerFirstIndexText = driver.findElement(By.xpath(headerFirstIndex)).getText();
+            int metricsFieldsListSize = "Metric Name".equals(headerFirstIndexText) ? 2 : metricsFieldsList.size();
+            boolean metricHeadersMark = !"Metric Name".equals(headerFirstIndexText);
+
+            for (int j = 0; j < metricsFieldsListSize; j++) {
+                SeriesAppender<String, String> appender = Series
+                        .byElement(Extractor.<String>$col())
+                        .appender();
+
+                String metricFieldsHeaderIndex = String.format("//app-monitor-data-table[%d]/nz-card/div[2]/nz-table/nz-spin"
+                        + "/div/div/nz-table-inner-scroll/div[1]/table/thead/tr/th[%d]", i + 2, j + 1);
+                By metricFieldsHeaderBy = By.xpath(metricFieldsHeaderIndex);
+                for (WebElement webElement : driver.findElements(metricFieldsHeaderBy)) {
+                    String frontMetricHeaderText = webElement.getText();
+                    Optional.ofNullable(frontMetricHeaderText)
+                            .filter(text -> !text.trim().isEmpty())
+                            .ifPresent(headerList::add);
+                }
+
+                String metricFieldsIndex = String.format("//app-monitor-data-table[%d]/nz-card/div[2]/nz-table/nz-spin"
+                        + "/div/div/nz-table-inner-scroll/div[2]/table/tbody/tr/td[%d]", i + 2, j + 1);
+                By metricFieldsBy = By.xpath(metricFieldsIndex);
+                for (WebElement webElement : driver.findElements(metricFieldsBy)) {
+                    String frontMetricFieldText = webElement.getText();
+                    Optional.ofNullable(frontMetricFieldText)
+                            .filter(text -> !text.trim().isEmpty())
+                            .ifPresent(appender::append);
+                }
+
+                if (appender.size() != 0) {
+                    Series<String> series = appender.toSeries();
+                    seriesList.add(series);
+                }
+            }
+
+            DataFrame frontMetricDataFrame = DataFrame
+                    .byColumn(headerList.toArray(new String[0]))
+                    .of(seriesList.toArray(new Series[0]));
+            String frontMetric = Printers.tabular(10, 125).toString(frontMetricDataFrame);
+            log.info("\n" + frontMetricName + frontMetric);
+
+            int dfIndexSize = frontMetricDataFrame.getColumnsIndex().size();
+            int dfFirstColHeight = frontMetricDataFrame.cols(0).select().height();
+            int metricSize = metricsFieldsList.size();
+            if (metricHeadersMark) {
+                assertions.add(() -> assertEquals(metricSize, dfIndexSize, "Error in the Number of monitor metric fields."));
+
+                IntStream.range(0, dfIndexSize).forEach(index -> {
+                    String frontField = frontMetricDataFrame.getColumnsIndex().get(index);
+                    String metricField = concatMetricField(metricsFieldsList, index);
+                    assertions.add(() -> assertEquals(metricField, frontField, metricField + " Name is incorrect."));
+                });
+            } else {
+                assertions.add(() -> assertEquals(metricSize, dfFirstColHeight, "Error in the Number of monitor metric fields."));
+
+                DataFrame rowProxies = frontMetricDataFrame.cols(0).select();
+                IntStream.range(0, dfFirstColHeight).forEach(index -> {
+                    String rowValue = (String) rowProxies.get(0, index);
+                    String metricField = concatMetricField(metricsFieldsList, index);
+                    assertions.add(() -> assertEquals(metricField, rowValue, metricField + " Name is incorrect."));
+                });
+            }
+
+            for (String columnName : frontMetricDataFrame.getColumnsIndex()) {
+                Series<?> columnSeries = frontMetricDataFrame.getColumn(columnName);
+                IntStream.range(0, columnSeries.size()).forEach(index -> {
+                    Object columnValue = columnSeries.get(index);
+                    assertions.add(() -> assertTrue(Objects.nonNull(columnValue),
+                            columnName + ": " + index + " row, " + columnValue + " is null."));
+                });
+            }
+        }
+        return assertions;
+    }
+
+    private String concatMetricField(List<Metrics.Field> metricsFieldsList, int index) {
+        try {
+            Metrics.Field metricField = metricsFieldsList.get(index);
+            String field = metricField.getI18n().get("en-US");
+            String unit = metricField.getUnit();
+            unit = unit == null ? "" : " " + unit;
+            return field + unit;
+        } catch (IndexOutOfBoundsException e) {
+            log.error("concat metric field error", e);
+            return null;
+        }
+    }
+
+    private Map<String, Job> loadAppDefines() throws InvocationTargetException, InstantiationException, IllegalAccessException, NoSuchMethodException {
+        AppServiceImpl appService = new AppServiceImpl();
+        Class<?> appServiceImplClass = AppServiceImpl.class;
+        Class<?>[] declaredClasses = appServiceImplClass.getDeclaredClasses();
+
+        Class<?> appDefineStoreClass = null;
+        for (Class<?> declared : declaredClasses) {
+            if (declared.getSimpleName().equals("JarAppDefineStoreImpl")) {
+                appDefineStoreClass = declared;
+                break;
+            }
+        }
+
+        if (appDefineStoreClass != null) {
+            Constructor<?> appDefineStoreConstructor = appDefineStoreClass.getDeclaredConstructor(appServiceImplClass);
+            appDefineStoreConstructor.setAccessible(true);
+            Object appDefineStoreInstance = appDefineStoreConstructor.newInstance(appService);
+
+            Method getMessageMethod = appDefineStoreInstance.getClass().getDeclaredMethod("loadAppDefines");
+            getMessageMethod.setAccessible(true);
+            Object result = getMessageMethod.invoke(appDefineStoreInstance);
+            log.debug("loadAppDefines method returns result: " + result);
+
+            return appService.getAllAppDefines();
+        }
+        return null;
+    }
+
+    private Job loadAppDefines(String app) {
+        try {
+            Map<String, Job> jobMap = loadAppDefines();
+            return Objects.requireNonNull(jobMap).getOrDefault(app, null);
+        } catch (InvocationTargetException | InstantiationException | IllegalAccessException | NoSuchMethodException e) {
+            log.error("define/app-{}.yml file parsing error: ", app.toLowerCase());
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/monitoring/monitors/MonitorsEditPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/monitoring/monitors/MonitorsEditPage.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.monitoring.monitors;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ThreadUtils;
+import org.apache.hertzbeat.automated.testing.core.MonitorsEditConfig;
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.monitoring.MonitorsNavPage;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.lang.reflect.Field;
+import java.time.Duration;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.NONE;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.EMPTY;
+
+/**
+ * Monitors Edit Page
+ */
+@Slf4j
+@PageInfo(
+        selector = EMPTY,
+        selectorType = NONE,
+        urlPart = {"/edit", "/new"}
+)
+public class MonitorsEditPage extends NavBarPage implements MonitorsNavPage.InnerTab {
+
+    public By targetHost = By.xpath("//input[@id='host']");
+    public By taskName = By.xpath("//input[@id='name']");
+    public By port = By.xpath("//nz-input-number[@id='port']/div[@class='ant-input-number-input-wrap']/input");
+    public By databaseName = By.xpath("//input[@id='database']");
+    public By username = By.xpath("//input[@id='username']");
+    public By password = By.xpath("//input[@id='password']");
+
+    public By intervals = By.xpath("//nz-input-number[@id='intervals']/div/input");
+    public By bindLabelsKey = By.xpath("//input[@id='labels-0-key']");
+    public By bindLabelsValue = By.xpath("//input[@id='labels-0-value']");
+    public By bindAnnotationKey = By.xpath("//input[@id='annotations-0-key']");
+    public By bindAnnotationValue = By.xpath("//input[@id='annotations-0-value']");
+    public By description = By.xpath("//nz-textarea-count/textarea[@id='description']");
+
+    public By detectBtn = By.xpath("//div[@class='ant-row']/div/button/span[contains(text(), 'Detect')]");
+    public By okBtn = By.xpath("//div[@class='ant-row']/div/button/span[contains(text(), 'OK')]");
+    public By cancelBtn = By.xpath("//div[@class='ant-row']/div/button/span[contains(text(), 'Cancel')]");
+
+    private boolean markAdvancedBtn = true;
+
+    public MonitorsEditPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    public MonitorsEditPage clickDetectBtn() {
+        waitForClickable(detectBtn).click();
+        return this;
+    }
+
+    public MonitorsEditPage clickOkBtn() {
+        waitForClickable(okBtn).click();
+        return this;
+    }
+
+    public MonitorsEditPage clickCancelBtn() {
+        waitForClickable(cancelBtn).click();
+        return this;
+    }
+
+    /**
+     * Advanced configuration page
+     */
+    public class Advanced {
+        public By advancedBtn = By.xpath("//div[@role='button']//span[text()='Advanced']");
+        public By queryTimeout = By.xpath("//nz-input-number[@id='timeout']/div/input");
+        public By url = By.xpath("//input[@id='url']");
+        public By enableSshTunnel = By.xpath("//nz-switch[@id='enableSshTunnel']");
+        public By sshHost = By.xpath("//input[@id='sshHost']");
+        public By sshPort = By.xpath("//nz-input-number[@id='sshPort']/div[@class='ant-input-number-input-wrap']/input");
+        public By sshTimeout = By.xpath("//nz-input-number[@id='sshTimeout']/div[@class='ant-input-number-input-wrap']/input");
+        public By sshUsername = By.xpath("//input[@id='sshUsername']");
+        public By sshPassword = By.xpath("//input[@id='sshPassword']");
+        public By shareSshConnection = By.xpath("//nz-switch[@id='sshShareConnection']");
+        public By sshPrivateKey = By.xpath("//textarea[@id='sshPrivateKey']");
+        public By sshPrivateKeyPassPhrase = By.xpath("//input[@id='sshPrivateKeyPassphrase']");
+
+        public void clickAdvancedBtn() {
+            if (markAdvancedBtn) {
+                waitForClickable(advancedBtn).click();
+                // Page advanced configuration items are not uniform, no matching waiting elements, set forced waiting.
+                ThreadUtils.sleepQuietly(Duration.ofMillis(500));
+                markAdvancedBtn = false;
+            }
+        }
+    }
+
+    /**
+     * Collector configuration page
+     */
+    public class Collector {
+        public By collectorSe = By.xpath("//nz-select[@id='collector' and @name='collector']");
+        public By collectorItems = By.xpath("//cdk-virtual-scroll-viewport/div[@class='cdk-virtual-scroll-content-wrapper']/nz-option-item");
+
+        public void clickCollectorSe() {
+            waitForClickable(collectorSe).click();
+        }
+
+        public void setCollectorOption(LimitedEnum limitedEnum) {
+            for (int i = 0; i < limitedEnum.getLength(); i++) {
+                waitForClickable(By.xpath(
+                        String.format("//cdk-virtual-scroll-viewport/div[@class='cdk-virtual-scroll-content-wrapper']/nz-option-item[%d]", i + 1)));
+            }
+            waitForVisibilityOfAll(collectorItems).get(limitedEnum.ordinal()).click();
+        }
+    }
+
+    public MonitorsEditPage edit(MonitorsEditConfig monitorsEditConfig) {
+        Class<MonitorsEditConfig> monitorsEditConfigClass = MonitorsEditConfig.class;
+        Class<MonitorsEditConfig.Advanced> configAdvancedClass = MonitorsEditConfig.Advanced.class;
+        Class<MonitorsEditConfig.Collector> configCollectorClass = MonitorsEditConfig.Collector.class;
+        Class<MonitorsEditPage> monitorsEditPageClass = MonitorsEditPage.class;
+        Class<Advanced> pageAdvancedClass = Advanced.class;
+        // Class<Collector> pageCollectorClass = Collector.class;
+
+        for (Field monitorsEditConfigField : monitorsEditConfigClass.getDeclaredFields()) {
+            try {
+                monitorsEditConfigField.setAccessible(true);
+                String monitorsEditConfigFieldName = monitorsEditConfigField.getName();
+                Object monitorsEditConfigFieldValue = monitorsEditConfigField.get(monitorsEditConfig);
+
+                if (monitorsEditConfigFieldValue instanceof MonitorsEditConfig.Advanced configAdvanced) {
+                    Advanced pageAdvanced = this.new Advanced();
+                    for (Field configAdvancedField : configAdvancedClass.getDeclaredFields()) {
+                        configAdvancedField.setAccessible(true);
+                        String configAdvancedFieldName = configAdvancedField.getName();
+                        Object configAdvancedFieldValue = configAdvancedField.get(configAdvanced);
+
+                        Field pageAdvancedField = pageAdvancedClass.getDeclaredField(configAdvancedFieldName);
+                        pageAdvancedField.setAccessible(true);
+                        By by = (By) pageAdvancedField.get(pageAdvanced);
+                        log.info(pageAdvancedField + ": " + configAdvancedFieldValue);
+
+                        if (configAdvancedFieldValue instanceof Boolean) {
+                            pageAdvanced.clickAdvancedBtn();
+                            // Edit page switch button
+                            String attribute = waitForClickable(by).getAttribute("ng-reflect-model");
+                            if (attribute != null && !attribute.equals(configAdvancedFieldValue.toString())) {
+                                waitForClickable(by).click();
+                            }
+                            continue;
+                        }
+
+                        if (configAdvancedFieldValue != null) {
+                            pageAdvanced.clickAdvancedBtn();
+                            this.sendKeysAction(by, configAdvancedFieldValue.toString());
+                        }
+                    }
+                    continue;
+                }
+
+                if (monitorsEditConfigFieldValue instanceof MonitorsEditConfig.Collector configCollector) {
+                    Collector pageCollector = this.new Collector();
+                    for (Field configCollectorField : configCollectorClass.getDeclaredFields()) {
+                        configCollectorField.setAccessible(true);
+                        String configCollectorFieldName = configCollectorField.getName();
+                        Object configCollectorFieldValue = configCollectorField.get(configCollector);
+                        if (configCollectorFieldValue instanceof CollectorEnum) {
+                            log.info("collector: " + configCollectorFieldName);
+                            pageCollector.clickCollectorSe();
+                            pageCollector.setCollectorOption((LimitedEnum) configCollectorFieldValue);
+                        }
+                    }
+                    continue;
+                }
+
+                Field monitorsEditPageField = monitorsEditPageClass.getDeclaredField(monitorsEditConfigFieldName);
+                monitorsEditPageField.setAccessible(true);
+                By by = (By) monitorsEditPageField.get(this);
+                log.info(monitorsEditPageField + ": " + monitorsEditConfigFieldValue);
+
+                if (monitorsEditConfigFieldValue instanceof Boolean) {
+                    // Edit page switch button
+                    String attribute = waitForClickable(by).getAttribute("ng-reflect-model");
+                    if (attribute != null && !attribute.equals(monitorsEditConfigFieldValue.toString())) {
+                        waitForClickable(by).click();
+                    }
+                    continue;
+                }
+
+                if (monitorsEditConfigFieldValue != null) {
+                    this.sendKeysAction(by, monitorsEditConfigFieldValue.toString());
+                }
+            } catch (IllegalAccessException | NoSuchFieldException e) {
+                log.error("No matching monitors configuration parameter.");
+            }
+        }
+        return this;
+    }
+
+    /**
+     * Collector Enum
+     */
+    public enum CollectorEnum implements LimitedEnum {
+        DEFAULT_SYSTEM_DISPATCH("Default System Dispatch"),
+        MAIN_DEFAULT_COLLECTOR("main-default-collector");
+
+        private final String desc;
+
+        CollectorEnum(String desc) {
+            this.desc = desc;
+        }
+
+        @Override
+        public String getDesc() {
+            return desc;
+        }
+
+        @Override
+        public int getLength() {
+            return values().length;
+        }
+    }
+
+    /**
+     * Limited Enum
+     */
+    public interface LimitedEnum {
+        String getDesc();
+
+        int getLength();
+
+        int ordinal();
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/more/SettingsNavPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/more/SettingsNavPage.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.more;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.CSS;
+import static org.apache.hertzbeat.automated.testing.pages.navigation.NavBarPage.SETTINGS;
+
+/**
+ * Settings Nav-Page
+ */
+@PageInfo(
+        selector = SETTINGS,
+        selectorType = CSS,
+        urlPart = "/setting/settings/config"
+)
+public class SettingsNavPage extends NavBarPage implements NavBarPage.NavBarTab{
+
+    public static final String SYSTEM_CONFIGURATION = "//div[@class='menu']/ul/li[1]";
+    public static final String MESSAGE_SERVER_SETTING = "//div[@class='menu']/ul/li[2]";
+    public static final String FILE_SERVER_CONFIGURATION = "//div[@class='menu']/ul/li[3]";
+
+    public SettingsNavPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    @Override
+    public <T> T goToInnerTab(Class<T> clazz) {
+        return super.goToTab(clazz);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/more/settings/FileServerConfigurationPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/more/settings/FileServerConfigurationPage.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.more.settings;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.more.SettingsNavPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.XPATH;
+import static org.apache.hertzbeat.automated.testing.pages.more.SettingsNavPage.FILE_SERVER_CONFIGURATION;
+
+/**
+ * File Server Configuration Page
+ */
+@PageInfo(
+        selector = FILE_SERVER_CONFIGURATION,
+        selectorType = XPATH,
+        urlPart = "/setting/settings/object-store"
+)
+public class FileServerConfigurationPage extends SettingsNavPage implements SettingsNavPage.InnerTab{
+
+    public FileServerConfigurationPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/more/settings/MessageServerSettingPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/more/settings/MessageServerSettingPage.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.more.settings;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.more.SettingsNavPage;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.XPATH;
+import static org.apache.hertzbeat.automated.testing.pages.more.SettingsNavPage.MESSAGE_SERVER_SETTING;
+
+/**
+ * Message Server Setting Page
+ */
+@PageInfo(
+        selector = MESSAGE_SERVER_SETTING,
+        selectorType = XPATH,
+        urlPart = "/setting/settings/server"
+)
+public class MessageServerSettingPage extends SettingsNavPage implements SettingsNavPage.InnerTab{
+
+    public MessageServerSettingPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/more/settings/SystemConfigurationPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/more/settings/SystemConfigurationPage.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.more.settings;
+
+import org.apache.commons.lang3.ThreadUtils;
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.pages.more.SettingsNavPage;
+import org.openqa.selenium.By;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.time.Duration;
+
+import static org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum.XPATH;
+import static org.apache.hertzbeat.automated.testing.pages.more.SettingsNavPage.SYSTEM_CONFIGURATION;
+
+/**
+ * System Configuration Page
+ */
+@PageInfo(
+        selector = SYSTEM_CONFIGURATION,
+        selectorType = XPATH,
+        urlPart = "/setting/settings/config"
+)
+public class SystemConfigurationPage extends SettingsNavPage implements SettingsNavPage.InnerTab{
+
+    private final By systemLanguageSe = By.xpath("//div[@class='left']/form/se[1]/div[2]");
+    private final By systemLanguageSeText = By.xpath("//div[@class='left']/form/se[1]/div[2]//nz-select-item[@title]");
+    private final By systemTimeZoneSe = By.xpath("//div[@class='left']/form/se[2]/div[2]");
+    private final By systemThemeSe = By.xpath("//div[@class='left']/form/se[3]/div[2]");
+    private final By confirmUpdateBtn = By.xpath("//div[@class='left']/form/se[4]/div[2]//button/span[@class='ng-star-inserted']");
+
+    private Boolean clickConfirmUpdateBtnMark = false;
+
+    public SystemConfigurationPage(RemoteWebDriver driver) {
+        super(driver);
+    }
+
+    public SystemConfigurationPage setSystemDefaultLanguage() {
+        clickConfirmUpdateBtnMark = waitForVisibility(systemLanguageSeText).getText().contains("English");
+        return clickConfirmUpdateBtnMark ? this : setSystemLanguage(SystemLanguageEnum.English);
+    }
+
+    public SystemConfigurationPage setSystemLanguage(SystemLanguageEnum systemLanguage) {
+        new SysSelect(systemLanguageSe).setSystemConfigurationOption(systemLanguage);
+        return this;
+    }
+
+    public SystemConfigurationPage setSystemTimeZone(SystemTimeZoneEnum systemTimeZone) {
+        new SysSelect(systemTimeZoneSe).setSystemConfigurationOption(systemTimeZone);
+        return this;
+    }
+
+    public SystemConfigurationPage setSystemTheme(SystemThemeEnum systemTheme) {
+        new SysSelect(systemThemeSe).setSystemConfigurationOption(systemTheme);
+        return this;
+    }
+
+    public SystemConfigurationPage confirmUpdate() {
+        if (clickConfirmUpdateBtnMark) {
+            return this;
+        }
+        waitForClickable(confirmUpdateBtn).click();
+        /* Switching system languages and other operations, reloading and rendering pages,
+         * time-consuming operations, forced waiting.
+         */
+        ThreadUtils.sleepQuietly(Duration.ofSeconds(2));
+        waitForClickable(confirmUpdateBtn);
+        return this;
+    }
+
+    private class SysSelect{
+        private final By sysSelectItems = By.xpath("//cdk-virtual-scroll-viewport/div[1]/nz-option-item/div");
+
+        public SysSelect(By seBy) {
+            clickAction(seBy);
+        }
+
+        private void setSystemConfigurationOption(LimitedEnum limitedEnum) {
+            for (int i = 0; i < limitedEnum.getLength(); i++) {
+                waitForClickable(By.xpath(
+                        String.format("//cdk-virtual-scroll-viewport/div[1]/nz-option-item[%d]/div", i + 1)));
+            }
+            waitForVisibilityOfAll(sysSelectItems).get(limitedEnum.ordinal()).click();
+        }
+    }
+
+    /**
+     * System Language Enum
+     */
+    public enum SystemLanguageEnum implements LimitedEnum{
+        English("English(en_US)"),
+        SIMPLIFIED_CHINESE("Simplified Chinese(zh_CN)"),
+        TRADITIONAL_CHINESE("Traditional Chinese(zh_TW)"),
+        JAPANESE("Japanese(ja_JP)"),
+        PORTUGUESE("Portuguese(pt_BR)");
+
+        SystemLanguageEnum(String desc) {
+        }
+
+        @Override
+        public int getLength() {
+            return values().length;
+        }
+    }
+
+    /**
+     * System Time Zone Enum
+     */
+    public enum SystemTimeZoneEnum implements LimitedEnum{
+        PACIFIC_PAGO_PAGO("Pacific/Pago_Pago(UTC-11:00)"),
+        PACIFIC_TAHITI("Pacific/Tahiti(UTC-10:00)"),
+        PACIFIC_GAMBIER("Pacific/Gambier(UTC-09:00)"),
+        AMERICA_NOME("America/Nome(UTC-08:00)"),
+        AMERICA_PHOENIX("America/Phoenix(UTC-07:00)");
+        // ......
+
+        SystemTimeZoneEnum(String desc) {
+        }
+
+        @Override
+        public int getLength() {
+            return values().length;
+        }
+    }
+
+    /**
+     * System Theme Enum
+     */
+    public enum SystemThemeEnum implements LimitedEnum{
+        Default_Theme("Default Theme"),
+        DARK_THEME("Dark Theme"),
+        COMPACT_THEME("Compact Theme");
+
+        SystemThemeEnum(String desc) {
+        }
+
+        @Override
+        public int getLength() {
+            return values().length;
+        }
+    }
+
+    /**
+     * Limited Enum
+     */
+    public interface LimitedEnum {
+        int getLength();
+
+        int ordinal();
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/navigation/NavBarPage.java
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/java/org/apache/hertzbeat/automated/testing/pages/navigation/NavBarPage.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.automated.testing.pages.navigation;
+
+import org.apache.hertzbeat.automated.testing.common.PageInfo;
+import org.apache.hertzbeat.automated.testing.common.SelectorTypeEnum;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Navigation bar component page
+ */
+public class NavBarPage {
+
+    public final RemoteWebDriver driver;
+
+    public static final String DASHBOARD = "a.sidebar-nav__item-link[data-id='2']";
+    public static final String MONITORS = "a.sidebar-nav__item-link[data-id='4']";
+    public static final String BULLETIN = "a.sidebar-nav__item-link[data-id='5']";
+    public static final String TEMPLATE = "a.sidebar-nav__item-link[data-id='6']";
+    public static final String THRESHOLD = "a.sidebar-nav__item-link[data-id='21']";
+    public static final String INTEGRATION = "a.sidebar-nav__item-link[data-id='22']";
+    public static final String GROUP = "a.sidebar-nav__item-link[data-id='23']";
+    public static final String INHIBIT = "a.sidebar-nav__item-link[data-id='24']";
+    public static final String SILENCE = "a.sidebar-nav__item-link[data-id='25']";
+    public static final String ALARMS = "a.sidebar-nav__item-link[data-id='26']";
+    public static final String NOTIFICATION = "a.sidebar-nav__item-link[data-id='27']";
+    public static final String STATUS = "a.sidebar-nav__item-link[data-id='29']";
+    public static final String COLLECTOR = "a.sidebar-nav__item-link[data-id='30']";
+    public static final String LABELS = "a.sidebar-nav__item-link[data-id='31']";
+    public static final String PLUGINS = "a.sidebar-nav__item-link[data-id='32']";
+    public static final String SETTINGS = "a.sidebar-nav__item-link[data-id='34']";
+    public static final String HELP = "a.sidebar-nav__item-link[data-id='35']";
+    public static final String EMPTY = "";
+
+    public NavBarPage(RemoteWebDriver driver) {
+        this.driver = driver;
+    }
+
+    public WebElement waitForPresence(By anyBy) {
+        return new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.presenceOfElementLocated(anyBy));
+    }
+
+    public List<WebElement> waitForPresenceOfAll(By anyBy) {
+        return new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.presenceOfAllElementsLocatedBy(anyBy));
+    }
+
+    public WebElement waitForVisibility(By anyBy) {
+        return new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfElementLocated(anyBy));
+    }
+
+    public List<WebElement> waitForVisibilityOfAll(By anyBy) {
+        return new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.visibilityOfAllElementsLocatedBy(anyBy));
+    }
+
+    public WebElement waitForClickable(By anyBy) {
+        waitForPresence(anyBy);
+        waitForVisibility(anyBy);
+        return new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(anyBy));
+    }
+
+    public WebElement waitForClickable(WebElement webElement) {
+        return new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.elementToBeClickable(webElement));
+    }
+
+    public void waitForPageLoading(String[] urlPart) {
+        new WebDriverWait(driver, Duration.ofSeconds(10)).until(ExpectedConditions.or(
+                Arrays.stream(urlPart)
+                        .map(ExpectedConditions::urlContains)
+                        .toArray(ExpectedCondition[]::new))
+        );
+    }
+
+    public void clickTab(String selector, SelectorTypeEnum selectorType, String[] urlPart) {
+        switch (selectorType) {
+            case CSS -> waitForClickable(By.cssSelector(selector)).click();
+            case XPATH -> waitForClickable(By.xpath(selector)).click();
+            case ID -> waitForClickable(By.id(selector)).click();
+            case CLASS_NAME -> waitForClickable(By.className(selector)).click();
+            default -> {
+            }
+        }
+        waitForPageLoading(urlPart);
+    }
+
+    public <T> T goToTab(Class<T> clazz) {
+        PageInfo pageInfo = clazz.getAnnotation(PageInfo.class);
+        if (pageInfo != null) {
+            String selector = pageInfo.selector();
+            SelectorTypeEnum selectorType = pageInfo.selectorType();
+            String[] urlPart = pageInfo.urlPart();
+            if (selector != null && selectorType != null && urlPart != null) {
+                clickTab(selector, selectorType, urlPart);
+                try {
+                    Constructor<T> constructor = clazz.getDeclaredConstructor(RemoteWebDriver.class);
+                    constructor.setAccessible(true);
+                    return constructor.newInstance(driver);
+                } catch (NoSuchMethodException | InstantiationException | InvocationTargetException | IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        } else {
+            throw new IllegalArgumentException("Unknown page object type");
+        }
+        return null;
+    }
+
+    public void refresh() {
+        driver.navigate().refresh();
+    }
+
+    public void clickAction(By anyBy) {
+        new Actions(driver).moveToElement(waitForClickable(anyBy)).click().perform();
+    }
+
+    public void sendKeys(By anyBy, String keys) {
+        WebElement webElement = waitForVisibility(anyBy);
+        webElement.clear();
+        webElement.sendKeys(keys);
+    }
+
+    public void sendKeysAction(By anyBy, String keys) {
+        WebElement webElement = waitForVisibility(anyBy);
+        new Actions(driver)
+                .moveToElement(webElement)
+                .click()
+                .keyDown(webElement, Keys.CONTROL)
+                .sendKeys("a")
+                .keyUp(webElement, Keys.CONTROL)
+                .sendKeys(Keys.BACK_SPACE)
+                .sendKeys(keys)
+                .perform();
+    }
+
+    public void scrollDownPage(Integer deltaY) {
+        new Actions(driver).scrollByAmount(0, Objects.requireNonNullElse(deltaY, Integer.MAX_VALUE)).perform();
+    }
+
+    /**
+     * NavBarTab interface
+     */
+    public interface NavBarTab {
+        <T> T goToInnerTab(Class<T> clazz);
+
+        /**
+         * InnerTab sub interface
+         */
+        public interface InnerTab {
+        }
+    }
+
+}

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/resources/docker/base/hertzbeat-h2-compose.yaml
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/resources/docker/base/hertzbeat-h2-compose.yaml
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+networks:
+  hertzbeat:
+    driver: bridge
+
+services:
+  hertzbeat:
+    image: apache/hertzbeat:test
+    hostname: hertzbeat-test
+    restart: always
+    privileged: true
+    environment:
+      TZ: Asia/Shanghai
+      LANG: en_US.UTF-8
+    ports:
+      - "1157:1157"
+      - "1158:1158"
+    networks:
+      - hertzbeat

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/resources/docker/monitors/postgresql-compose.yaml
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/resources/docker/monitors/postgresql-compose.yaml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+networks:
+  hertzbeat:
+    driver: bridge
+
+services:
+  postgresql:
+    image: postgres:15
+    hostname: postgresql-test
+    environment:
+      POSTGRES_USER: root
+      POSTGRES_PASSWORD: 123456
+      POSTGRES_DB: test_db
+    ports:
+      - "5432:5432"
+    networks:
+      - hertzbeat

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/resources/edit/mysql.yml
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/resources/edit/mysql.yml
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# config case
+targetHost: mysql-test
+taskName: mysql-monitor-edit
+port: 3306
+databaseName: test_db
+username: root
+password: 123456
+advanced:
+  queryTimeout: 6000
+  url: service:jmx:rmi:///jndi/rmi://host:port/jmxrmi
+  enableSshTunnel: true # default false
+  sshHost: mysql-test
+  sshPort: 22
+  sshTimeout: 6000
+  sshUsername: root
+  sshPassword: 123456
+  shareSshConnection: false # default true
+  sshPrivateKey: lssa_9tAe3j0pQODpNm6i5NvV9HJMo3q6KwRY_5b9499e0
+  sshPrivateKeyPassPhrase: 123456
+collector:
+  collectorName: main-default-collector # & Default System Dispatch
+intervals: 10
+bindLabelsKey: test
+bindLabelsValue: mysql
+bindAnnotationKey: note
+bindAnnotationValue: this is a test case
+description: This is a mysql monitoring task for testing

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/resources/edit/postgresql.yml
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/resources/edit/postgresql.yml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+targetHost: postgresql-test
+taskName: postgresql-monitor-test
+port: 5432
+databaseName: test_db
+username: root
+password: 123456
+advanced:
+  queryTimeout: 6000
+  url:
+  enableSshTunnel:
+  sshHost:
+  sshPort:
+  sshTimeout:
+  sshUsername:
+  sshPassword:
+  shareSshConnection:
+  sshPrivateKey:
+  sshPrivateKeyPassPhrase:
+collector:
+  collectorName: Default System Dispatch
+intervals: 10
+bindLabelsKey: test
+bindLabelsValue: postgresql
+bindAnnotationKey: note
+bindAnnotationValue: this is a postgresql monitor test case
+description: This is a postgresql monitoring task for testing

--- a/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/resources/log4j2.xml
+++ b/hertzbeat-e2e/hertzbeat-automated-testing-e2e/src/test/resources/log4j2.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements.  See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<Configuration status="DEBUG">
+    <Appenders>
+        <Console name="ConsoleAppender" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger - %msg%n" charset="UTF-8"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="ConsoleAppender"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/hertzbeat-e2e/pom.xml
+++ b/hertzbeat-e2e/pom.xml
@@ -31,6 +31,7 @@
         <module>hertzbeat-collector-common-e2e</module>
         <module>hertzbeat-collector-kafka-e2e</module>
         <module>hertzbeat-collector-basic-e2e</module>
+        <module>hertzbeat-automated-testing-e2e</module>
     </modules>
 
     <properties>
@@ -40,40 +41,10 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <testcontainers.version>1.20.2</testcontainers.version>
         <junit.version>4.13.2</junit.version>
+        <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <awaitility.version>4.2.0</awaitility.version>
+        <log4j-slf4j-impl.version>2.17.2</log4j-slf4j-impl.version>
     </properties>
-
-
-    <dependencies>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
-            <version>${testcontainers.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>${awaitility.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.hertzbeat</groupId>
-            <artifactId>hertzbeat-manager</artifactId>
-            <version>${hertzbeat.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
 
     <dependencyManagement>
         <dependencies>
@@ -84,7 +55,78 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
-  
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hertzbeat</groupId>
+            <artifactId>hertzbeat-manager</artifactId>
+            <version>${hertzbeat.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>${log4j-slf4j-impl.version}</version>
+        </dependency>
+    </dependencies>
+
 </project>


### PR DESCRIPTION
## What's changed?

Added automated browser end-to-end testing module,
It can be later integrated into the CI process.
Complete general automated testing of new monitoring tasks and real-time metrics verification (take postgres monitor as an case).
In the future, continuous improvement is needed, and the test coverage is gradually improved through the power of the community.



![](https://raw.githubusercontent.com/Cyanty/images/main/collect/test-001.gif)


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
