### PR TITLE
Potential fix for code scanning alert no. 73: Uncontrolled data used in path expression

### DIFF
--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/AppServiceImpl.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/AppServiceImpl.java
@@ -666,6 +666,7 @@ public class AppServiceImpl implements AppService, InitializingBean {
 
         @Override
         public void save(String app, String ymlContent) {
+            validateAppName(app);
             var classpath = Objects.requireNonNull(this.getClass().getClassLoader().getResource("")).getPath();
             var defineAppPath = classpath + "define" + File.separator + "app-" + app + ".yml";
             var defineAppFile = new File(defineAppPath);
@@ -673,24 +674,34 @@ public class AppServiceImpl implements AppService, InitializingBean {
                 FileUtils.writeStringToFile(defineAppFile, ymlContent, StandardCharsets.UTF_8, false);
             } catch (Exception e) {
                 log.error(e.getMessage());
-                throw new RuntimeException("flush file " + defineAppPath + " error: " + e.getMessage());
+                throw new RuntimeException("Flush file " + defineAppPath + " error: " + e.getMessage());
             }
         }
 
         @Override
         public void delete(String app) {
+            validateAppName(app);
             var classpath = Objects.requireNonNull(this.getClass().getClassLoader().getResource("")).getPath();
             var defineAppPath = classpath + "define" + File.separator + "app-" + app + ".yml";
             var defineAppFile = new File(defineAppPath);
 
-            if (!defineAppFile.exists() && appDefines.containsKey(app.toLowerCase())){
-                throw new CommonException("the app define file is not in current file server provider");
+            if (!defineAppFile.exists() && appDefines.containsKey(app.toLowerCase())) {
+                throw new CommonException("The app define file is not in the current file server provider");
             }
 
             if (defineAppFile.exists() && defineAppFile.isFile()) {
                 defineAppFile.delete();
             }
             appDefines.remove(app.toLowerCase());
+        }
+    }
+
+    private void validateAppName(String app) {
+        if (app == null || app.isEmpty() || app.contains("..") || app.contains("/") || app.contains("\\")) {
+            throw new IllegalArgumentException("Invalid app name: " + app);
+        }
+        if (!app.matches("^[a-zA-Z0-9_-]+$")) {
+            throw new IllegalArgumentException("App name must only contain alphanumeric characters, dashes, or underscores: " + app);
         }
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/apache/hertzbeat/security/code-scanning/73](https://github.com/apache/hertzbeat/security/code-scanning/73)

To fix the issue, we need to validate the `app` parameter before using it to construct a file path. Specifically:
1. Ensure that the `app` parameter does not contain any path traversal sequences (e.g., `../`) or path separators (`/` or `\`).
2. Use a whitelist approach to allow only valid app names that match a specific pattern (e.g., alphanumeric characters and dashes).
3. Reject any input that does not meet the validation criteria.

The validation logic should be implemented in the `delete` method of the `LocalFileAppDefineStoreImpl` class. Additionally, the `save` method should also be updated to include similar validation, as it also constructs a file path using the `app` parameter.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
