### PR TITLE
[bugfix] Fix incorrect webhook URLs for Uptime Kuma, Zabbix, and Tencent Cloud

### DIFF
--- a/web-app/src/assets/doc/alert-integration/tencent.en-US.md
+++ b/web-app/src/assets/doc/alert-integration/tencent.en-US.md
@@ -9,7 +9,7 @@
 4. On the new notification template page, fill in the basic information
 5. In the **API Callback** module, enter the HertzBeat Webhook API URL:
    ```
-   http://{your_system_host}/api/alerts/tencent
+   http://{your_system_host}/api/alerts/report/tencent
    ```
 6. Save the notification template
 

--- a/web-app/src/assets/doc/alert-integration/tencent.ja-JP.md
+++ b/web-app/src/assets/doc/alert-integration/tencent.ja-JP.md
@@ -9,7 +9,7 @@
 4. 新しい通知テンプレートページで、基本情報を入力します。
 5. **インターフェースコールバック** モジュールで、HertzBeat が提供する Webhook インターフェースアドレス URL を入力します。
    ```
-   http://{your_system_host}/api/alerts/tencent
+   http://{your_system_host}/api/alerts/report/tencent
    ```
 6. 通知テンプレートを保存します。
 

--- a/web-app/src/assets/doc/alert-integration/tencent.zh-CN.md
+++ b/web-app/src/assets/doc/alert-integration/tencent.zh-CN.md
@@ -9,7 +9,7 @@
 4. 在新建通知模板页面，填写基础信息
 5. 在 **接口回调** 模块中，填写 HertzBeat 提供的 Webhook 接口地址 URL：
    ```
-   http://{your_system_host}/api/alerts/tencent
+   http://{your_system_host}/api/alerts/report/tencent
    ```
 6. 保存通知模板
 

--- a/web-app/src/assets/doc/alert-integration/tencent.zh-TW.md
+++ b/web-app/src/assets/doc/alert-integration/tencent.zh-TW.md
@@ -9,7 +9,7 @@
 4. 在新建通知模板頁面，填寫基礎信息
 5. 在 **接口回調** 模塊中，填寫 HertzBeat 提供的 Webhook 接口地址 URL：
    ```
-   http://{your_system_host}/api/alerts/tencent
+   http://{your_system_host}/api/alerts/report/tencent
    ```
 6. 保存通知模板
 

--- a/web-app/src/assets/doc/alert-integration/uptime-kuma.en-US.md
+++ b/web-app/src/assets/doc/alert-integration/uptime-kuma.en-US.md
@@ -3,12 +3,13 @@
 ### Configure the Uptime Kuma alarm callback
 
 #### Go to the notification configuration
+
 1. Log in to the Uptime Kuma web management interface
 2. Go to **Settings** > **Notifications** > **Set Notifications**
 3. Select the Webhook notification type
 4. In the Post URL, fill in the Webhook Interface URL provided by HertzBeat:
    ```
-   http://{your_system_host}/api/report/uptime-kuma
+   http://{your_system_host}/api/alerts/report/uptime-kuma
    ```
 5. In the request body, select Preset-application/json, and configure the rest as needed
 6. Save the settings notification
@@ -16,10 +17,12 @@
 ### Frequently Asked Questions
 
 #### No alerts received
+
 - Make sure that the webhook URL can be accessed by the uptime kuma service
 - Check whether the server logs contain request records
 
 #### The alarm is not triggered
+
 - Make sure that the conditions of the alert policy are correct and that notifications are bound
 
 For more information, please refer to [Uptime Kuma Wiki](https://github.com/louislam/uptime-kuma/wiki)

--- a/web-app/src/assets/doc/alert-integration/uptime-kuma.zh-CN.md
+++ b/web-app/src/assets/doc/alert-integration/uptime-kuma.zh-CN.md
@@ -8,7 +8,7 @@
 3. 选择 **Webhook** 通知类型
 4. 在 **Post URL** 中，填写 HertzBeat 提供的 Webhook 接口地址 URL：
    ```
-   http://{your_system_host}/api/report/uptime-kuma
+   http://{your_system_host}/api/alerts/report/uptime-kuma
    ```
 5. 在 **请求体** 选择 **预设-application/json**,其他请按需配置
 6. 保存设置通知

--- a/web-app/src/assets/doc/alert-integration/uptime-kuma.zh-TW.md
+++ b/web-app/src/assets/doc/alert-integration/uptime-kuma.zh-TW.md
@@ -8,7 +8,7 @@
 3. 選擇 **Webhook** 通知類型
 4. 在 **Post URL** 中，填寫 HertzBeat 提供的 Webhook 接口地址 URL：
    ```
-   http://{your_system_host}/api/report/uptime-kuma
+   http://{your_system_host}/api/alerts/report/uptime-kuma
    ```
 5. 在 **請求體** 選擇 **預設-application/json**，其他請按需配置
 6. 保存設置通知

--- a/web-app/src/assets/doc/alert-integration/zabbix.en-US.md
+++ b/web-app/src/assets/doc/alert-integration/zabbix.en-US.md
@@ -10,7 +10,7 @@ Send Zabbix alerts to the HertzBeat alert platform via Webhook.
 
    | Name | Value |
       |-----|-----|
-   | URL | http://your-hertzbeat-server:1157/api/report/zabbix |
+   | URL | http://your-hertzbeat-server:1157/api/alerts/report/zabbix |
    | AlertName | {TRIGGER.NAME} |
    | AlertId | {EVENT.ID} |
    | HostName | {HOST.NAME} |

--- a/web-app/src/assets/doc/alert-integration/zabbix.zh-CN.md
+++ b/web-app/src/assets/doc/alert-integration/zabbix.zh-CN.md
@@ -10,7 +10,7 @@
 
    | 名称 | 值 |
    |-----|-----|
-   | URL | http://your-hertzbeat-server:1157/api/report/zabbix |
+   | URL | http://your-hertzbeat-server:1157/api/alerts/report/zabbix |
    | AlertName | {TRIGGER.NAME} |
    | AlertId | {EVENT.ID} |
    | HostName | {HOST.NAME} |

--- a/web-app/src/assets/doc/alert-integration/zabbix.zh-TW.md
+++ b/web-app/src/assets/doc/alert-integration/zabbix.zh-TW.md
@@ -10,7 +10,7 @@
 
    | 名稱 | 值 |
       |-----|-----|
-   | URL | http://your-hertzbeat-server:1157/api/report/zabbix |
+   | URL | http://your-hertzbeat-server:1157/api/alerts/report/zabbix |
    | AlertName | {TRIGGER.NAME} |
    | AlertId | {EVENT.ID} |
    | HostName | {HOST.NAME} |


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

#3350 

Corrected webhook endpoint examples in integration guide.

## Checklist

- [X]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
