### PR TITLE
enable GitHub Dependabot to create PRs for security alerts but not for every dependency update

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -52,6 +52,9 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: true
         required_approving_review_count: 1
+  # enable GitHub Dependabot to create PRs for security alerts but not for every dependency update
+  dependabot_alerts:  true
+  dependabot_updates: false
 notifications:
   commits: notifications@hertzbeat.apache.org
   issues: notifications@hertzbeat.apache.org


### PR DESCRIPTION
## What's changed?

relates to #3000 

see https://github.com/apache/infrastructure-asfyaml/blob/main/README.md#depend_alerts


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
