### PR TITLE
[fix] Fix antlr4 parsing of `or` and `unless` logical and set binary operators

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/expr/AlertExpressionEvalVisitor.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/expr/AlertExpressionEvalVisitor.java
@@ -115,48 +115,26 @@ public class AlertExpressionEvalVisitor extends AlertExpressionBaseVisitor<List<
         List<Map<String, Object>> leftOperand = visit(ctx.left);
         List<Map<String, Object>> rightOperand = visit(ctx.right);
 
-        Map<String, Object> leftMap = null;
-        boolean leftMatch = false;
-        Map<String, Object> rightMap = null;
-        boolean rightMatch = false;
-        for (Map<String, Object> item : leftOperand) {
-            if (leftMap == null) {
-                leftMap = item;
+        // build a hashMap of the left-hand label collection
+        Map<String, Map<String, Object>> leftLabelMap = leftOperand.stream()
+                .filter(item -> item.get(VALUE) != null)
+                .collect(Collectors.toMap(this::labelKey, HashMap::new, (k1, k2) -> k1));
+
+        // first add all the non-empty items on the left side
+        List<Map<String, Object>> results = new ArrayList<>(leftLabelMap.values());
+
+        // add the term that has a value on the right side and not on the left side
+        for (Map<String, Object> rightItem : rightOperand) {
+            Object rightVal = rightItem.get(VALUE);
+            if (rightVal == null) {
+                continue;
             }
-            if (item.get(VALUE) != null) {
-                leftMap = item;
-                leftMatch = true;
-                break;
-            }
-        }
-        for (Map<String, Object> item : rightOperand) {
-            if (rightMap == null) {
-                rightMap = item;
-            }
-            if (item.get(VALUE) != null) {
-                rightMap = item;
-                rightMatch = true;
-                break;
+            String key = labelKey(rightItem);
+            if (!leftLabelMap.containsKey(key)) {
+                results.add(new HashMap<>(rightItem));
             }
         }
-        if (leftMatch && rightMatch) {
-            rightMap.putAll(leftMap);
-            return new LinkedList<>(List.of(rightMap));
-        } else if (leftMatch) {
-            return new LinkedList<>(List.of(leftMap));
-        } else if (rightMatch) {
-            return new LinkedList<>(List.of(rightMap));
-        } else {
-            if (leftMap != null && rightMap != null) {
-                rightMap.putAll(leftMap);
-                return new LinkedList<>(List.of(rightMap));
-            } else if (leftMap != null) {
-                return new LinkedList<>(List.of(leftMap));
-            } else if (rightMap != null) {
-                return new LinkedList<>(List.of(rightMap));
-            }
-        }
-        return new LinkedList<>();
+        return results;
     }
 
     @Override

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/expr/AlertExpressionEvalVisitorTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/expr/AlertExpressionEvalVisitorTest.java
@@ -24,12 +24,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
 /**
@@ -311,10 +313,116 @@ class AlertExpressionEvalVisitorTest {
     }
 
     @Test
+    void testOrOpPromql() {
+        String promql = "http_server_requests_seconds_count > 10 or jvm_threads_states_threads > 0";
+
+        Map<String, Object> countValue1 = new HashMap<>() {
+            {
+                put("exception", "none");
+                put("instance", "host.docker.internal:8989");
+                put("__value__", 1307);
+                put("method", "GET");
+                put("__name__", "http_server_requests_seconds_count");
+                put("__timestamp__", "1.750320922467E9");
+                put("error", "none");
+                put("job", "spring-boot-app");
+                put("uri", "/actuator/prometheus");
+                put("outcome", "SUCCESS");
+                put("status", "200");
+            }
+        };
+
+        Map<String, Object> countValue2 = new HashMap<>() {
+            {
+                put("exception", "none");
+                put("instance", "host.docker.internal:8989");
+                put("__value__", 16);
+                put("method", "GET");
+                put("__name__", "http_server_requests_seconds_count");
+                put("__timestamp__", "1.750320922467E9");
+                put("error", "none");
+                put("job", "spring-boot-app");
+                put("uri", "/**");
+                put("outcome", "SUCCESS");
+                put("status", "200");
+            }
+        };
+
+        Map<String, Object> countValue3 = new HashMap<>() {
+            {
+                put("exception", "none");
+                put("instance", "host.docker.internal:8989");
+                put("__value__", 7);
+                put("method", "GET");
+                put("__name__", "http_server_requests_seconds_count");
+                put("__timestamp__", "1.750320922467E9");
+                put("error", "none");
+                put("job", "spring-boot-app");
+                put("uri", "/actuator/health");
+                put("outcome", "SUCCESS");
+                put("status", "200");
+            }
+        };
+
+        Map<String, Object> threadsValue1 = new HashMap<>() {
+            {
+                put("instance", "host.docker.internal:8989");
+                put("__value__", 10.007799125);
+                put("__name__", "jvm_threads_states_threads");
+                put("__timestamp__", "1.750320922467E9");
+                put("job", "spring-boot-app");
+                put("state=", "runnable");
+            }
+        };
+
+        Map<String, Object> threadsValue2 = new HashMap<>() {
+            {
+                put("instance", "host.docker.internal:8989");
+                put("__value__", 1);
+                put("__name__", "jvm_threads_states_threads");
+                put("__timestamp__", "1.750320922467E9");
+                put("job", "spring-boot-app");
+                put("state=", "timed-waiting");
+            }
+        };
+
+        Map<String, Object> threadsValue3 = new HashMap<>() {
+            {
+                put("instance", "host.docker.internal:8989");
+                put("__value__", 19.02);
+                put("__name__", "jvm_threads_states_threads");
+                put("__timestamp__", "1.750320922467E9");
+                put("job", "spring-boot-app");
+                put("state=", "waiting");
+            }
+        };
+
+        when(mockExecutor.execute("http_server_requests_seconds_count")).thenReturn(List.of(countValue1, countValue2, countValue3));
+        when(mockExecutor.execute("jvm_threads_states_threads")).thenReturn(List.of(threadsValue1, threadsValue2, threadsValue3));
+        List<Map<String, Object>> result = evaluate(promql);
+        assertEquals(5, result.size());
+        assertTrue(result.stream().allMatch(t -> null != t.get("__value__")));
+
+
+        when(mockExecutor.execute("jvm_threads_states_threads")).thenReturn(new ArrayList<>());
+        result = evaluate(promql);
+        assertEquals(2, result.size());
+        assertTrue(result.stream().allMatch(t -> null != t.get("__value__")));
+        assertEquals(1307, result.get(0).get("__value__"));
+
+        when(mockExecutor.execute("http_server_requests_seconds_count")).thenReturn(new ArrayList<>());
+        when(mockExecutor.execute("jvm_threads_states_threads")).thenReturn(List.of(threadsValue1, threadsValue2, threadsValue3));
+        result = evaluate(promql);
+        assertEquals(3, result.size());
+        assertTrue(result.stream().allMatch(t -> null != t.get("__value__")));
+        assertEquals(10.007799125, result.get(0).get("__value__"));
+    }
+
+    @Test
     void testMultipleUnlessConditions() {
-        when(mockExecutor.execute("metric1")).thenReturn(List.of(new HashMap<>(Map.of("__value__", 40.0))));
-        when(mockExecutor.execute("metric2")).thenReturn(List.of(new HashMap<>(Map.of("__value__", 50.0))));
-        when(mockExecutor.execute("metric3")).thenReturn(List.of(new HashMap<>(Map.of("__value__", 60.0))));
+        when(mockExecutor.execute("metric1")).thenReturn(List.of(new HashMap<>(Map.of("job", "api", "__value__", 40.0))));
+        when(mockExecutor.execute("metric2")).thenReturn(List.of(new HashMap<>(Map.of("job", "web", "__value__", 50.0))));
+        when(mockExecutor.execute("metric3")).thenReturn(List.of(new HashMap<>(Map.of("job", "api", "__value__", 60.0))));
         when(mockExecutor.execute("select cpu_usage from metrics where service = 'web'")).thenReturn(
                 List.of(new HashMap<>(Map.of("__value__", 40.0))));
         when(mockExecutor.execute("select memory_usage from metrics where service = 'db'")).thenReturn(
@@ -322,15 +430,13 @@ class AlertExpressionEvalVisitorTest {
         when(mockExecutor.execute("select disk_usage from metrics where service = 'cache'")).thenReturn(
                 List.of(new HashMap<>(Map.of("__value__", 60.0))));
         // promql
-        List<Map<String, Object>> result = evaluate("metric1 > 30 unless metric2 > 45 unless metric3 < 70");
-        assertEquals(1, result.size());
-        assertNull(result.get(0).get("__value__"));
+        List<Map<String, Object>> result = evaluate("(metric1 > 30 unless metric2 > 45) unless metric3 > 50");
+        assertEquals(0, result.size());
         // sql
-        result = evaluate("(select cpu_usage from metrics where service = 'web') > 30"
-                + " unless (select memory_usage from metrics where service = 'db') > 45"
-                + " unless (select disk_usage from metrics where service = 'cache') < 70");
-        assertEquals(1, result.size());
-        assertNull(result.get(0).get("__value__"));
+        result = evaluate("((select cpu_usage from metrics where service = 'web') > 30"
+                + " unless (select memory_usage from metrics where service = 'db') > 55)"
+                + " unless (select disk_usage from metrics where service = 'cache') > 50");
+        assertEquals(0, result.size());
     }
 
     @Test

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/service/DataSourceServiceTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/service/DataSourceServiceTest.java
@@ -392,8 +392,7 @@ class DataSourceServiceTest {
         dataSourceService.setExecutors(List.of(mockExecutor));
 
         List<Map<String, Object>> result = dataSourceService.calculate("promql", "node_cpu_seconds_total{mode=\"user\"} > 250 or node_cpu_seconds_total{mode=\"idle\"} < 20");
-        assertEquals(1, result.size());
-        assertNull(result.get(0).get("__value__"));
+        assertEquals(0, result.size());
     }
 
     @Test
@@ -414,8 +413,7 @@ class DataSourceServiceTest {
         dataSourceService.setExecutors(List.of(mockExecutor));
 
         List<Map<String, Object>> result = dataSourceService.calculate("promql", "node_cpu_seconds_total{mode=\"user\"} > 50 or node_cpu_seconds_total{mode=\"idle\"} < 320");
-        assertEquals(1, result.size());
-        assertNotNull(result.get(0).get("__value__"));
+        assertEquals(4, result.size());
     }
 
     @Test
@@ -436,8 +434,8 @@ class DataSourceServiceTest {
         dataSourceService.setExecutors(List.of(mockExecutor));
 
         List<Map<String, Object>> result = dataSourceService.calculate("promql", "node_cpu_seconds_total{mode=\"user\"} > 50 unless node_cpu_seconds_total{mode=\"idle\"} < 320");
-        assertEquals(1, result.size());
-        assertNull(result.get(0).get("__value__"));
+        assertEquals(2, result.size());
+        assertEquals(100.0, result.get(0).get("__value__"));
     }
 
     @Test
@@ -458,8 +456,8 @@ class DataSourceServiceTest {
         dataSourceService.setExecutors(List.of(mockExecutor));
 
         List<Map<String, Object>> result = dataSourceService.calculate("promql", "node_cpu_seconds_total{mode=\"user\"} > 50 unless node_cpu_seconds_total{mode=\"idle\"} < 20");
-        assertEquals(1, result.size());
-        assertNotNull(result.get(0).get("__value__"));
+        assertEquals(2, result.size());
+        assertEquals(100.0, result.get(0).get("__value__"));
     }
 
     @Test
@@ -480,8 +478,7 @@ class DataSourceServiceTest {
         dataSourceService.setExecutors(List.of(mockExecutor));
 
         List<Map<String, Object>> result = dataSourceService.calculate("promql", "node_cpu_seconds_total{mode=\"user\"} > 250 unless node_cpu_seconds_total{mode=\"idle\"} < 20");
-        assertEquals(1, result.size());
-        assertNull(result.get(0).get("__value__"));
+        assertEquals(0, result.size());
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

Please refer to: [#3482](https://github.com/apache/hertzbeat/pull/3482)

Reference: PR[#3482]

Modification details:
1. Fixed the semantic issue with `unless` /  `or`. For details, see: [Logical/set binary operators](https://prometheus.io/docs/prometheus/latest/querying/operators/#logicalset-binary-operators)
2. Add/fix test cases and pass historical cases successfully .

The effect after the fix is as follows：

UNLESS：
<img width="1511" alt="iShot_2025-06-21_00 33 10" src="https://github.com/user-attachments/assets/c2f03569-982e-483b-943a-0e50ef8a3491" />
<img width="1511" alt="iShot_2025-06-21_00 33 41" src="https://github.com/user-attachments/assets/8fcfe738-b173-4698-a1f7-439f688d2e4a" />
<img width="1510" alt="iShot_2025-06-21_00 41 22" src="https://github.com/user-attachments/assets/887fd39f-e124-4968-9984-3897b89d24a7" />

OR：
<img width="1511" alt="iShot_2025-06-21_00 42 07" src="https://github.com/user-attachments/assets/fd365cf1-70f1-4e4c-845b-ec44ccdb8e59" />
<img width="1511" alt="iShot_2025-06-21_12 20 23" src="https://github.com/user-attachments/assets/c6ee83aa-2dfa-49a4-bd1f-dcd2e3a96547" />
<img width="1510" alt="iShot_2025-06-21_00 45 48" src="https://github.com/user-attachments/assets/caad1943-3df6-43be-aebc-293cbfccd0f5" />

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
