### PR TITLE
[Improve] changed scroll of intervals in New Monitor page 

### DIFF
--- a/web-app/src/app/shared/components/form-field/form-field.component.html
+++ b/web-app/src/app/shared/components/form-field/form-field.component.html
@@ -196,7 +196,7 @@
     (ngModelChange)="onChange($event)"
     [nzMin]="extra.interval_type === 'push' ? 1 : 10"
     [nzMax]="604800"
-    [nzStep]="extra.interval_type === 'push' ? 1 : 60"
+    [nzStep]="extra.interval_type === 'push' ? 1 : 10"
     name="intervals"
     id="intervals"
   >


### PR DESCRIPTION
## What's changed?
Previously, the "Intervals" input field for scrape-based monitors used a step of 60 seconds,This change modifies the nzStep property of the nz-input-number component, reducing the interval step from 60 to 10. 


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
![Screen Recording 2025-08-29 102517](https://github.com/user-attachments/assets/d6aa6e2c-df62-4448-9c65-ba4f9f962cc0)
**close #3720**
