### PR TITLE
[fix] Fixed issue where jdbc url was replaced

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/database/JdbcCommonCollect.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/database/JdbcCommonCollect.java
@@ -471,19 +471,19 @@ public class JdbcCommonCollect extends AbstractCollect {
             // remove special characters
             String cleanedUrl = jdbcProtocol.getUrl().replaceAll("[\\x00-\\x1F\\x7F\\xA0]", "");
             String url = recursiveDecode(cleanedUrl);
-            url = url.toLowerCase();
+            String urlLowerCase = url.toLowerCase();
             // url format check
-            if (!url.matches("^jdbc:[a-zA-Z0-9]+:([^\\s;]+)(;[^\\s;]+)*$")) {
+            if (!urlLowerCase.matches("^jdbc:[a-zA-Z0-9]+:([^\\s;]+)(;[^\\s;]+)*$")) {
                 throw new IllegalArgumentException("Invalid JDBC URL format");
             }
             // backlist check
             for (String keyword : BLACK_LIST) {
-                if (url.contains(keyword.toLowerCase())) {
+                if (urlLowerCase.contains(keyword.toLowerCase())) {
                     throw new IllegalArgumentException("Invalid JDBC URL: contains potentially malicious parameter: " + keyword);
                 }
             }
             // universal detection
-            String normalizedUrl = url.replaceAll("[\\x00-\\x1F\\x7F\\xA0]", " ").toLowerCase();
+            String normalizedUrl = urlLowerCase.replaceAll("[\\x00-\\x1F\\x7F\\xA0]", " ");
             // universal detection of JDBC injection and deserialization attacks
             if (normalizedUrl.matches(".*jndi\\s*[:=].*")
                     || normalizedUrl.matches(".*ldap\\s*[:=].*")
@@ -514,7 +514,7 @@ public class JdbcCommonCollect extends AbstractCollect {
                     }
                 }
             }
-            return normalizedUrl;
+            return url;
         }
         assert jdbcProtocol.getPlatform() != null;
         return switch (jdbcProtocol.getPlatform()) {


### PR DESCRIPTION
## What's changed?

Please refer to: [#3623](https://github.com/apache/hertzbeat/issues/3623)

The reason is that during JDBC URL security-related processing, the returned URL is replaced by the system. We believe that the case-sensitive recommendations in [connector-j-reference-jdbc-url-format](https://dev.mysql.com/doc/connectors/en/connector-j-reference-jdbc-url-format.html) should be followed to enable security-related processing without replacing user-entered URLs.

For details:
1. Fixed an issue where the Jdbc URL was replaced and ensured security-related processing.
2. Added a test case to verify whether the Jdbc URL is consistent with the user input after processing is complete.
3. Added test cases for security-related processing.


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.