### PR TITLE
[bugfix] CommonDispatcher#dispatchCollectData may get `NullPointerException` if not a service discovery job

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-collector/src/main/java/org/apache/hertzbeat/collector/dispatch/CommonDispatcher.java
+++ b/hertzbeat-collector/hertzbeat-collector-collector/src/main/java/org/apache/hertzbeat/collector/dispatch/CommonDispatcher.java
@@ -298,7 +298,7 @@ public class CommonDispatcher implements MetricsTaskDispatch, CollectDataDispatc
                 }
             }
 
-            if (job.isSd() || metricsSet == null) {
+            if ( metricsSet == null || job.isSd() ) {
                 // The collection and execution of all metrics of this job are completed
                 // and the result listener is notified of the combination of all metrics data
                 timerDispatch.responseSyncJobData(job.getId(), job.getResponseDataTemp());


### PR DESCRIPTION
## What's changed?
in CommonDispatcher#dispatchCollectData , when `job.isSd()` is false,the condition `metricsSet == null` won't be checked before accessing `metricsSet`.

https://github.com/apache/hertzbeat/blob/63c187488f0b34701349d21931489f8cfefc964e/hertzbeat-collector/hertzbeat-collector-collector/src/main/java/org/apache/hertzbeat/collector/dispatch/CommonDispatcher.java#L301

This may lead to `NullPointerException`.
https://github.com/apache/hertzbeat/blob/63c187488f0b34701349d21931489f8cfefc964e/hertzbeat-collector/hertzbeat-collector-collector/src/main/java/org/apache/hertzbeat/collector/dispatch/CommonDispatcher.java#L305

<img width="1074" alt="0601" src="https://github.com/user-attachments/assets/3b3ed2b6-d087-4edd-bf9d-d81c088c8b5d" />


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
