### PR TITLE
[bugfix] fixed jexl keyword issue in windows monitoring template

### DIFF
--- a/hertzbeat-manager/src/main/resources/define/app-windows.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-windows.yml
@@ -316,7 +316,7 @@ metrics:
         type: 0
         i18n:
           zh-CN: 编号
-          en-US: 编号
+          en-US: Index
       - field: hrSWInstalledName
         type: 1
         i18n:
@@ -357,14 +357,14 @@ metrics:
         type: 0
         i18n:
           zh-CN: 编号
-          en-US: 编号
+          en-US: Index
       - field: descr
         type: 1
         i18n:
           zh-CN: 存储描述
           en-US: Storage Description
         label: true
-      - field: size
+      - field: Size
         i18n:
           zh-CN: 存储大小
           en-US: Storage Size
@@ -400,7 +400,7 @@ metrics:
     calculates:
       - index=hrStorageIndex
       - descr=hrStorageDescr
-      - size=hrStorageSize * hrStorageAllocationUnits
+      - Size=hrStorageSize * hrStorageAllocationUnits
       - free=(hrStorageSize - hrStorageUsed) * hrStorageAllocationUnits
       - used=hrStorageUsed * hrStorageAllocationUnits
       - usage= hrStorageUsed / hrStorageSize * 100


### PR DESCRIPTION
## What's changed?

Related issue: #3630 

- Those template only contains the `size` keyword, and use `Size` to replace the keyword `size`
- fixed i18n en-US

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have added the necessary unit tests and all cases have passed.

## Reproduce

An error message appears when saving the template.

<img width="1677" height="517" alt="1-0" src="https://github.com/user-attachments/assets/2677f6a0-a5ff-436e-b5dc-888d319157a3" />


## Repair Result

> HertzBeat version: `1.7.2`

- Template saved successfully.
- Run unit test `YamlCheckScript#checkYaml()` method successful.
- Verify that the indicator data is normal, that threshold alarms are normal, and that the test cases pass.

<img width="1668" height="497" alt="1-1" src="https://github.com/user-attachments/assets/7af48395-7c98-4ea5-b5be-d074bf47cefb" />

<img width="1679" height="1302" alt="1-2" src="https://github.com/user-attachments/assets/0ddc93cd-f627-4480-81a0-1f9945cdcb39" />

<img width="1657" height="722" alt="1-3" src="https://github.com/user-attachments/assets/ac7aaf4f-73e7-4190-a576-ecbf0eca8cac" />
