### PR TITLE
[fix] antlr4 `vectors and` parse semantic fixes and optimizations

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/expr/AlertExpressionEvalVisitor.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/expr/AlertExpressionEvalVisitor.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Alert expression visitor implement
@@ -32,7 +34,9 @@ import java.util.Map;
 public class AlertExpressionEvalVisitor extends AlertExpressionBaseVisitor<List<Map<String, Object>>> {
 
     private static final String THRESHOLD = "__threshold__";
+    private static final String NAME = "__name__";
     private static final String VALUE = "__value__";
+    private static final String TIMESTAMP = "__timestamp__";
 
     private final QueryExecutor executor;
     private final CommonTokenStream tokens;
@@ -84,42 +88,26 @@ public class AlertExpressionEvalVisitor extends AlertExpressionBaseVisitor<List<
     public List<Map<String, Object>> visitAndExpr(AlertExpressionParser.AndExprContext ctx) {
         List<Map<String, Object>> leftOperand = visit(ctx.left);
         List<Map<String, Object>> rightOperand = visit(ctx.right);
+        List<Map<String, Object>> results = new ArrayList<>();
 
-        Map<String, Object> leftMap = null;
-        boolean leftMatch = false;
-        Map<String, Object> rightMap = null;
-        boolean rightMatch = false;
-        for (Map<String, Object> item : leftOperand) {
-            if (leftMap == null) {
-                leftMap = item;
+        // build a hash set of the right-side tag collection
+        Set<String> rightLabelsSet = rightOperand.stream()
+                .filter(item -> item.get(VALUE) != null)
+                .map(this::labelKey)
+                .collect(Collectors.toSet());
+
+        // iterate over the left side, O(1) match
+        for (Map<String, Object> leftItem : leftOperand) {
+            Object leftVal = leftItem.get(VALUE);
+            if (leftVal == null) {
+                continue;
             }
-            if (item.get(VALUE) != null) {
-                leftMap = item;
-                leftMatch = true;
-                break;
-            }
-        }
-        for (Map<String, Object> item : rightOperand) {
-            if (rightMap == null) {
-                rightMap = item;
-            }
-            if (item.get(VALUE) != null) {
-                rightMap = item;
-                rightMatch = true;
-                break;
+            String labelKey = labelKey(leftItem);
+            if (rightLabelsSet.contains(labelKey)) {
+                results.add(new HashMap<>(leftItem));
             }
         }
-        if (leftMatch && rightMatch) {
-            rightMap.putAll(leftMap);
-            return new LinkedList<>(List.of(rightMap));
-        } else if (leftMap != null) {
-            leftMap.put(VALUE, null);
-            return new LinkedList<>(List.of(leftMap));
-        } else if (rightMap != null) {
-            rightMap.put(VALUE, null);
-            return new LinkedList<>(List.of(rightMap));
-        }
-        return new LinkedList<>();
+        return results;
     }
 
     @Override
@@ -327,4 +315,20 @@ public class AlertExpressionEvalVisitor extends AlertExpressionBaseVisitor<List<
         String script = text.substring(1, text.length() - 1);
         return executor.execute(script);
     }
+
+    /**
+     * Generate tag key (excluding `__name__` and `__value__` and `__timestamp__`)
+     */
+    private String labelKey(Map<String, Object> labelsMap) {
+        if (null == labelsMap || labelsMap.isEmpty()) {
+            return "-";
+        }
+        String key = labelsMap.entrySet().stream()
+                .filter(e -> !e.getKey().equals(VALUE) && !e.getKey().equals(NAME) && !e.getKey().equals(TIMESTAMP))
+                .sorted(Map.Entry.comparingByKey())
+                .map(e -> e.getKey() + "=" + (e.getValue() == null ? "" : e.getValue()))
+                .collect(Collectors.joining(","));
+        return key.isEmpty() ? "-" : key;
+    }
+
 }

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/expr/AlertExpressionEvalVisitorTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/expr/AlertExpressionEvalVisitorTest.java
@@ -579,7 +579,6 @@ class AlertExpressionEvalVisitorTest {
         assertEquals(2, result.size());
         assertEquals(1307, result.get(0).get("__value__"));
         assertEquals(16, result.get(1).get("__value__"));
-        System.out.println();
     }
 
 

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/service/DataSourceServiceTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/service/DataSourceServiceTest.java
@@ -17,11 +17,6 @@
 
 package org.apache.hertzbeat.alert.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import java.util.HashMap;
-
 import com.github.benmanes.caffeine.cache.Cache;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -29,17 +24,24 @@ import org.apache.hertzbeat.alert.service.impl.DataSourceServiceImpl;
 import org.apache.hertzbeat.warehouse.db.QueryExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * test case for {@link DataSourceService}
  */
 class DataSourceServiceTest {
-    
+
     private DataSourceServiceImpl dataSourceService;
-    
+
     @BeforeEach
     void setUp() {
         dataSourceService = new DataSourceServiceImpl();
@@ -51,12 +53,12 @@ class DataSourceServiceTest {
                 new HashMap<>(Map.of("__value__", 100.0, "timestamp", 1343554, "instance", "node1")),
                 new HashMap<>(Map.of("__value__", 200.0, "timestamp", 1343555, "instance", "node2"))
         );
-        
+
         QueryExecutor mockExecutor = Mockito.mock(QueryExecutor.class);
         Mockito.when(mockExecutor.support("promql")).thenReturn(true);
         Mockito.when(mockExecutor.execute(Mockito.anyString())).thenReturn(prometheusData);
         dataSourceService.setExecutors(List.of(mockExecutor));
-        
+
         List<Map<String, Object>> result = dataSourceService.calculate("promql", "node_cpu_seconds_total > 150");
         assertEquals(2, result.size());
         assertNull(result.get(0).get("__value__"));
@@ -296,45 +298,36 @@ class DataSourceServiceTest {
     @Test
     void calculate15() {
         List<Map<String, Object>> prometheusData1 = List.of(
-                new HashMap<>(Map.of("__value__", 100.0, "timestamp", 1343554, "instance", "node1")),
-                new HashMap<>(Map.of("__value__", 200.0, "timestamp", 1343555, "instance", "node2"))
+                new HashMap<>(Map.of("__value__", 1))
         );
-        List<Map<String, Object>> prometheusData2 = List.of(
-                new HashMap<>(Map.of("__value__", 100.0, "timestamp", 1343554, "instance", "node1")),
-                new HashMap<>(Map.of("__value__", 200.0, "timestamp", 1343555, "instance", "node2"))
-        );
-
         QueryExecutor mockExecutor = Mockito.mock(QueryExecutor.class);
         Mockito.when(mockExecutor.support("promql")).thenReturn(true);
-        Mockito.when(mockExecutor.execute("node_cpu_seconds_total{mode=\"user\"}")).thenReturn(prometheusData1);
-        Mockito.when(mockExecutor.execute("node_cpu_seconds_total{mode=\"idle\"}")).thenReturn(prometheusData2);
+        Mockito.when(mockExecutor.execute("count(node_cpu_seconds_total{mode=\"user\"} > 250)")).thenReturn(prometheusData1);
+        Mockito.when(mockExecutor.execute("count(node_cpu_seconds_total{mode=\"idle\"} < 220 )")).thenReturn(new ArrayList<>());
         dataSourceService.setExecutors(List.of(mockExecutor));
 
-        List<Map<String, Object>> result = dataSourceService.calculate("promql", "node_cpu_seconds_total{mode=\"user\"} > 250 and node_cpu_seconds_total{mode=\"idle\"} < 220");
-        assertEquals(1, result.size());
-        assertNull(result.get(0).get("__value__"));
+        List<Map<String, Object>> result = dataSourceService.calculate("promql", "count(node_cpu_seconds_total{mode=\"user\"} > 250) > 0 and count(node_cpu_seconds_total{mode=\"idle\"} < 220 ) > 0");
+        assertEquals(0, result.size());
     }
 
     @Test
     void calculate16() {
         List<Map<String, Object>> prometheusData1 = List.of(
-                new HashMap<>(Map.of("__value__", 100.0, "timestamp", 1343554, "instance", "node1")),
-                new HashMap<>(Map.of("__value__", 200.0, "timestamp", 1343555, "instance", "node2"))
+                new HashMap<>(Map.of("__value__", 1))
         );
         List<Map<String, Object>> prometheusData2 = List.of(
-                new HashMap<>(Map.of("__value__", 100.0, "timestamp", 1343554, "instance", "node1")),
-                new HashMap<>(Map.of("__value__", 200.0, "timestamp", 1343555, "instance", "node2"))
+                new HashMap<>(Map.of("__value__", 1))
         );
 
         QueryExecutor mockExecutor = Mockito.mock(QueryExecutor.class);
         Mockito.when(mockExecutor.support("promql")).thenReturn(true);
-        Mockito.when(mockExecutor.execute("node_cpu_seconds_total{mode=\"user\"}")).thenReturn(prometheusData1);
-        Mockito.when(mockExecutor.execute("node_cpu_seconds_total{mode=\"idle\"}")).thenReturn(prometheusData2);
+        Mockito.when(mockExecutor.execute("count(node_cpu_seconds_total{mode=\"user\"} > 250)")).thenReturn(prometheusData1);
+        Mockito.when(mockExecutor.execute("count(node_cpu_seconds_total{mode=\"idle\"} < 220 )")).thenReturn(prometheusData2);
         dataSourceService.setExecutors(List.of(mockExecutor));
 
-        List<Map<String, Object>> result = dataSourceService.calculate("promql", "node_cpu_seconds_total{mode=\"user\"} > 50 and node_cpu_seconds_total{mode=\"idle\"} < 20");
+        List<Map<String, Object>> result = dataSourceService.calculate("promql", "count(node_cpu_seconds_total{mode=\"user\"} > 250) > 0 and count(node_cpu_seconds_total{mode=\"idle\"} < 220 ) > 0");
         assertEquals(1, result.size());
-        assertNull(result.get(0).get("__value__"));
+        assertNotNull(result.get(0).get("__value__"));
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

Please refer to: [#3480](https://github.com/apache/hertzbeat/issues/3480)

Main issue:
1. Only the first non-empty item of `leftOperand` and `rightOperand` was processed, merging once instead of intersecting all non-empty items, resulting in an incorrect outcome.
2. The tags are not aligned, and no matching is done for the tag sets; they are merged directly, which causes tag confusion and results in errors. This is because the semantics of `and` are based on the intersection of tag sets, and the result only retains the tags and values from the left side.

Modification details:
1. Fixed the semantic issue with `and`. For details, see: [Logical/set binary operators](https://prometheus.io/docs/prometheus/latest/querying/operators/#logicalset-binary-operators)
2. Optimize parsing and union matching processing performance.
3. Add/fix test cases and pass historical cases successfully .

<img width="1509" alt="iShot_2025-06-20_10 31 20" src="https://github.com/user-attachments/assets/2601c69c-153e-4e06-86b9-d0e5845bd129" />
<img width="1510" alt="iShot_2025-06-20_10 31 57" src="https://github.com/user-attachments/assets/65437a81-a1ae-4e90-b6fe-f595aebec1c3" />
<img width="1511" alt="iShot_2025-06-20_10 32 37" src="https://github.com/user-attachments/assets/fe29d111-876f-4c29-8370-3fede38458b5" />
<img width="808" alt="iShot_2025-06-20_10 38 30" src="https://github.com/user-attachments/assets/6e6aa08d-f1cb-4087-a709-d5b58e6b3dc8" />

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

