### PR TITLE
[bugfix] Fix incorrect expression parsing in alert setting component

### DIFF
--- a/hertzbeat-manager/src/main/resources/define/app-hertzbeat_token.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-hertzbeat_token.yml
@@ -22,11 +22,13 @@ app: hertzbeat_token
 name:
   zh-CN: HertzBeat(Token)
   en-US: HertzBeat(Token)
+  ja-JP: HertzBeat(Token)
 # The description and help of this monitoring type
 help:
   zh-CN: Hertzbeat 对 HertzBeat监控(Token)进行测量监控。<br>您可以点击 “<i>新建 HertzBeat监控(Token)</i>” 并进行配置，或者选择“<i>更多操作</i>”，导入已有配置。
   en-US: Hertzbeat monitors HertzBeat Monitor(Token). You could click the "<i>New HertzBeat Monitor(Token)</i>" button and proceed with the configuration or import an existing setup through the "<i>More Actions</i>" menu.
   zh-TW: Hertzbeat對HertzBeat監控（Token）進行量測監控。<br>您可以點擊“<i>新建HertzBeat監控（Token）</i>”並進行配寘，或者選擇“<i>更多操作</i>”，導入已有配寘。
+  ja-JP: Hertzbeat は Hertzbeat(Token)の一般的なメトリック監視します。<br>「<i>新規 Apache Hertzbeat(Token)</i>」をクリックしてパラメタを設定した後、新規することができます。
 helpLink:
   zh-CN: https://hertzbeat.apache.org/zh-cn/docs/help/hertzbeat_token
   en-US: https://hertzbeat.apache.org/docs/help/hertzbeat_token
@@ -38,6 +40,7 @@ params:
     name:
       zh-CN: 目标Host
       en-US: Target Host
+      ja-JP: 目標ホスト
     # type-param field type(most mapping the html input type)
     type: host
     # required-true or false
@@ -46,6 +49,7 @@ params:
     name:
       zh-CN: 端口
       en-US: Port
+      ja-JP: ポート
     # type-param field type(most mapping the html input type)
     type: number
     # when type is number, range is required
@@ -57,6 +61,7 @@ params:
     name:
       zh-CN: 启动SSL
       en-US: SSL
+      ja-JP: SSL利用
     # type-param field type(boolean mapping the html switch tag)
     type: boolean
     required: false
@@ -64,6 +69,7 @@ params:
     name:
       zh-CN: Content-Type
       en-US: Content-Type
+      ja-JP: コンテンツタイプ
     type: text
     placeholder: 'Request Body Type'
     required: false
@@ -71,6 +77,7 @@ params:
     name:
       zh-CN: 请求BODY
       en-US: BODY
+      ja-JP: ボディ
     type: textarea
     placeholder: 'Available When POST PUT'
     required: false
@@ -81,6 +88,7 @@ metrics:
     i18n:
       zh-CN: 认证
       en-US: Auth
+      ja-JP: 認証
     # metrics scheduling priority(0->127)->(high->low), metrics with the same priority will be scheduled in parallel
     # priority 0's metrics is availability metrics, it will be scheduled first, only availability metrics collect success will the scheduling continue
     priority: 0
@@ -92,11 +100,13 @@ metrics:
         i18n:
           zh-CN: 令牌
           en-US: Token
+          ja-JP: トークン
       - field: refreshToken
         type: 1
         i18n:
           zh-CN: 刷新令牌
           en-US: Refresh Token
+          ja-JP: リフレッシュトークン
     # the protocol used for monitoring, eg: sql, ssh, http, telnet, wmi, snmp, sdk
     protocol: http
     # the config content when protocol is http
@@ -128,6 +138,7 @@ metrics:
     i18n:
       zh-CN: 概要信息
       en-US: Summary
+      ja-JP: 概要
     priority: 1
     fields:
       - field: app
@@ -136,26 +147,31 @@ metrics:
         i18n:
           zh-CN: 应用
           en-US: App
+          ja-JP: 応用
       - field: category
         type: 1
         i18n:
           zh-CN: 类别
           en-US: Category
+          ja-JP: カテゴリ
       - field: status
         type: 0
         i18n:
           zh-CN: 状态
           en-US: Status
+          ja-JP: ステータス
       - field: size
         type: 0
         i18n:
           zh-CN: 数量
           en-US: Size
+          ja-JP: サイズ
       - field: availableSize
         type: 0
         i18n:
           zh-CN: 可用数量
           en-US: Available Size
+          ja-JP: 利用可能なサイズ
     protocol: http
     http:
       host: ^_^host^_^
@@ -174,6 +190,7 @@ metrics:
     i18n:
       zh-CN: 内部队列
       en-US: Inner Queue
+      ja-JP: 内部キュー
     priority: 1
     fields:
       - field: responseTime
@@ -182,26 +199,31 @@ metrics:
         i18n:
           zh-CN: 响应时间
           en-US: Response Time
+          ja-JP: 応答時間
       - field: alertDataQueue
         type: 0
         i18n:
           zh-CN: 变更数据队列
           en-US: Alert Data Queue
+          ja-JP: アラートデータキュー
       - field: metricsDataToAlertQueue
         type: 0
         i18n:
           zh-CN: 指标数据到变更队列
           en-US: Metrics Data to Alert Queue
+          ja-JP: アラートキュー
       - field: metricsDataToPersistentStorageQueue
         type: 0
         i18n:
           zh-CN: 指标数据到持久化队列
           en-US: Metrics Data to Persistent Storage Queue
+          ja-JP: 永続ストレージキュー
       - field: metricsDataToMemoryStorageQueue
         type: 0
         i18n:
           zh-CN: 指标数据到内存存储队列
           en-US: Metrics Data to Memory Storage Queue
+          ja-JP: メモリストレージキュー
     protocol: http
     http:
       host: ^_^host^_^
@@ -221,6 +243,7 @@ metrics:
     i18n:
       zh-CN: 指标数据到内存存储队列
       en-US: Metrics Data to Memory Storage Queue
+      ja-JP: メモリストレージキュー
     visible: false
     priority: 2
     fields:
@@ -229,6 +252,7 @@ metrics:
         i18n:
           zh-CN: 状态
           en-US: State
+          ja-JP: 状態
     protocol: http
     http:
       host: ^_^host^_^
@@ -247,6 +271,7 @@ metrics:
     i18n:
       zh-CN: 线程
       en-US: Threads
+      ja-JP: スレッド
     priority: 3
     fields:
       - field: state
@@ -254,11 +279,13 @@ metrics:
         i18n:
           zh-CN: 状态
           en-US: State
+          ja-JP: 状態
       - field: number
         type: 0
         i18n:
           zh-CN: 数量
           en-US: Number
+          ja-JP: 総数
     aliasFields:
       - $.measurements[?(@.statistic == "VALUE")].value
     calculates:
@@ -282,6 +309,7 @@ metrics:
     i18n:
       zh-CN: 空间名称
       en-US: Space Name
+      ja-JP: スペース名
     visible: false
     priority: 4
     fields:
@@ -290,6 +318,7 @@ metrics:
         i18n:
           zh-CN: ID
           en-US: ID
+          ja-JP: ID
     protocol: http
     http:
       host: ^_^host^_^
@@ -308,6 +337,7 @@ metrics:
     i18n:
       zh-CN: 内存使用
       en-US: Memory Used
+      ja-JP: 使用済みのメモリ
     priority: 5
     fields:
       - field: space
@@ -315,12 +345,14 @@ metrics:
         i18n:
           zh-CN: 空间
           en-US: Space
+          ja-JP: スペース
       - field: mem_used
         type: 0
         unit: MB
         i18n:
           zh-CN: 内存使用量
           en-US: Memory Used
+          ja-JP: 使用済みのメモリ
     aliasFields:
       - $.measurements[?(@.statistic == "VALUE")].value
     calculates:

--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.ts
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.ts
@@ -1411,13 +1411,13 @@ export class AlertSettingComponent implements OnInit {
   }
 
   get monitorDataByLabel(): any[] {
-    return this.transferData.filter(item => 
-      item.labels.some((label: string) => this.selectedLabels.has(label))
-    ).map(item => ({
-      key: item.key,
-      title: item.title,
-      description: item.description,
-      labels: item.labels
-    }));
+    return this.transferData
+      .filter(item => item.labels.some((label: string) => this.selectedLabels.has(label)))
+      .map(item => ({
+        key: item.key,
+        title: item.title,
+        description: item.description,
+        labels: item.labels
+      }));
   }
 }

--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.ts
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.ts
@@ -959,7 +959,6 @@ export class AlertSettingComponent implements OnInit {
   selectedLabels: Set<string> = new Set(); // Selected labels
   inputLabelValue = '';
   labelInputElement!: ElementRef<HTMLInputElement>;
-  monitorDataByLabel: any[] = [];
 
   $asTransferItems = (data: unknown): TransferItem[] => data as TransferItem[];
   onConnectModalCancel() {
@@ -1000,7 +999,6 @@ export class AlertSettingComponent implements OnInit {
 
   handleDeleteLabel(removedLabel: string): void {
     this.selectedLabels.delete(removedLabel);
-    this.showMonitorByLabel();
   }
 
   showLabelInput(): void {
@@ -1014,21 +1012,8 @@ export class AlertSettingComponent implements OnInit {
     if (this.inputLabelValue && !this.selectedLabels.has(this.inputLabelValue)) {
       this.selectedLabels.add(this.inputLabelValue);
     }
-    this.showMonitorByLabel();
     this.inputLabelValue = '';
     this.labelInputVisible = false;
-  }
-
-  showMonitorByLabel(): void {
-    const monitorsByLabel = this.transferData.filter(item => item.labels.some((label: string) => this.selectedLabels.has(label)));
-    this.monitorDataByLabel = monitorsByLabel.map(item => {
-      return {
-        key: item.key,
-        title: item.title,
-        description: item.description,
-        labels: item.labels
-      };
-    });
   }
 
   onFilterLabelsChange(newLabels: string[], direction: string): void {
@@ -1188,8 +1173,8 @@ export class AlertSettingComponent implements OnInit {
         .replace(/^\s*&&\s*/, '')
         .replace(/\s*&&\s*$/, '')
         // Remove monitor label binding expressions
-        .replace(/&&\s*\(?(equals\(__labels__,\s*"[^"]+"\)(\s*or\s*equals\(__labels__,\s*"[^"]+"\))*)\)?/, '')
-        .replace(/\(?(equals\(__labels__,\s*"[^"]+"\)(\s*or\s*equals\(__labels__,\s*"[^"]+"\))*)\)?\s*&&\s*/, '')
+        .replace(/&&\s*\(?(contains\(__labels__,\s*"[^"]+"\)(\s*or\s*contains\(__labels__,\s*"[^"]+"\))*)\)?/, '')
+        .replace(/\(?(contains\(__labels__,\s*"[^"]+"\)(\s*or\s*contains\(__labels__,\s*"[^"]+"\))*)\)?\s*&&\s*/, '')
     );
   }
 
@@ -1301,7 +1286,7 @@ export class AlertSettingComponent implements OnInit {
 
   // Parse label from expression
   private parseLabelFromExpr(expr: string) {
-    const labelPattern = /equals\(__labels__,\s*"([^"]+)"\)/g;
+    const labelPattern = /contains\(__labels__,\s*"([^"]+)"\)/g;
     let match;
     this.selectedLabels.clear();
     while ((match = labelPattern.exec(expr)) !== null) {
@@ -1423,5 +1408,16 @@ export class AlertSettingComponent implements OnInit {
 
   onTextareaDragLeave(event: DragEvent): void {
     (event.target as HTMLElement).classList.remove('drag-over');
+  }
+
+  get monitorDataByLabel(): any[] {
+    return this.transferData.filter(item => 
+      item.labels.some((label: string) => this.selectedLabels.has(label))
+    ).map(item => ({
+      key: item.key,
+      title: item.title,
+      description: item.description,
+      labels: item.labels
+    }));
   }
 }


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
#3494 
This PR resolves a critical parsing error within the alert settings component. The error occurred when editing an existing threshold rule with `contains(__labels__,"xxx")`, causing the expression to be displayed incorrectly and making the rule uneditable.

The underlying issue was that the logic for extracting the user-facing expression (`user_expr`) from the full, raw expression (`raw_expr`) did not properly filter out internal clauses like `contains(__label__,"xxx")`. This resulted in a failed visualization of the metric expression.

test:

https://github.com/user-attachments/assets/3fdfd5fe-da59-43b4-b728-1c43c800d07e

## Checklist

- [X]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
