### PR TITLE
fix: quote SQL strings containing JEXL reserved keywords in monitoring templates

### DIFF
--- a/hertzbeat-manager/src/main/resources/define/app-dm.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-dm.yml
@@ -161,7 +161,8 @@ metrics:
       # SQL Query Method：oneRow, multiRow, columns
       queryType: columns
       # script sql
-      sql: select PARA_NAME, PARA_VALUE from SYS."V$DM_INI" where PARA_NAME = 'MAX_SESSIONS'or PARA_NAME = 'CTL_PATH' or PARA_NAME = 'PORT_NUM';
+      sql: "'select PARA_NAME, PARA_VALUE from SYS.\"V$DM_INI\" where PARA_NAME = ''MAX_SESSIONS'' or PARA_NAME = ''CTL_PATH'' or PARA_NAME = ''PORT_NUM'';'"
+
       # JDBC url
       url: ^_^url^_^
 

--- a/hertzbeat-manager/src/main/resources/define/app-greenplum.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-greenplum.yml
@@ -162,7 +162,7 @@ metrics:
       # SQL Query Method：oneRow, multiRow, columns
       queryType: columns
       # sql
-      sql: select name, setting as value from pg_settings where name = 'max_connections' or name = 'server_version' or name = 'server_encoding' or name = 'port' or name = 'data_directory';
+      sql: "select name, setting as value from pg_settings where name = 'max_connections' or name = 'server_version' or name = 'server_encoding' or name = 'port' or name = 'data_directory';"
       # JDBC url
       url: ^_^url^_^
 
@@ -238,7 +238,7 @@ metrics:
       password: ^_^password^_^
       database: ^_^database^_^
       queryType: multiRow
-      sql: SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks, blks_read, blks_hit, blk_read_time, blk_write_time, stats_reset from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;
+      sql: "SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks, blks_read, blks_hit, blk_read_time, blk_write_time, stats_reset from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;"
       url: ^_^url^_^
 
   - name: activity
@@ -548,7 +548,7 @@ metrics:
       password: ^_^password^_^
       database: ^_^database^_^
       queryType: multiRow
-      sql: SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;
+      sql: "SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;"
       url: ^_^url^_^
 
   - name: slow_sql

--- a/hertzbeat-manager/src/main/resources/define/app-kingbase.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-kingbase.yml
@@ -162,7 +162,7 @@ metrics:
       # SQL Query Method：oneRow, multiRow, columns
       queryType: columns
       # sql
-      sql: select name, setting as value from pg_settings where name = 'max_connections' or name = 'server_version' or name = 'server_encoding' or name = 'port' or name = 'data_directory';
+      sql: "select name, setting as value from pg_settings where name = 'max_connections' or name = 'server_version' or name = 'server_encoding' or name = 'port' or name = 'data_directory';"
       # JDBC url
       url: ^_^url^_^
 
@@ -238,7 +238,7 @@ metrics:
       password: ^_^password^_^
       database: ^_^database^_^
       queryType: multiRow
-      sql: SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks, blks_read, blks_hit, blk_read_time, blk_write_time, stats_reset from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;
+      sql: "SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks, blks_read, blks_hit, blk_read_time, blk_write_time, stats_reset from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;"
       url: ^_^url^_^
 
   - name: activity
@@ -548,7 +548,7 @@ metrics:
       password: ^_^password^_^
       database: ^_^database^_^
       queryType: multiRow
-      sql: SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;
+      sql: "SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;"
       url: ^_^url^_^
 
   - name: slow_sql

--- a/hertzbeat-manager/src/main/resources/define/app-mariadb.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-mariadb.yml
@@ -194,7 +194,7 @@ metrics:
       # SQL Query Method：oneRow, multiRow, columns
       queryType: columns
       # sql
-      sql: show global variables where Variable_name like 'version%' or Variable_name = 'max_connections' or Variable_name = 'datadir' or Variable_name = 'port' or Variable_name = 'thread_cache_size' or Variable_name = 'table_open_cache' or Variable_name = 'innodb_buffer_pool_size';
+      sql: "show global variables where Variable_name like 'version%' or Variable_name = 'max_connections' or Variable_name = 'datadir' or Variable_name = 'port' or Variable_name = 'thread_cache_size' or Variable_name = 'table_open_cache' or Variable_name = 'innodb_buffer_pool_size';"
       # JDBC url
       url: ^_^url^_^
 
@@ -316,7 +316,7 @@ metrics:
       database: ^_^database^_^
       timeout: ^_^timeout^_^
       queryType: columns
-      sql: show global status where Variable_name = 'questions' or Variable_name = 'uptime';
+      sql: "show global status where Variable_name = 'questions' or Variable_name = 'uptime';"
       url: ^_^url^_^
 
   - name: innodb
@@ -496,7 +496,7 @@ metrics:
       database: ^_^database^_^
       timeout: ^_^timeout^_^
       queryType: columns
-      sql: show global status where Variable_name like 'thread%' or Variable_name = 'com_select' or Variable_name = 'com_insert' or Variable_name = 'com_update' or Variable_name = 'com_delete' or Variable_name = 'com_commit' or Variable_name = 'com_rollback' or Variable_name = 'questions' or Variable_name = 'uptime';
+      sql: "show global status where Variable_name like 'thread%' or Variable_name = 'com_select' or Variable_name = 'com_insert' or Variable_name = 'com_update' or Variable_name = 'com_delete' or Variable_name = 'com_commit' or Variable_name = 'com_rollback' or Variable_name = 'questions' or Variable_name = 'uptime';"
       url: ^_^url^_^
 
   - name: handler

--- a/hertzbeat-manager/src/main/resources/define/app-mysql.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-mysql.yml
@@ -299,7 +299,7 @@ metrics:
       # SQL Query Method：oneRow, multiRow, columns
       queryType: columns
       # sql
-      sql: show global variables where Variable_name like 'version%' or Variable_name = 'max_connections' or Variable_name = 'datadir' or Variable_name = 'port' or Variable_name = 'thread_cache_size' or Variable_name = 'table_open_cache' or Variable_name = 'innodb_buffer_pool_size';
+      sql: "show global variables where Variable_name like 'version%' or Variable_name = 'max_connections' or Variable_name = 'datadir' or Variable_name = 'port' or Variable_name = 'thread_cache_size' or Variable_name = 'table_open_cache' or Variable_name = 'innodb_buffer_pool_size';"
       # JDBC url
       url: ^_^url^_^
       sshTunnel:
@@ -441,7 +441,7 @@ metrics:
       database: ^_^database^_^
       timeout: ^_^timeout^_^
       queryType: columns
-      sql: show global status where Variable_name = 'questions' or Variable_name = 'uptime';
+      sql: "show global status where Variable_name = 'questions' or Variable_name = 'uptime';"
       url: ^_^url^_^
       sshTunnel:
         enable: ^_^enableSshTunnel^_^
@@ -641,7 +641,7 @@ metrics:
       database: ^_^database^_^
       timeout: ^_^timeout^_^
       queryType: columns
-      sql: show global status where Variable_name like 'thread%' or Variable_name = 'com_select' or Variable_name = 'com_insert' or Variable_name = 'com_update' or Variable_name = 'com_delete' or Variable_name = 'com_commit' or Variable_name = 'com_rollback' or Variable_name = 'questions' or Variable_name = 'uptime';
+      sql: "show global status where Variable_name like 'thread%' or Variable_name = 'com_select' or Variable_name = 'com_insert' or Variable_name = 'com_update' or Variable_name = 'com_delete' or Variable_name = 'com_commit' or Variable_name = 'com_rollback' or Variable_name = 'questions' or Variable_name = 'uptime';"
       url: ^_^url^_^
       sshTunnel:
         enable: ^_^enableSshTunnel^_^

--- a/hertzbeat-manager/src/main/resources/define/app-oceanbase.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-oceanbase.yml
@@ -192,7 +192,7 @@ metrics:
       # SQL Query Method：oneRow, multiRow, columns
       queryType: columns
       # sql
-      sql: show global variables where Variable_name like 'version%' or Variable_name = 'max_connections' or Variable_name = 'datadir' ;
+      sql: "show global variables where Variable_name like 'version%' or Variable_name = 'max_connections' or Variable_name = 'datadir' ;"
       # JDBC url
       url: ^_^url^_^
   # metrics - tenant

--- a/hertzbeat-manager/src/main/resources/define/app-opengauss.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-opengauss.yml
@@ -133,7 +133,7 @@ metrics:
       # SQL query method: oneRow, multiRow, columns
       queryType: columns
       # sql
-      sql: select name, setting as value from pg_settings where name = 'max_connections' or name = 'server_version' or name = 'server_encoding' or name = 'port' or name = 'data_directory';
+      sql: "select name, setting as value from pg_settings where name = 'max_connections' or name = 'server_version' or name = 'server_encoding' or name = 'port' or name = 'data_directory';"
       url: ^_^url^_^
 
   - name: state
@@ -203,7 +203,7 @@ metrics:
       # SQL query method: oneRow, multiRow, columns
       queryType: multiRow
       # sql
-      sql: SELECT COALESCE(datname,'shared-object') as name, conflicts, deadlocks, blks_read, blks_hit, blk_read_time, blk_write_time, stats_reset from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;
+      sql: "SELECT COALESCE(datname,'shared-object') as name, conflicts, deadlocks, blks_read, blks_hit, blk_read_time, blk_write_time, stats_reset from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;"
       url: ^_^url^_^
 
   - name: activity

--- a/hertzbeat-manager/src/main/resources/define/app-oracle.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-oracle.yml
@@ -411,7 +411,7 @@ metrics:
       timeout: ^_^timeout^_^
       reuseConnection: ^_^reuseConnection^_^
       queryType: columns
-      sql: select metric_name, value from gv$sysmetric where metric_name = 'I/O Megabytes per Second' or  metric_name = 'User Transaction Per Sec' or metric_name = 'I/O Requests per Second'
+      sql: "select metric_name, value from gv$sysmetric where metric_name = 'I/O Megabytes per Second' or  metric_name = 'User Transaction Per Sec' or metric_name = 'I/O Requests per Second'"
       url: ^_^url^_^
 
 
@@ -540,7 +540,7 @@ metrics:
       timeout: ^_^timeout^_^
       reuseConnection: ^_^reuseConnection^_^
       queryType: columns
-      sql: select metric_name, value from gv$sysmetric where metric_name = 'User Commits Per Sec' or  metric_name = 'User Rollbacks Per Sec'
+      sql: "select metric_name, value from gv$sysmetric where metric_name = 'User Commits Per Sec' or  metric_name = 'User Rollbacks Per Sec'"
       url: ^_^url^_^
 
   - name: wait
@@ -669,7 +669,7 @@ metrics:
       timeout: ^_^timeout^_^
       reuseConnection: ^_^reuseConnection^_^
       queryType: multiRow
-      sql: select stat_name as type, value as num from v$osstat where stat_name like '%CPU%' or stat_name like '%TIME'
+      sql: "select stat_name as type, value as num from v$osstat where stat_name like '%CPU%' or stat_name like '%TIME'"
       url: ^_^url^_^
 
   - name: mem_stats

--- a/hertzbeat-manager/src/main/resources/define/app-postgresql.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-postgresql.yml
@@ -243,7 +243,7 @@ metrics:
       # SQL Query Method：oneRow, multiRow, columns
       queryType: columns
       # sql
-      sql: select name, setting as value from pg_settings where name = 'max_connections' or name = 'server_version' or name = 'server_encoding' or name = 'port' or name = 'data_directory';
+      sql: "select name, setting as value from pg_settings where name = 'max_connections' or name = 'server_version' or name = 'server_encoding' or name = 'port' or name = 'data_directory';"
       # JDBC url
       url: ^_^url^_^
       sshTunnel:
@@ -329,7 +329,7 @@ metrics:
       password: ^_^password^_^
       database: ^_^database^_^
       queryType: multiRow
-      sql: SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks, blks_read, blks_hit, blk_read_time, blk_write_time, stats_reset from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;
+      sql: "SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks, blks_read, blks_hit, blk_read_time, blk_write_time, stats_reset from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;"
       url: ^_^url^_^
       sshTunnel:
         enable: ^_^enableSshTunnel^_^
@@ -719,7 +719,7 @@ metrics:
       password: ^_^password^_^
       database: ^_^database^_^
       queryType: multiRow
-      sql: SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;
+      sql: "SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;"
       url: ^_^url^_^
       sshTunnel:
         enable: ^_^enableSshTunnel^_^

--- a/hertzbeat-manager/src/main/resources/define/app-tidb.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-tidb.yml
@@ -314,7 +314,7 @@ metrics:
       # SQL Query Method：oneRow, multiRow, columns
       queryType: columns
       # sql
-      sql: show global variables where Variable_name like 'version%' or Variable_name = 'max_connections' or Variable_name = 'datadir' or Variable_name = 'port';
+      sql: "show global variables where Variable_name like 'version%' or Variable_name = 'max_connections' or Variable_name = 'datadir' or Variable_name = 'port';"
       # JDBC url
       url: ^_^url^_^
 

--- a/hertzbeat-manager/src/main/resources/define/app-vastbase.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-vastbase.yml
@@ -147,7 +147,7 @@ metrics:
       # SQL Query Method：oneRow, multiRow, columns
       queryType: columns
       # sql
-      sql: select name, setting as value from pg_settings where name = 'max_connections' or name = 'server_version' or name = 'server_encoding' or name = 'port' or name = 'data_directory';
+      sql: "select name, setting as value from pg_settings where name = 'max_connections' or name = 'server_version' or name = 'server_encoding' or name = 'port' or name = 'data_directory';"
       # JDBC url
       url: ^_^url^_^
 
@@ -214,7 +214,7 @@ metrics:
       password: ^_^password^_^
       database: ^_^database^_^
       queryType: multiRow
-      sql: SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks, blks_read, blks_hit, blk_read_time, blk_write_time, stats_reset from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;
+      sql: "SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks, blks_read, blks_hit, blk_read_time, blk_write_time, stats_reset from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;"
       url: ^_^url^_^
 
   - name: activity
@@ -493,7 +493,7 @@ metrics:
       password: ^_^password^_^
       database: ^_^database^_^
       queryType: multiRow
-      sql: SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;
+      sql: "SELECT COALESCE(datname,'shared-object') as db_name, conflicts, deadlocks from pg_stat_database where (datname != 'template1' and datname != 'template0') or datname is null;"
       url: ^_^url^_^
 
   - name: slow_sql


### PR DESCRIPTION
This PR fixes potential parsing issues caused by JEXL reserved keywords in SQL strings in monitoring templates.
Changes:
- Added quotes around SQL strings containing JEXL reserved keywords.
- Updated 11 monitoring template files.

Related to issue: #3630