### PR TITLE
[bugfix] fixed jexl keyword issue in kingbase monitoring template

### DIFF
--- a/hertzbeat-manager/src/main/resources/define/app-kingbase.yml
+++ b/hertzbeat-manager/src/main/resources/define/app-kingbase.yml
@@ -490,7 +490,7 @@ metrics:
           zh-CN: 次数
           en-US: Num
           ja-JP: 数量
-      - field: size
+      - field: Size
         type: 0
         unit: B
         i18n:


### PR DESCRIPTION
## What's changed?

Related issue: #3630 

- This template only contains the `size` keyword, and use `Size` to replace the keyword `size`

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have added the necessary unit tests and all cases have passed.

## Reproduce

<img width="1934" height="500" alt="1-0" src="https://github.com/user-attachments/assets/b9522347-eb36-46fc-b673-220ffbef1587" />

## Repair Result

> Kingbase version: `V8R6(KingbaseES V008R006C005B0013)`

- Template saved successfully.
- Run unit test `YamlCheckScript#checkYaml()` method successful.
- Prepare test data.
  Execute the following SQL to generate some temporary files.
  ```sql
  select * from generate_series(1,10000000000) order by 1; 
  ```

- Verify that the indicator data is normal, that threshold alarms are normal, and that the test cases pass.

<img width="1939" height="565" alt="1-1" src="https://github.com/user-attachments/assets/18839b82-83ef-4111-82d6-62ed40bbafcb" />

<img width="1932" height="1187" alt="1-2" src="https://github.com/user-attachments/assets/938a5831-c70b-4b71-b029-3ac946ec26d8" />

<img width="1938" height="834" alt="1-3" src="https://github.com/user-attachments/assets/25ec4e3e-090c-4b74-8ac6-e1c4c6cf74e9" />


