### PR TITLE
[feature] Support for `Periodic Threshold` preview.

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/AlertDefineService.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/AlertDefineService.java
@@ -18,11 +18,14 @@
 package org.apache.hertzbeat.alert.service;
 
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.List;
-import java.util.Set;
 import org.apache.hertzbeat.common.entity.alerter.AlertDefine;
+import org.apache.hertzbeat.common.support.exception.AlertExpressionException;
 import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Alarm define manager service
@@ -107,5 +110,11 @@ public interface AlertDefineService {
      * @return Real-time alarm definition list
      */
     List<AlertDefine> getRealTimeAlertDefines();
-    
+
+    /**
+     * Get define preview
+     * @return Data queried based on expressions
+     * @throws AlertExpressionException expression error
+     */
+    List<Map<String, Object>> getDefinePreview(String datasource, String type, String expr);
 }

--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/impl/DataSourceServiceImpl.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/impl/DataSourceServiceImpl.java
@@ -24,11 +24,14 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.apache.hertzbeat.alert.expr.AlertExpressionEvalVisitor;
 import org.apache.hertzbeat.alert.expr.AlertExpressionLexer;
 import org.apache.hertzbeat.alert.expr.AlertExpressionParser;
 import org.apache.hertzbeat.alert.service.DataSourceService;
+import org.apache.hertzbeat.common.support.exception.AlertExpressionException;
+import org.apache.hertzbeat.common.util.ResourceBundleUtil;
 import org.apache.hertzbeat.warehouse.db.QueryExecutor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -36,6 +39,7 @@ import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.Map;
+import java.util.ResourceBundle;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -44,6 +48,8 @@ import java.util.concurrent.TimeUnit;
 @Service
 @Slf4j
 public class DataSourceServiceImpl implements DataSourceService {
+
+    protected ResourceBundle bundle = ResourceBundleUtil.getBundle("alerter");
 
     @Setter
     @Autowired(required = false)
@@ -80,6 +86,9 @@ public class DataSourceServiceImpl implements DataSourceService {
         expr = expr.replaceAll("\\s+", " ");
         try {
             return evaluate(expr, executor);
+        } catch (AlertExpressionException ae) {
+            log.error("Calculate query parse error {}: {}", datasource, ae.getMessage());
+            throw ae;
         } catch (Exception e) {
             log.error("Error executing query on datasource {}: {}", datasource, e.getMessage());
             throw new RuntimeException("Query execution failed", e);
@@ -90,6 +99,9 @@ public class DataSourceServiceImpl implements DataSourceService {
         CommonTokenStream tokens = tokenStreamCache.get(expr, this::createTokenStream);
         AlertExpressionParser parser = new AlertExpressionParser(tokens);
         ParseTree tree = expressionCache.get(expr, e -> parser.expr());
+        if (null != tokens && tokens.LA(1) != Token.EOF) {
+            throw new AlertExpressionException(bundle.getString("alerter.calculate.parse.error"));
+        }
         AlertExpressionEvalVisitor visitor = new AlertExpressionEvalVisitor(executor, tokens);
         return visitor.visit(tree);
 

--- a/hertzbeat-alerter/src/main/resources/alerter_en_US.properties
+++ b/hertzbeat-alerter/src/main/resources/alerter_en_US.properties
@@ -32,3 +32,4 @@ alerter.notify.console = Console Login
 alerter.priority.0 = Emergency Alert
 alerter.priority.1 = Critical Alert
 alerter.priority.2 = Warning Alert
+alerter.calculate.parse.error = Expression is not fully parsed, may have syntax errors or incomplete inputs

--- a/hertzbeat-alerter/src/main/resources/alerter_zh_CN.properties
+++ b/hertzbeat-alerter/src/main/resources/alerter_zh_CN.properties
@@ -32,3 +32,4 @@ alerter.notify.console = 登入控制台
 alerter.priority.0 = 紧急告警
 alerter.priority.1 = 严重告警
 alerter.priority.2 = 警告告警
+alerter.calculate.parse.error = 表达式未完全解析，可能存在语法错误或输入不完整

--- a/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/support/exception/AlertExpressionException.java
+++ b/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/support/exception/AlertExpressionException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.common.support.exception;
+
+/**
+ * Alert expression exception
+ */
+public class AlertExpressionException extends RuntimeException {
+
+    public AlertExpressionException(String message) {
+        super(message);
+    }
+}

--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.html
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.html
@@ -448,6 +448,35 @@
             >
             </textarea>
           </nz-textarea-count>
+          <button nz-button nzType="primary" style="width: 100%; margin-bottom: 10px" (click)="onPreviewExpr()">
+            <i nz-icon nzType="eye" nzTheme="outline"></i>
+            {{ 'common.preview.button' | i18n }}
+          </button>
+          <div *ngIf="previewData && previewData.length > 0" class="preview-table-container">
+            <nz-table
+              #previewTable
+              [nzData]="previewData"
+              [nzSize]="'small'"
+              [nzLoading]="previewTableLoading"
+              [nzScroll]="previewData.length > 3 ? { x: '1240px', y: '180px' } : { x: '1240px' }"
+              [nzShowPagination]="false"
+            >
+              <thead>
+                <tr>
+                  <th *ngFor="let column of previewColumns" [nzWidth]="column.width || 'auto'">
+                    {{ column.title }}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr *ngFor="let data of previewTable.data">
+                  <td *ngFor="let column of previewColumns">
+                    {{ data[column.key] }}
+                  </td>
+                </tr>
+              </tbody>
+            </nz-table>
+          </div>
         </nz-form-control>
       </nz-form-item>
       <nz-form-item *ngIf="define.type === 'periodic'">

--- a/web-app/src/app/service/alert-define.service.ts
+++ b/web-app/src/app/service/alert-define.service.ts
@@ -67,6 +67,13 @@ export class AlertDefineService {
     return this.http.delete<Message<any>>(alert_defines_uri, options);
   }
 
+  public getMonitorsDefinePreview(datasource: string, type: string, expr: string): Observable<Message<any>> {
+    let httpParams = new HttpParams();
+    if (type != null) httpParams = httpParams.set('type', type);
+    if (expr != null) httpParams = httpParams.set('expr', expr);
+    return this.http.get<Message<any>>(`${alert_define_uri}/preview/${datasource}`, { params: httpParams });
+  }
+
   public getAlertDefines(search: string[] | undefined, pageIndex: number, pageSize: number): Observable<Message<Page<AlertDefine>>> {
     pageIndex = pageIndex ? pageIndex : 0;
     pageSize = pageSize ? pageSize : 8;

--- a/web-app/src/assets/i18n/en-US.json
+++ b/web-app/src/assets/i18n/en-US.json
@@ -469,6 +469,7 @@
   "common.name": "Metric Name",
   "common.new-time": "Create Time",
   "common.no": "No",
+  "common.preview.button": "Preview",
   "common.notice": "Notice",
   "common.notify.apply-fail": "Apply Failed!",
   "common.notify.apply-success": "Apply Success!",

--- a/web-app/src/assets/i18n/ja-JP.json
+++ b/web-app/src/assets/i18n/ja-JP.json
@@ -469,6 +469,7 @@
   "common.name": "メトリック名",
   "common.new-time": "作成時間",
   "common.no": "いいえ",
+  "common.preview.button": "プレビュー",
   "common.notice": "通知",
   "common.notify.apply-fail": "適用に失敗しました！",
   "common.notify.apply-success": "適用に成功しました！",

--- a/web-app/src/assets/i18n/pt-BR.json
+++ b/web-app/src/assets/i18n/pt-BR.json
@@ -864,6 +864,7 @@
   "common.total": "Total",
   "common.yes": "Sim",
   "common.no": "Não",
+  "common.preview.button": "Visualização",
   "common.enable": "Habilitar",
   "common.disable": "Desabilitar",
   "common.copy": "Copiar para a Área de Transferência",

--- a/web-app/src/assets/i18n/zh-CN.json
+++ b/web-app/src/assets/i18n/zh-CN.json
@@ -469,6 +469,7 @@
   "common.name": "指标名",
   "common.new-time": "创建时间",
   "common.no": "否",
+  "common.preview.button": "预览",
   "common.notice": "提醒",
   "common.notify.apply-fail": "应用失败!",
   "common.notify.apply-success": "应用成功!",

--- a/web-app/src/assets/i18n/zh-TW.json
+++ b/web-app/src/assets/i18n/zh-TW.json
@@ -468,6 +468,7 @@
   "common.name": "指標名",
   "common.new-time": "創建時間",
   "common.no": "否",
+  "common.preview.button": "預覽",
   "common.notice": "提醒",
   "common.notify.apply-fail": "應用失敗!",
   "common.notify.apply-success": "應用成功!",


### PR DESCRIPTION
## What's changed?

Support for `Periodic Threshold` preview.

For details:
1. Added `Threshold` -> `Periodic Threshold` preview, exception content support for internationalization
2. Add anltr4 `Look Ahead` method to determine if parsing is finished.
3. Add new test cases/fix test cases and go through the history of test cases successfully.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

<img width="1547" alt="iShot_2025-06-24_20 15 55" src="https://github.com/user-attachments/assets/d90b7fcf-c2b3-41a0-8778-a79ff77deb77" />
<img width="1547" alt="iShot_2025-06-24_20 21 25" src="https://github.com/user-attachments/assets/c7334a98-fe01-41ba-925d-508f9428e851" />


1、andOp
![and](https://github.com/user-attachments/assets/fb0d43bd-7646-492a-b341-2d40fe16f67e)

2、compareOp
![0](https://github.com/user-attachments/assets/7de8c071-4407-49c3-9c3a-e44687396656)

3、orOp
![OR](https://github.com/user-attachments/assets/51456e07-08a1-4890-a28d-db927d31807e)

