### PR TITLE
[improve] Improve performance issues when loading large numbers of metric cards in Monitors

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-detail/monitor-detail.component.html
+++ b/web-app/src/app/routes/monitor/monitor-detail/monitor-detail.component.html
@@ -67,11 +67,13 @@
             <app-monitor-data-table
               class="card"
               [height]="'400px'"
-              *ngFor="let metric of metrics; let i = index"
+              *ngFor="let metric of displayedMetrics; let i = index"
               [metrics]="metric"
               [monitorId]="monitorId"
               [app]="app"
             ></app-monitor-data-table>
+            <!-- IO sentinel for lazy loading -->
+            <div id="metrics-load-sentinel" style="width: 100%; height: 1px"></div>
           </div>
         </nz-tab>
         <nz-tab [nzTitle]="title2Template" (nzClick)="loadMetricChart()">
@@ -82,13 +84,15 @@
           <div class="cards">
             <app-monitor-data-chart
               class="card"
-              *ngFor="let item of chartMetrics; let i = index"
+              *ngFor="let item of displayedChartMetrics; let i = index"
               [app]="app"
               [metrics]="item.metrics"
               [metric]="item.metric"
               [unit]="item.unit"
               [monitorId]="monitorId"
             ></app-monitor-data-chart>
+            <!-- IO sentinel for lazy loading charts -->
+            <div id="charts-load-sentinel" style="width: 100%; height: 1px"></div>
           </div>
         </nz-tab>
         <nz-tab *ngIf="grafanaDashboard.enabled" [nzTitle]="title3Template">


### PR DESCRIPTION
## What's changed?

Optimize loading performance for `Monitor Real-Time Detail` and `Monitor Historical Chart Detail` to resolve indicator stuttering issues.

![Aug-27-2025 01-30-43](https://github.com/user-attachments/assets/92294ac7-70cb-4048-84f8-6944af775b2c)


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

![new](https://github.com/user-attachments/assets/8766b01a-11bc-4164-8ee9-7ea8dfafaab4)


