### PR TITLE
[improvement] disable default OpenTelemetry exporters to prevent connection errors

### DIFF
--- a/hertzbeat-manager/src/main/resources/application.yml
+++ b/hertzbeat-manager/src/main/resources/application.yml
@@ -62,6 +62,14 @@ sureness:
              8tVt4bisXQ13rbN0oxhUZR73M6EByXIO+SV5
              dKhaX0csgOCTlCxq20yhmUea6H6JIpSE2Rwp'
 
+otel:
+  traces:
+    exporter: none
+  metrics:
+    exporter: none
+  logs:
+    exporter: none
+
 ---
 spring:
   config:


### PR DESCRIPTION

## What's changed?

#3435 

When running HertzBeat locally, OpenTelemetry SDK by default attempts to send traces, metrics, and logs to `http://localhost:4318`

This behavior is caused by the auto-configuration of OpenTelemetry exporters when no explicit exporter is set.

The following properties are added to explicitly disable all OpenTelemetry exporters when `warehouse.greptime.enabled = false`:

```yaml
otel:
  traces:
    exporter: none
  metrics:
    exporter: none
  logs:
    exporter: none
```

<!-- Describe Your PR Here -->


## Checklist

- [X]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
