### PR TITLE
[improvement] disable default OpenTelemetry exporters to prevent connection errors

### DIFF
--- a/hertzbeat-manager/src/main/resources/application.yml
+++ b/hertzbeat-manager/src/main/resources/application.yml
@@ -62,14 +62,6 @@ sureness:
              8tVt4bisXQ13rbN0oxhUZR73M6EByXIO+SV5
              dKhaX0csgOCTlCxq20yhmUea6H6JIpSE2Rwp'
 
-otel:
-  traces:
-    exporter: none
-  metrics:
-    exporter: none
-  logs:
-    exporter: none
-
 ---
 spring:
   config:

--- a/hertzbeat-otel/src/main/java/org/apache/hertzbeat/otel/config/OpenTelemetryConfig.java
+++ b/hertzbeat-otel/src/main/java/org/apache/hertzbeat/otel/config/OpenTelemetryConfig.java
@@ -98,29 +98,37 @@ public class OpenTelemetryConfig {
     }
 
     /**
-     * Provides an AutoConfigurationCustomizerProvider to tailor the auto-configured OpenTelemetry SDK.
-     * This includes setting up GrepTimeDB exporters for logs and traces, and customizing the resource.
-     * Active only if 'greptime.enabled' is true.
-     *
-     * @param greptimeProperties Configuration for GrepTimeDB.
-     * @return AutoConfigurationCustomizerProvider instance.
+     * Provides default OpenTelemetry configuration that always executes.
      */
     @Bean
-    @ConditionalOnProperty(name = "warehouse.store.greptime.enabled", havingValue = "true")
-    public AutoConfigurationCustomizerProvider greptimeOtelCustomizer(GreptimeProperties greptimeProperties) {
-        log.info("GreptimeDB is enabled. Applying OpenTelemetry SDK customizations.");
-
+    public AutoConfigurationCustomizerProvider defaultOtelCustomizer() {
+        log.info("Applying default OpenTelemetry SDK customizations.");
         return providerCustomizer -> providerCustomizer
                 .addPropertiesCustomizer(sdkConfigProperties -> {
                     Map<String, String> newProperties = new HashMap<>();
                     newProperties.put("otel.metrics.exporter", "none");
-                    newProperties.put("otel.traces.exporter", "otlp");
+                    newProperties.put("otel.traces.exporter", "none");
                     newProperties.put("otel.logs.exporter", "none");
                     return newProperties;
                 })
                 .addResourceCustomizer((resource, configProperties) -> {
                     log.info("Customizing auto-configured OpenTelemetry Resource with service name: {}.", HERTZBEAT_SERVICE_NAME);
                     return resource.merge(Resource.builder().put(SERVICE_NAME, HERTZBEAT_SERVICE_NAME).build());
+                });
+    }
+
+    /**
+     * Provides GrepTimeDB-specific OpenTelemetry configuration when enabled.
+     */
+    @Bean
+    @ConditionalOnProperty(name = "warehouse.store.greptime.enabled", havingValue = "true")
+    public AutoConfigurationCustomizerProvider greptimeOtelCustomizer(GreptimeProperties greptimeProperties) {
+        log.info("GreptimeDB is enabled. Applying additional OpenTelemetry SDK customizations for GrepTimeDB.");
+        return providerCustomizer -> providerCustomizer
+                .addPropertiesCustomizer(sdkConfigProperties -> {
+                    Map<String, String> newProperties = new HashMap<>();
+                    newProperties.put("otel.traces.exporter", "otlp");
+                    return newProperties;
                 })
                 .addSpanExporterCustomizer((originalSpanExporter, configProperties) -> {
                     String traceEndpoint = greptimeProperties.httpEndpoint() + "/v1/otlp/v1/traces";


### PR DESCRIPTION

## What's changed?

<!-- Describe Your PR Here -->
#3437 

This PR improves the OpenTelemetry configuration by implementing a more elegant approach to prevent connection errors when external telemetry systems are not configured.

## Checklist

- [X]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
