### PR TITLE
[improvement] change column definitions for commonAnnotations and alertFingerprints to TEXT type

### DIFF
--- a/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/entity/alerter/GroupAlert.java
+++ b/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/entity/alerter/GroupAlert.java
@@ -81,12 +81,12 @@ public class GroupAlert {
 
     @Schema(title = "Common Annotations", example = "{\"summary\": \"High CPU usage detected\", \"description\": \"CPU usage is back to normal for server1\"}")
     @Convert(converter = JsonMapAttributeConverter.class)
-    @Column(length = 4096)
+    @Column(columnDefinition = "TEXT")
     private Map<String, String> commonAnnotations;
     
     @Schema(title = "Alert Fingerprints", example = "[\"dxsdfdsf\"]")
     @Convert(converter = JsonStringListAttributeConverter.class)
-    @Column(length = 8192)
+    @Column(columnDefinition = "TEXT")
     private List<String> alertFingerprints;
 
     @Schema(title = "The creator of this record", example = "tom")

--- a/hertzbeat-manager/src/main/resources/db/migration/h2/V172__update_column.sql
+++ b/hertzbeat-manager/src/main/resources/db/migration/h2/V172__update_column.sql
@@ -1,0 +1,24 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ensure every sql can rerun without error
+
+-- Modify common_annotations column to TEXT (H2 TEXT is equivalent to CLOB)
+ALTER TABLE HZB_ALERT_GROUP ALTER COLUMN common_annotations CLOB;
+
+-- Modify alert_fingerprints column to TEXT (H2 TEXT is equivalent to CLOB)  
+ALTER TABLE HZB_ALERT_GROUP ALTER COLUMN alert_fingerprints CLOB;

--- a/hertzbeat-manager/src/main/resources/db/migration/mysql/V172__update_column.sql
+++ b/hertzbeat-manager/src/main/resources/db/migration/mysql/V172__update_column.sql
@@ -1,0 +1,64 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ensure every sql can rerun without error
+
+-- Modify hzb_alert_group table columns to TEXT type to resolve MySQL row size limit issue
+
+DELIMITER //
+CREATE PROCEDURE ModifyGroupAlertColumns()
+BEGIN
+    DECLARE table_exists INT;
+    DECLARE col_exists INT;
+
+    -- Check if the table exists
+    SELECT COUNT(*) INTO table_exists 
+    FROM INFORMATION_SCHEMA.TABLES 
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'HZB_ALERT_GROUP';
+    
+    IF table_exists = 1 THEN
+        -- Check and modify common_annotations column to TEXT
+        SELECT COUNT(*) INTO col_exists 
+        FROM INFORMATION_SCHEMA.COLUMNS 
+        WHERE TABLE_SCHEMA = DATABASE() 
+        AND TABLE_NAME = 'HZB_ALERT_GROUP' 
+        AND COLUMN_NAME = 'common_annotations'
+        AND DATA_TYPE != 'text';
+        
+        IF col_exists = 1 THEN
+            ALTER TABLE HZB_ALERT_GROUP MODIFY COLUMN common_annotations TEXT;
+        END IF;
+        
+        -- Check and modify alert_fingerprints column to TEXT
+        SELECT COUNT(*) INTO col_exists 
+        FROM INFORMATION_SCHEMA.COLUMNS 
+        WHERE TABLE_SCHEMA = DATABASE() 
+        AND TABLE_NAME = 'HZB_ALERT_GROUP' 
+        AND COLUMN_NAME = 'alert_fingerprints'
+        AND DATA_TYPE != 'text';
+        
+        IF col_exists = 1 THEN
+            ALTER TABLE HZB_ALERT_GROUP MODIFY COLUMN alert_fingerprints TEXT;
+        END IF;
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL ModifyGroupAlertColumns();
+DROP PROCEDURE IF EXISTS ModifyGroupAlertColumns;
+COMMIT;

--- a/hertzbeat-manager/src/main/resources/db/migration/postgresql/V172__update_column.sql
+++ b/hertzbeat-manager/src/main/resources/db/migration/postgresql/V172__update_column.sql
@@ -1,0 +1,25 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- ensure every sql can rerun without error
+
+-- Modify hzb_alert_group table columns to TEXT type to resolve row size limit issue
+
+ALTER TABLE HZB_ALERT_GROUP ALTER COLUMN common_annotations TYPE TEXT;
+ALTER TABLE HZB_ALERT_GROUP ALTER COLUMN alert_fingerprints TYPE TEXT;
+
+commit;


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
#3454 

The MySQL row size limit issue has been resolved by:
- Changed commonAnnotations and alertFingerprints columns from VARCHAR(4096/8192) to TEXT type
- Added migration scripts for all three supported databases (MySQL, H2, PostgreSQL)

## Checklist

- [X]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
