### PR TITLE
Issue 3630 hertzbeat

### DIFF
--- a/hertzbeat-manager/src/main/resources/define/app-hertzbeat.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-hertzbeat.yml
@@ -62,6 +62,7 @@ params:
     type: number
     required: false
     hide: true
+    defaultValue: 6000
   - field: authType
     name:
       zh-CN: 认证方式
@@ -125,7 +126,7 @@ metrics:
           zh-CN: 状态
           en-US: Status
           ja-JP: ステータス
-      - field: size
+      - field: Size
         type: 0
         i18n:
           zh-CN: 数量
@@ -137,6 +138,18 @@ metrics:
           zh-CN: 可用数量
           en-US: Available Size
           ja-JP: 利用可能なサイズ
+    aliasFields:
+      - $.app
+      - $.category
+      - $.status
+      - $.size
+      - $.availableSize
+    calculates:
+      - app=$.app
+      - category=$.category
+      - status=$.status
+      - Size=$.size
+      - availableSize=$.availableSize
     #  the protocol used for monitoring, eg: sql, ssh, http, telnet, wmi, snmp, sdk, we use HTTP protocol here
     protocol: http
     # the config content when protocol is http

--- a/hertzbeat-manager/src/main/resources/define/app-hertzbeat_token.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-hertzbeat_token.yml
@@ -160,7 +160,7 @@ metrics:
           zh-CN: 状态
           en-US: Status
           ja-JP: ステータス
-      - field: size
+      - field: Size
         type: 0
         i18n:
           zh-CN: 数量
@@ -172,6 +172,18 @@ metrics:
           zh-CN: 可用数量
           en-US: Available Size
           ja-JP: 利用可能なサイズ
+    aliasFields:
+      - $.app
+      - $.category
+      - $.status
+      - $.size
+      - $.availableSize
+    calculates:
+      - app=$.app
+      - category=$.category
+      - status=$.status
+      - Size=$.size
+      - availableSize=$.availableSize
     protocol: http
     http:
       host: ^_^host^_^


### PR DESCRIPTION
## What's changed?

Related issue: #3630 

- Those template only contains the `size` keyword, and use `Size` to replace the keyword `size`

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have added the necessary unit tests and all cases have passed.

## Reproduce

An error message appears when saving the template.

<img width="1676" height="349" alt="1-0" src="https://github.com/user-attachments/assets/aacb07ae-30ca-4387-b1f3-87c2c1fb8f09" />


## Repair Result

> HertzBeat version: `1.7.2`

- Template saved successfully.
- Run unit test `YamlCheckScript#checkYaml()` method successful.
- Verify that the indicator data is normal, that threshold alarms are normal, and that the test cases pass.

#### app-hertzbeat

<img width="1681" height="855" alt="1-1" src="https://github.com/user-attachments/assets/4b940b61-8fb5-483d-bed8-a18de872c20d" />

<img width="1681" height="1436" alt="1-3" src="https://github.com/user-attachments/assets/3bf534b8-6ec7-4fff-80f1-33c9b9bc5dfb" />

<img width="1671" height="729" alt="1-2" src="https://github.com/user-attachments/assets/2594cb44-0018-4f5e-ada4-96aad59a6529" />


#### app-hertzbeat_token

<img width="1679" height="1061" alt="2-0" src="https://github.com/user-attachments/assets/21328a79-ce52-44fb-a4f7-d653a5060710" />

<img width="1676" height="979" alt="2-1" src="https://github.com/user-attachments/assets/de2704ef-d212-4f6b-8f60-36a02f7325c4" />

<img width="1676" height="783" alt="2-3" src="https://github.com/user-attachments/assets/7c209745-bd77-4bce-8dda-421d0288af94" />


