### PR TITLE
[MINOR UPDATE] recommend newer mysql connector jar

### DIFF
--- a/home/docs/help/mysql.md
+++ b/home/docs/help/mysql.md
@@ -9,7 +9,8 @@ keywords: [open source monitoring tool, open source database monitoring tool, mo
 
 ### Attention, Need Add MYSQL jdbc driver jar
 
-- Download the MYSQL jdbc driver jar package, such as mysql-connector-java-8.1.0.jar. <https://mvnrepository.com/artifact/com.mysql/mysql-connector-j/8.1.0>
+- Download the MYSQL jdbc driver jar package, such as mysql-connector-java-8.4.0.jar. <https://mvnrepository.com/artifact/com.mysql/mysql-connector-j/8.4.0>
+- It is recommended that you use the latest available mysql-connector-java version as there are regular security fixes to JDBC drivers.
 - Copy the jar package to the `hertzbeat/ext-lib` directory.
 - Restart the HertzBeat service.
 


### PR DESCRIPTION
## What's changed?

Relates to #3538 - your build uses 8.4.0 and there is a 9.3.0 release. 8.1.0 has CVE-2023-22102


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
