### PR TITLE
[feat] Auto-generate AES key if not configured

### DIFF
--- a/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/config/CommonConfig.java
+++ b/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/config/CommonConfig.java
@@ -19,7 +19,6 @@ package org.apache.hertzbeat.common.config;
 
 import org.apache.hertzbeat.common.constants.ConfigConstants;
 import org.apache.hertzbeat.common.constants.SignConstants;
-import org.apache.hertzbeat.common.util.AesUtil;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
@@ -34,10 +33,4 @@ import org.springframework.context.annotation.ComponentScan;
         + ConfigConstants.FunctionModuleConstants.COMMON)
 @EnableConfigurationProperties(CommonProperties.class)
 public class CommonConfig {
-
-    public CommonConfig(CommonProperties commonProperties) {
-        if (commonProperties != null && commonProperties.getSecret() != null) {
-            AesUtil.setDefaultSecretKey(commonProperties.getSecret());
-        }
-    }
 }

--- a/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/util/AesUtil.java
+++ b/hertzbeat-common/src/main/java/org/apache/hertzbeat/common/util/AesUtil.java
@@ -37,7 +37,7 @@ public final class AesUtil {
      *  Default encryption key The AES encryption key is 16 bits by default.
      *  If the AES encryption key is larger than or smaller than 16 bits, an error message is displayed
      */
-    private static final String ENCODE_RULES = "tomSun28HaHaHaHa";
+    public static final String ENCODE_RULES = "tomSun28HaHaHaHa";
 
     /**
      * Default algorithm

--- a/hertzbeat-common/src/test/java/org/apache/hertzbeat/common/util/AesUtilTest.java
+++ b/hertzbeat-common/src/test/java/org/apache/hertzbeat/common/util/AesUtilTest.java
@@ -90,4 +90,15 @@ class AesUtilTest {
         assertFalse(isCiphertext(encryptedText, invalidKey));
     }
 
+    @Test
+    void testDefaultKeyCompatibility() {
+        // Test with default key
+        String originalText = "This is a secret message";
+        // encode use default secret key
+        String encryptedText = aesEncode(originalText, AesUtil.ENCODE_RULES);
+        // decode use new secret key
+        String decryptedText = aesDecode(encryptedText, "newkey1234567890");
+        // old data can decode with default secret key
+        assertEquals(originalText, decryptedText);
+    }
 }

--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/pojo/dto/SystemSecret.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/pojo/dto/SystemSecret.java
@@ -35,4 +35,9 @@ public class SystemSecret {
      * secret key for jwt
      */
     private String jwtSecret;
+
+    /**
+     * secret key for aes
+     */
+    private String aesSecret;
 }


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
This pull request enhances the AES encryption module to improve the initial setup process and default security posture.

1. If the application starts and cannot find a pre-existing AES key in the database and application.yml, it will now automatically generate a strong, unique key and persist it for future use. 

2. When decrypting data, the system will first try the new (auto-generated or user-configured) key. If decryption fails (e.g., on data encrypted with an older key), it will automatically fall back and attempt to decrypt using the legacy default key. This guarantees that old data remains accessible after the upgrade.


## Checklist

- [X]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [X]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
