### PR TITLE
[bugfix] Fix the issue where Prometheus RealTime Threshold is not eff…

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/calculate/RealTimeAlertCalculator.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/calculate/RealTimeAlertCalculator.java
@@ -139,6 +139,9 @@ public class RealTimeAlertCalculator {
         String instanceHost = metricsData.getInstanceHost();
         String app = metricsData.getApp();
         String metrics = metricsData.getMetrics();
+        if ((CommonConstants.PROMETHEUS_APP_PREFIX + instanceName).equals(metricsData.getApp())) {
+            app = CommonConstants.PROMETHEUS;
+        }
         int priority = metricsData.getPriority();
         int code = metricsData.getCode().getNumber();
         Map<String, String> labels = metricsData.getLabels();

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/calculate/RealTimeAlertCalculatorMatchTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/calculate/RealTimeAlertCalculatorMatchTest.java
@@ -133,7 +133,12 @@ public class RealTimeAlertCalculatorMatchTest {
 
         AlertDefine matchDefine = new AlertDefine();
         matchDefine.setName("test");
-        matchDefine.setExpr("equals(__app__,\"prometheus\") && equals(__metrics__,\"canal_instance\") && (equals(__instance__, \"515224274242816\") or equals(__instance__, \"518789738974464\")) && metric_value > 0");
+        matchDefine.setExpr(
+            "equals(__app__,\"prometheus\") && "
+            + "equals(__metrics__,\"canal_instance\") && "
+            + "(equals(__instance__, \"515224274242816\") or equals(__instance__, \"518789738974464\")) && "
+            + "metric_value > 0"
+        );
         matchDefine.setTemplate("Canal instance val: ${value}%");
         matchDefine.setTimes(1);
 

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/calculate/RealTimeAlertCalculatorMatchTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/calculate/RealTimeAlertCalculatorMatchTest.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.alert.calculate;
+
+import com.google.common.collect.Lists;
+import org.apache.hertzbeat.alert.AlerterWorkerPool;
+import org.apache.hertzbeat.alert.dao.SingleAlertDao;
+import org.apache.hertzbeat.alert.reduce.AlarmCommonReduce;
+import org.apache.hertzbeat.alert.service.AlertDefineService;
+import org.apache.hertzbeat.common.constants.CommonConstants;
+import org.apache.hertzbeat.common.constants.MetricDataConstants;
+import org.apache.hertzbeat.common.entity.alerter.AlertDefine;
+import org.apache.hertzbeat.common.entity.message.CollectRep;
+import org.apache.hertzbeat.common.queue.CommonDataQueue;
+import org.apache.hertzbeat.common.queue.impl.InMemoryCommonDataQueue;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ *
+ */
+public class RealTimeAlertCalculatorMatchTest {
+
+    private final AlerterWorkerPool workerPool = new AlerterWorkerPool();
+
+    @Mock
+    private CommonDataQueue dataQueue = new InMemoryCommonDataQueue();
+
+    @Mock
+    private AlertDefineService alertDefineService;
+
+    @Mock
+    private SingleAlertDao singleAlertDao;
+
+    @Mock
+    private AlarmCommonReduce alarmCommonReduce;
+
+    @Mock
+    private AlarmCacheManager alarmCacheManager;
+
+    private RealTimeAlertCalculator realTimeAlertCalculator;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(singleAlertDao.querySingleAlertsByStatus(any())).thenReturn(new ArrayList<>());
+        realTimeAlertCalculator = new RealTimeAlertCalculator(
+                workerPool,
+                dataQueue,
+                alertDefineService,
+                singleAlertDao,
+                alarmCommonReduce,
+                alarmCacheManager,
+                false
+        );
+    }
+
+    @Test
+    void testFilterThresholdsByAppAndMetrics_withInstanceExpr_HasSpace() {
+
+        String app = "redis";
+        String instanceId = "501045327364864";
+        int priority = 0;
+
+        AlertDefine matchDefine = new AlertDefine();
+        matchDefine.setExpr("equals(__app__,\"redis\") && equals(__instance__, \"501045327364864\")");
+
+        AlertDefine unmatchDefine = new AlertDefine();
+        unmatchDefine.setExpr("equals(__app__,\"redis\") && equals(__instance__, \"999999999\")");
+
+        List<AlertDefine> allDefines = Collections.singletonList(matchDefine);
+
+        List<AlertDefine> filtered = realTimeAlertCalculator.filterThresholdsByAppAndMetrics(allDefines, app, "", Map.of(), instanceId, priority);
+
+        // It should filter out 999999999.
+        assertEquals(1, filtered.size());
+        assertEquals("equals(__app__,\"redis\") && equals(__instance__, \"501045327364864\")",
+                filtered.get(0).getExpr());
+    }
+
+    @Test
+    void testPrometheusReplaceMultipleJobsApp() throws InterruptedException {
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
+        builder.setId(518789738974464L)
+                .setApp("_prometheus_Cool_Stingray_34Nj_copy")
+                .setMetrics("canal_instance")
+                .setPriority(0)
+                .setCode(CollectRep.Code.SUCCESS);
+
+        CollectRep.Field destination = CollectRep.Field.newBuilder().setName("destination").setType(CommonConstants.TYPE_STRING).setLabel(true).build();
+        CollectRep.Field mode = CollectRep.Field.newBuilder().setName("mode").setType(CommonConstants.TYPE_STRING).setLabel(true).build();
+        CollectRep.Field metricValue = CollectRep.Field.newBuilder().setName("metric_value").setType(CommonConstants.TYPE_NUMBER).setLabel(true).build();
+
+        Map<String, String> meta = new HashMap<>();
+        meta.put(MetricDataConstants.INSTANCE_NAME, "Cool_Stingray_34Nj_copy");
+        meta.put(MetricDataConstants.INSTANCE_HOST, "127.0.0.1");
+
+        builder.addMetadataAll(meta);
+        builder.addAllFields(Lists.newArrayList(destination, mode, metricValue));
+        builder.addValueRow(CollectRep.ValueRow.newBuilder().addColumn("example").addColumn("spring").addColumn("1.0").build());
+
+        CollectRep.MetricsData metricsData = builder.build();
+
+
+        AlertDefine matchDefine = new AlertDefine();
+        matchDefine.setName("test");
+        matchDefine.setExpr("equals(__app__,\"prometheus\") && equals(__metrics__,\"canal_instance\") && (equals(__instance__, \"515224274242816\") or equals(__instance__, \"518789738974464\")) && metric_value > 0");
+        matchDefine.setTemplate("Canal instance val: ${value}%");
+        matchDefine.setTimes(1);
+
+        List<AlertDefine> allDefines = Collections.singletonList(matchDefine);
+
+        when(alertDefineService.getRealTimeAlertDefines()).thenReturn(allDefines);
+        when(dataQueue.pollMetricsDataToAlerter()).thenReturn(metricsData).thenThrow(new InterruptedException());
+
+        realTimeAlertCalculator.startCalculate();
+
+        Thread.sleep(3000);
+
+        verify(alarmCacheManager, times(1)).getPending(any());
+        verify(alarmCacheManager, times(1)).putFiring(any(), any());
+        verify(alarmCommonReduce, times(1)).reduceAndSendAlarm(any());
+    }
+
+    @Test
+    void testPrometheusReplaceApp() throws InterruptedException {
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
+        builder.setId(1)
+                .setApp("_prometheus_Cool_Stingray_34Nj")
+                .setMetrics("canal_instance")
+                .setPriority(0)
+                .setCode(CollectRep.Code.SUCCESS);
+
+        CollectRep.Field destination = CollectRep.Field.newBuilder().setName("destination").setType(CommonConstants.TYPE_STRING).setLabel(true).build();
+        CollectRep.Field mode = CollectRep.Field.newBuilder().setName("mode").setType(CommonConstants.TYPE_STRING).setLabel(true).build();
+        CollectRep.Field metricValue = CollectRep.Field.newBuilder().setName("metric_value").setType(CommonConstants.TYPE_NUMBER).setLabel(true).build();
+
+        Map<String, String> meta = new HashMap<>();
+        meta.put(MetricDataConstants.INSTANCE_NAME, "Cool_Stingray_34Nj");
+        meta.put(MetricDataConstants.INSTANCE_HOST, "127.0.0.1");
+
+        builder.addMetadataAll(meta);
+        builder.addAllFields(Lists.newArrayList(destination, mode, metricValue));
+        builder.addValueRow(CollectRep.ValueRow.newBuilder().addColumn("example").addColumn("spring").addColumn("1.0").build());
+
+        CollectRep.MetricsData metricsData = builder.build();
+
+        AlertDefine matchDefine = new AlertDefine();
+        matchDefine.setName("test");
+        matchDefine.setExpr("equals(__app__,\"prometheus\") && equals(__metrics__,\"canal_instance\") && metric_value > 0");
+        matchDefine.setTemplate("Canal instance val: ${value}%");
+        matchDefine.setTimes(1);
+
+        List<AlertDefine> allDefines = Collections.singletonList(matchDefine);
+
+        when(alertDefineService.getRealTimeAlertDefines()).thenReturn(allDefines);
+        when(dataQueue.pollMetricsDataToAlerter()).thenReturn(metricsData).thenThrow(new InterruptedException());
+
+        realTimeAlertCalculator.startCalculate();
+
+        Thread.sleep(3000);
+
+        verify(alarmCacheManager, times(1)).getPending(any());
+        verify(alarmCacheManager, times(1)).putFiring(any(), any());
+        verify(alarmCommonReduce, times(1)).reduceAndSendAlarm(any());
+    }
+
+    @Test
+    void testCalculateWithNormalApp() throws InterruptedException {
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
+        builder.setId(1)
+                .setApp("springboot3")
+                .setMetrics("available")
+                .setPriority(0)
+                .setCode(CollectRep.Code.SUCCESS)
+                .setTenantId(0).setId(518679137103104L)
+                .setTime(1749110170834L)
+                .setPriority(0);
+
+        CollectRep.Field responseTime = CollectRep.Field.newBuilder()
+                .setName("responseTime")
+                .setType(CommonConstants.TYPE_STRING)
+                .setUnit("ms")
+                .setLabel(false)
+                .build();
+
+        Map<String, String> meta = new HashMap<>();
+        meta.put(MetricDataConstants.INSTANCE_NAME, "Vibrant_Gazelle_83vJ");
+        meta.put(MetricDataConstants.INSTANCE_HOST, "127.0.0.1");
+
+        builder.addMetadataAll(meta);
+        builder.addAllFields(Lists.newArrayList(responseTime));
+        builder.addValueRow(CollectRep.ValueRow.newBuilder().addColumn("18").build());
+
+        CollectRep.MetricsData metricsData = builder.build();
+
+        AlertDefine matchDefine = new AlertDefine();
+        matchDefine.setName("test");
+        matchDefine.setExpr("equals(__app__,\"springboot3\") && equals(__metrics__,\"available\") && equals(__instance__, \"518679137103104\") && responseTime > 0");
+        matchDefine.setTemplate("Canal instance val: ${value}%");
+        matchDefine.setTimes(1);
+
+        List<AlertDefine> allDefines = Collections.singletonList(matchDefine);
+
+        when(alertDefineService.getRealTimeAlertDefines()).thenReturn(allDefines);
+        when(dataQueue.pollMetricsDataToAlerter()).thenReturn(metricsData).thenThrow(new InterruptedException());
+
+        realTimeAlertCalculator.startCalculate();
+
+        Thread.sleep(3000);
+
+        verify(alarmCacheManager, times(1)).getPending(any());
+        verify(alarmCacheManager, times(1)).putFiring(any(), any());
+        verify(alarmCommonReduce, times(1)).reduceAndSendAlarm(any());
+    }
+
+}


### PR DESCRIPTION
## What's changed?

Please refer to:(#3425)

1、Because the monitor name was converted in `org.apache.hertzbeat.manager.service.impl.MonitorServiceImpl#addMonitor`
```
if (CommonConstants.PROMETHEUS.equals(monitor.getApp())) {
	appDefine.setApp(CommonConstants.PROMETHEUS_APP_PREFIX + monitor.getName());
}
```

2、And in `org.apache.hertzbeat.manager.service.impl.MonitorServiceImpl#addMonitor`, the label key: instance name is populated into the Job metadata.
```
Map<String, String> metadata = Map.of(CommonConstants.LABEL_INSTANCE_NAME, monitor.getName(), CommonConstants.LABEL_INSTANCE_HOST, monitor.getHost());
appDefine.setMetadata(metadata);
```

3、After the prometheus data has been collected, an alert needs to be sent to calculate whether the threshold is matched or not
```
// Send：
org.apache.hertzbeat.collector.dispatch.CommonDispatcher#dispatchCollectData(org.apache.hertzbeat.common.timer.Timeout, org.apache.hertzbeat.common.entity.job.Metrics, java.util.List<org.apache.hertzbeat.common.entity.message.CollectRep.MetricsData>)

// Calculate：
org.apache.hertzbeat.alert.calculate.RealTimeAlertCalculator#calculate
->
String app = metricsData.getApp();
// Filter thresholds by app, metrics, labels and instance  
thresholds = filterThresholdsByAppAndMetrics(thresholds, app, metrics, labels, instance, priority);  
if (thresholds.isEmpty()) {  
    return;  
}
```

4、The problem lies in the conversion in step 1, and I considered changing the page to backfill the monitor name, but then realized that it doesn't make sense.

I think a reasonable approach is to use (PROMETHEUS_APP_PREFIX + job metadata instanceName) to check if the current monitor is compatible. If it is, directly replace it with prometheus; if not, keep it as is

```
String app = metricsData.getApp();  
if ((CommonConstants.PROMETHEUS_APP_PREFIX + instanceName).equals(metricsData.getApp())) {  
    app = CommonConstants.PROMETHEUS;  
}
```

5、This is done for several reasons:
1. For multiple monitor jobs, each is isolated by a separate MetricsCollect.
2. Therefore, the data collected by each MetricsCollect is sent to alert using the instance name of the current job
3. For the calculation logic, it also determines whether a single job matches the calculation. Even when the threshold rule is associated with multiple monitoring configurations, since instanceId is treated as "or," it only requires the instance name (app) to remain consistent.

I haven't been familiar with the project for long; these are some of my thoughts and changes. Please let me know if anything is incorrect.
<img width="1512" alt="iShot_2025-06-05_22 45 30" src="https://github.com/user-attachments/assets/8894135f-a685-437a-88d7-a885059060f6" />
<img width="1512" alt="iShot_2025-06-05_22 45 05" src="https://github.com/user-attachments/assets/6a58f272-e975-457f-8e8e-a12d801fb32a" />
<img width="1511" alt="iShot_2025-06-05_22 44 31" src="https://github.com/user-attachments/assets/a8b121dd-0cb4-40ed-950b-d3848071b7e6" />



## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

