### PR TITLE
[fix] Fix `Monitors` paging display.

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
@@ -137,7 +137,13 @@
   <div class="monitor-list-header">
     <div class="monitor-header-actions">
       <label nz-checkbox [(ngModel)]="checkedAll" (ngModelChange)="onAllChecked($event)"></label>
-      <nz-pagination [(nzPageIndex)]="pageIndex" [nzPageSize]="pageSize" [nzTotal]="total" (nzPageIndexChange)="onPageIndexChange($event)" nzSimple></nz-pagination>
+      <nz-pagination
+        [(nzPageIndex)]="pageIndex"
+        [nzPageSize]="pageSize"
+        [nzTotal]="total"
+        (nzPageIndexChange)="onPageIndexChange($event)"
+        nzSimple
+      ></nz-pagination>
     </div>
   </div>
 

--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.html
@@ -137,7 +137,7 @@
   <div class="monitor-list-header">
     <div class="monitor-header-actions">
       <label nz-checkbox [(ngModel)]="checkedAll" (ngModelChange)="onAllChecked($event)"></label>
-      <nz-pagination [(nzPageIndex)]="pageIndex" [nzTotal]="total" (nzPageIndexChange)="onPageIndexChange($event)" nzSimple></nz-pagination>
+      <nz-pagination [(nzPageIndex)]="pageIndex" [nzPageSize]="pageSize" [nzTotal]="total" (nzPageIndexChange)="onPageIndexChange($event)" nzSimple></nz-pagination>
     </div>
   </div>
 


### PR DESCRIPTION
## What's changed?
Please refer to: [#3464](https://github.com/apache/hertzbeat/issues/3464)

The Monitors page is missing `nzPageSize`, which results in an error in calculating the number of pages.


## Checklist

- [ x ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ x ]  I have written the necessary doc or comment.
- [ x ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

1、Before repair
<img width="1510" alt="iShot_2025-06-14_13 56 56" src="https://github.com/user-attachments/assets/e199f19a-479e-4f2c-9025-ab62cf6507d8" />

2、After repair
<img width="1508" alt="iShot_2025-06-14_13 53 31" src="https://github.com/user-attachments/assets/7cdc398e-005e-4bde-9460-5010d9488cf0" />
