### PR TITLE
[OSPP] Modify Dockerfile to support RISC-V.

### DIFF
--- a/script/docker/collector/Dockerfile
+++ b/script/docker/collector/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM openjdk:21-slim-bullseye
+FROM eclipse-temurin:21-jdk
 
 MAINTAINER Apache HertzBeat "dev@hertzbeat.apache.org"
 

--- a/script/docker/server/Dockerfile
+++ b/script/docker/server/Dockerfile
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM openjdk:21-slim-bullseye
+FROM eclipse-temurin:21-jdk
 
 MAINTAINER Apache HertzBeat "dev@hertzbeat.apache.org"
 


### PR DESCRIPTION
## What's changed?

Replace jdk to support RISC-V.


## Checklist

- [✅ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ✅]  I have written the necessary doc or comment.
- [ ✅]  I have added the necessary unit tests and all cases have passed.

