### PR TITLE
[bugfix] fixed jexl keyword issue in spring_gateway monitoring template

### DIFF
--- a/hertzbeat-manager/src/main/resources/define/app-spring_gateway.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-spring_gateway.yml
@@ -19,15 +19,15 @@ category: mid
 app: spring_gateway
 # The monitoring i18n name
 name:
-  zh-CN: SpringGateway
-  en-US: SpringGateway
-  ja-JP: SpringGateway
+  zh-CN: Spring Cloud Gateway
+  en-US: Spring Cloud Gateway
+  ja-JP: Spring Cloud Gateway
 # The description and help of this monitoring type
 help:
-  zh-CN: HertzBeat 对 <a class='help_module_content' href='https://www.tutorialspoint.com/spring_boot/spring_boot_actuator.htm'> SpringBoot Actuator </a> 暴露的通用性能指标(globalfilters、routefilters、refresh、routes)进行采集监控。<span class='help_module_span'>注意⚠️：如果要监控 SpringGateway 中的信息，需要您的 SpringGateway 应用集成并开启 SpringBoot Actuator, <a class='help_module_content'  href='https://cloud.spring.io/spring-cloud-gateway/multi/multi__actuator_api.html'>点击查看具体步骤</a>。</span>
-  en-US: HertzBeat collect and monitors SpringGateway through general performance metric that exposed by the SpringBoot Actuator. <br><span class='help_module_span'><br>Note⚠️:You should make sure that your SpringGateway application have already integrated and enabled the SpringBoot Actuator, <a class='help_module_content'  href='https://cloud.spring.io/spring-cloud-gateway/multi/multi__actuator_api.html'>click here to see the specific steps.</a></span>
-  zh-TW: HertzBeat 對 <a class='help_module_content' href='https://www.tutorialspoint.com/spring_boot/spring_boot_actuator.htm'> SpringBoot Actuator </a>暴露的通用性能指標（globalfilters、routefilters、refresh、routes）進行採集監控。<span class='help_module_span'>注意⚠️：如果要監控SpringGateway中的指標，需要您的SpringGateway應用集成並開啟SpringBoot Actuator，<a class='help_module_content' href='https://cloud.spring.io/spring-cloud-gateway/multi/multi__actuator_api.html'>點擊查看具體步驟</a>。</span>
-  ja-JP: HertzBeat は <a class='help_module_content' href='https://www.tutorialspoint.com/spring_boot/spring_boot_actuator.htm'> SpringBoot Actuator </a> の一般的なパフォーマンスのメトリクスを監視します。<span class='help_module_span'>⚠️注意：SpringGateway で SpringBoot Actuatorを有効にする必要があります。<a class='help_module_content' href='https://cloud.spring.io/spring-cloud-gateway/multi/multi__actuator_api.html'>クリックしてガイドを見ます</a>。</span>
+  zh-CN: HertzBeat 对 <a class='help_module_content' href='https://www.tutorialspoint.com/spring_boot/spring_boot_actuator.htm'> SpringBoot Actuator </a> 暴露的通用性能指标(globalfilters、routefilters、refresh、routes)进行采集监控。<span class='help_module_span'>注意⚠️：如果要监控 Spring Cloud Gateway  中的信息，需要您的 Spring Cloud Gateway  应用集成并开启 SpringBoot Actuator, <a class='help_module_content'  href='https://cloud.spring.io/spring-cloud-gateway/multi/multi__actuator_api.html'>点击查看具体步骤</a>。</span>
+  en-US: HertzBeat collect and monitors SpringGateway through general performance metric that exposed by the SpringBoot Actuator. <br><span class='help_module_span'><br>Note⚠️:You should make sure that your Spring Cloud Gateway  application have already integrated and enabled the SpringBoot Actuator, <a class='help_module_content'  href='https://cloud.spring.io/spring-cloud-gateway/multi/multi__actuator_api.html'>click here to see the specific steps.</a></span>
+  zh-TW: HertzBeat 對 <a class='help_module_content' href='https://www.tutorialspoint.com/spring_boot/spring_boot_actuator.htm'> SpringBoot Actuator </a>暴露的通用性能指標（globalfilters、routefilters、refresh、routes）進行採集監控。<span class='help_module_span'>注意⚠️：如果要監控 Spring Cloud Gateway  中的指標，需要您的 Spring Cloud Gateway  應用集成並開啟SpringBoot Actuator，<a class='help_module_content' href='https://cloud.spring.io/spring-cloud-gateway/multi/multi__actuator_api.html'>點擊查看具體步驟</a>。</span>
+  ja-JP: HertzBeat は <a class='help_module_content' href='https://www.tutorialspoint.com/spring_boot/spring_boot_actuator.htm'> SpringBoot Actuator </a> の一般的なパフォーマンスのメトリクスを監視します。<span class='help_module_span'>⚠️注意：Spring Cloud Gateway  で SpringBoot Actuatorを有効にする必要があります。<a class='help_module_content' href='https://cloud.spring.io/spring-cloud-gateway/multi/multi__actuator_api.html'>クリックしてガイドを見ます</a>。</span>
 helpLink:
   zh-CN: https://hertzbeat.apache.org/zh-cn/docs/help/spring_gateway
   en-US: https://hertzbeat.apache.org/docs/help/spring_gateway
@@ -284,7 +284,7 @@ metrics:
           en-US: State
           ja-JP: 状態
         label: true
-      - field: size
+      - field: Size
         type: 0
         i18n:
           zh-CN: 数量
@@ -294,7 +294,7 @@ metrics:
       - $.measurements[?(@.statistic == "VALUE")].value
     calculates:
       - state='^o^state^o^'
-      - size=$.measurements[?(@.statistic == "VALUE")].value
+      - Size=$.measurements[?(@.statistic == "VALUE")].value
     protocol: http
     http:
       host: ^_^host^_^

--- a/home/docs/help/spring_gateway.md
+++ b/home/docs/help/spring_gateway.md
@@ -1,15 +1,15 @@
 ---
 id: spring_gateway 
-Title: Monitoring Spring Gateway   
-sidebar_label: Spring Gateway
-keywords: [open source monitoring tool, open source spring gateway monitoring tool, monitoring spring gateway metrics]
+Title: Monitoring Spring Cloud Gateway
+sidebar_label: Spring Cloud Gateway
+keywords: [open source monitoring tool, open source Spring Cloud Gateway monitoring tool, monitoring Spring Cloud Gateway metrics]
 ---
 
 > Collect and monitor the general performance metrics exposed by the SpringBoot actuator.
 
 ## Pre-monitoring operations
 
-If you want to monitor information in 'Spring Gateway' with this monitoring type, you need to integrate your SpringBoot application and enable the SpringBoot Actuator.
+If you want to monitor information in `Spring Cloud Gateway` with this monitoring type, you need to integrate your `Spring Cloud Gateway` application and enable the SpringBoot Actuator.
 
 **1、Add POM .XML dependencies:**
 
@@ -26,25 +26,26 @@ If you want to monitor information in 'Spring Gateway' with this monitoring type
 management:
   endpoint:
     gateway:
-      enabled: true # default value
+      enabled: true
+    env:
+      show-values: ALWAYS
   endpoints:
     web:
       exposure:
-        include: '*'
-    enabled-by-default: on
+        include: "*"
 ```
 
 ### Configure parameters
 
-|       Parameter name        |                                                    Parameter Help describes the                                                     |
-|-----------------------------|-------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
-| Monitor Host                | THE MONITORED PEER IPV4, IPV6 OR DOMAIN NAME. Note ⚠️ that there are no protocol headers (eg: https://, http://).                   |
-| Monitoring Name             | A name that identifies this monitoring that needs to be unique.                                                                     |
-| Port                        | The default port provided by the database is 8080.                                                                                  |
-| Enable HTTPS                | Whether to access the website through HTTPS, please note that ⚠️ when HTTPS is enabled, the default port needs to be changed to 443 |
-| The acquisition interval is | Monitor the periodic data acquisition interval, in seconds, and the minimum interval that can be set is 30 seconds                  |
-| Whether to probe the        | Whether to check the availability of the monitoring before adding a monitoring is successful, and the new modification operation    | will continue only if the probe is successful |
-| Description Comment         | For more information identifying and describing the remarks for this monitoring, users can remark the information here              |
+| Parameter name              | Parameter Help describes the                                                                                                                                                   | 
+|-----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Monitor Host                | THE MONITORED PEER IPV4, IPV6 OR DOMAIN NAME. Note ⚠️ that there are no protocol headers (eg: https://, http://).                                                              | 
+| Monitoring Name             | A name that identifies this monitoring that needs to be unique.                                                                                                                | 
+| Port                        | The default port provided by the database is 8080.                                                                                                                             |
+| Enable HTTPS                | Whether to access the website through HTTPS, please note that ⚠️ when HTTPS is enabled, the default port needs to be changed to 443                                            |
+| The acquisition interval is | Monitor the periodic data acquisition interval, in seconds, and the minimum interval that can be set is 30 seconds                                                             | 
+| Whether to probe the        | Whether to check the availability of the monitoring before adding a monitoring is successful, and the new modification operation will continue only if the probe is successful |
+| Description Comment         | For more information identifying and describing the remarks for this monitoring, users can remark the information here                                                         | 
 
 ### Collect metrics
 

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/spring_gateway.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/spring_gateway.md
@@ -1,15 +1,15 @@
 ---
 id: spring_gateway
-Title: 监控 Spring Gateway
-sidebar_label: Spring Gateway
-keywords: [开源监控工具, 开源 Spring Gateway 监控工具, 监控 Spring Gateway 指标]
+Title: 监控 Spring Cloud Gateway
+sidebar_label: Spring Cloud Gateway
+keywords: [开源监控工具, 开源 Spring Cloud Gateway 监控工具, 监控 Spring Cloud Gateway 指标]
 ---
 
 > 收集和监控 SpringBoot Actuator 提供的常规性能指标。
 
 ## 监控前操作
 
-如果您想使用此监控类型监控 'Spring Gateway' 的信息，您需要集成您的 SpringBoot 应用程序并启用 SpringBoot Actuator。
+如果您想使用此监控类型监控 `Spring Cloud Gateway` 的信息，您需要集成您的 `Spring Cloud Gateway` 应用程序并启用 SpringBoot Actuator。
 
 **1、添加 POM .XML 依赖:**
 
@@ -26,24 +26,25 @@ keywords: [开源监控工具, 开源 Spring Gateway 监控工具, 监控 Spring
 management:
   endpoint:
     gateway:
-      enabled: true # default value
+      enabled: true
+    env:
+      show-values: ALWAYS
   endpoints:
     web:
       exposure:
-        include: '*'
-    enabled-by-default: on
+        include: "*"
 ```
 
 ### 配置参数
 
-|   参数名称   |                          参数描述                          |
-|----------|--------------------------------------------------------|-----------------------------------------------|
+| 参数名称     | 参数描述                                                   |
+|----------|--------------------------------------------------------|
 | 监控主机     | 被监控的目标 IPV4、IPV6 或域名。注意⚠️不要包含协议头（例如：https://，http://）。 |
 | 监控名称     | 用于标识此监控的名称，需要保证唯一性。                                    |
 | 端口       | 数据库提供的默认端口为 8080。                                      |
 | 启用 HTTPS | 是否通过 HTTPS 访问网站，请注意⚠️当启用 HTTPS 时，需要将默认端口更改为 443        |
 | 采集间隔     | 监控周期性采集数据的时间间隔，单位为秒，最小间隔为 30 秒。                        |
-| 是否探测     | 在新增监控前是否先进行可用性探测，只有探测成功才会继续新增或修改操作。                    | will continue only if the probe is successful |
+| 是否探测     | 在新增监控前是否先进行可用性探测，只有探测成功才会继续新增或修改操作。                    | 
 | 描述备注     | 用于添加关于监控的额外标识和描述信息。                                    |
 
 ### 采集指标


### PR DESCRIPTION
## What's changed?

Related issue: #3630 

- This template only contains the `size` keyword, and use `Size` to replace the keyword `size`
- update Spring Cloud Gateway monitoring guide

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have added the necessary unit tests and all cases have passed.

## Reproduce

An error message appears when saving the template.

<img width="1926" height="463" alt="1-0" src="https://github.com/user-attachments/assets/f9e2f461-80ea-42a6-8fa8-41cb730ce2ec" />


## Repair Result

> HertzBeat version: `1.7.2`

- Template saved successfully.
- Run unit test `YamlCheckScript#checkYaml()` method successful.
- Verify that the indicator data is normal, that threshold alarms are normal, and that the test cases pass.

<img width="1927" height="1260" alt="1-1" src="https://github.com/user-attachments/assets/b374fb26-fa29-460f-bef5-1eddb8d72fe4" />

<img width="1913" height="1435" alt="1-2" src="https://github.com/user-attachments/assets/50db2e1f-f225-417b-9e80-b090be302609" />

<img width="1937" height="821" alt="1-3" src="https://github.com/user-attachments/assets/09bf42ae-1440-4889-a31a-a4c02e90cedc" />

