### PR TITLE
[infra] upgrade openjdk image to fix Debian source failed

### DIFF
--- a/script/docker/collector/Dockerfile
+++ b/script/docker/collector/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM openjdk:17-slim-buster
+FROM openjdk:21-slim-bullseye
 
 MAINTAINER Apache HertzBeat "dev@hertzbeat.apache.org"
 

--- a/script/docker/server/Dockerfile
+++ b/script/docker/server/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM openjdk:17-slim-buster
+FROM openjdk:21-slim-bullseye
 
 MAINTAINER Apache HertzBeat "dev@hertzbeat.apache.org"
 


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

fix build image error 

```
#7 [2/8] RUN apt-get update && apt-get install -y openssh-server && apt-get install -y locales
#7 0.155 Ign:1 http://security.debian.org/debian-security buster/updates InRelease
#7 0.155 Ign:2 http://deb.debian.org/debian buster InRelease
#7 0.157 Err:3 http://security.debian.org/debian-security buster/updates Release
#7 0.157   404  Not Found [IP: 151.101.2.132 80]
#7 0.158 Ign:4 http://deb.debian.org/debian buster-updates InRelease
#7 0.160 Err:5 http://deb.debian.org/debian buster Release
#7 0.160   404  Not Found [IP: 199.232.98.132 80]
#7 0.165 Err:6 http://deb.debian.org/debian buster-updates Release
#7 0.165   404  Not Found [IP: 199.232.98.132 80]
#7 0.169 Reading package lists...
#7 0.175 E: The repository 'http://security.debian.org/debian-security buster/updates Release' does not have a Release file.
#7 0.175 E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
#7 0.175 E: The repository 'http://deb.debian.org/debian buster-updates Release' does not have a Release file.
#7 ERROR: process "/bin/sh -c apt-get update && apt-get install -y openssh-server && apt-get install -y locales" did not complete successfully: exit code: 100
------
```

## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
