### PR TITLE
[improve] Prometheus streaming parsing supports CRLF

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/prometheus/parser/OnlineParser.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/prometheus/parser/OnlineParser.java
@@ -185,12 +185,20 @@ public class OnlineParser {
             stringBuilder.append((char) i);
             i = getChar(inputStream);
         }
+        // Skip \r character to handle Windows line endings
+        if (i == '\r') {
+            i = getChar(inputStream);
+        }
         return new CharChecker(i);
     }
 
     private static CharChecker skipOneLong(InputStream inputStream) throws IOException, FormatException {
         int i = getChar(inputStream);
         while (i >= '0' && i <= '9') {
+            i = getChar(inputStream);
+        }
+        // Skip \r character to handle Windows line endings
+        if (i == '\r') {
             i = getChar(inputStream);
         }
         return new CharChecker(i);

--- a/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/prometheus/parser/OnlineParserTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/prometheus/parser/OnlineParserTest.java
@@ -105,4 +105,186 @@ class OnlineParserTest {
             });
         });
     }
+
+    @Test
+    void testParseMetricsWithCrLf() throws Exception {
+        String str = "# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.\r\n"
+                + "# TYPE go_gc_duration_seconds summary\r\n"
+                + "jvm_gc_pause_seconds_count{action=\"end of major GC\",cause=\"Metadata GC Threshold\",} 1.0\r\n"
+                + "jvm_gc_pause_seconds_sum{action=\"end of major GC\",cause=\"Metadata GC Threshold\",} 0.139\r\n";
+        InputStream inputStream = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
+        Map<String, MetricFamily> metricFamilyMap = OnlineParser.parseMetrics(inputStream);
+        assertNotNull(metricFamilyMap);
+        assertEquals(2, metricFamilyMap.values().size());
+
+        MetricFamily metricFamily = metricFamilyMap.get("jvm_gc_pause_seconds_count");
+        assertEquals("jvm_gc_pause_seconds_count", metricFamily.getName());
+        assertEquals(1.0, metricFamily.getMetricList().get(0).getValue());
+
+        MetricFamily metricFamily1 = metricFamilyMap.get("jvm_gc_pause_seconds_sum");
+        assertEquals("jvm_gc_pause_seconds_sum", metricFamily1.getName());
+        assertEquals(0.139, metricFamily1.getMetricList().get(0).getValue());
+
+        str = "# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.\r\n"
+                + "# TYPE go_gc_duration_seconds summary\r\n"
+                + "jvm_gc_pause_seconds_count{action=\"end of major GC\",cause=\"Metadata GC Threshold\",} 1.0 1234567890\r\n"
+                + "jvm_gc_pause_seconds_sum{action=\"end of major GC\",cause=\"Metadata GC Threshold\",} 0.139 1234567890\r\n";
+        inputStream = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
+        metricFamilyMap = OnlineParser.parseMetrics(inputStream);
+        assertNotNull(metricFamilyMap);
+        assertEquals(2, metricFamilyMap.values().size());
+
+        metricFamily = metricFamilyMap.get("jvm_gc_pause_seconds_count");
+        assertEquals("jvm_gc_pause_seconds_count", metricFamily.getName());
+        assertEquals(1.0, metricFamily.getMetricList().get(0).getValue());
+
+        metricFamily1 = metricFamilyMap.get("jvm_gc_pause_seconds_sum");
+        assertEquals("jvm_gc_pause_seconds_sum", metricFamily1.getName());
+        assertEquals(0.139, metricFamily1.getMetricList().get(0).getValue());
+    }
+
+    @Test
+    void testParseMetricsWithLf() throws Exception {
+        String str = "# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.\n"
+                + "# TYPE go_gc_duration_seconds summary\n"
+                + "jvm_gc_pause_seconds_count{action=\"end of major GC\",cause=\"Metadata GC Threshold\",} 1.0\n"
+                + "jvm_gc_pause_seconds_sum{action=\"end of major GC\",cause=\"Metadata GC Threshold\",} 0.139\n";
+        InputStream inputStream = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
+        Map<String, MetricFamily> metricFamilyMap = OnlineParser.parseMetrics(inputStream);
+        assertNotNull(metricFamilyMap);
+        assertEquals(2, metricFamilyMap.values().size());
+
+        MetricFamily metricFamily = metricFamilyMap.get("jvm_gc_pause_seconds_count");
+        assertEquals("jvm_gc_pause_seconds_count", metricFamily.getName());
+        assertEquals(1.0, metricFamily.getMetricList().get(0).getValue());
+
+        MetricFamily metricFamily1 = metricFamilyMap.get("jvm_gc_pause_seconds_sum");
+        assertEquals("jvm_gc_pause_seconds_sum", metricFamily1.getName());
+        assertEquals(0.139, metricFamily1.getMetricList().get(0).getValue());
+
+        str = "# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.\n"
+                + "# TYPE go_gc_duration_seconds summary\n"
+                + "jvm_gc_pause_seconds_count{action=\"end of major GC\",cause=\"Metadata GC Threshold\",} 1.0 1234567890\n"
+                + "jvm_gc_pause_seconds_sum{action=\"end of major GC\",cause=\"Metadata GC Threshold\",} 0.139 1234567890\n";
+        inputStream = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
+        metricFamilyMap = OnlineParser.parseMetrics(inputStream);
+        assertNotNull(metricFamilyMap);
+        assertEquals(2, metricFamilyMap.values().size());
+
+        metricFamily = metricFamilyMap.get("jvm_gc_pause_seconds_count");
+        assertEquals("jvm_gc_pause_seconds_count", metricFamily.getName());
+        assertEquals(1.0, metricFamily.getMetricList().get(0).getValue());
+
+        metricFamily1 = metricFamilyMap.get("jvm_gc_pause_seconds_sum");
+        assertEquals("jvm_gc_pause_seconds_sum", metricFamily1.getName());
+        assertEquals(0.139, metricFamily1.getMetricList().get(0).getValue());
+    }
+
+    @Test
+    void testParseMetricsWithoutFinalNewline() throws Exception {
+        String str = "# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.\r\n"
+                + "# TYPE go_gc_duration_seconds summary\r\n"
+                + "jvm_gc_pause_seconds_count{action=\"end of major GC\",cause=\"Metadata GC Threshold\",} 1.0\r\n"
+                + "jvm_gc_pause_seconds_sum{action=\"end of major GC\",cause=\"Metadata GC Threshold\",} 0.139";
+
+        InputStream inputStream = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
+        Map<String, MetricFamily> metricFamilyMap = OnlineParser.parseMetrics(inputStream);
+
+        assertNotNull(metricFamilyMap);
+        assertEquals(2, metricFamilyMap.values().size());
+
+        MetricFamily metricFamily = metricFamilyMap.get("jvm_gc_pause_seconds_count");
+        assertEquals("jvm_gc_pause_seconds_count", metricFamily.getName());
+        assertEquals(1.0, metricFamily.getMetricList().get(0).getValue());
+
+        MetricFamily metricFamily1 = metricFamilyMap.get("jvm_gc_pause_seconds_sum");
+        assertEquals("jvm_gc_pause_seconds_sum", metricFamily1.getName());
+        assertEquals(0.139, metricFamily1.getMetricList().get(0).getValue());
+
+        str = "# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.\n"
+                + "# TYPE go_gc_duration_seconds summary\n"
+                + "jvm_gc_pause_seconds_count{action=\"end of major GC\",cause=\"Metadata GC Threshold\",} 1.0\n"
+                + "jvm_gc_pause_seconds_sum{action=\"end of major GC\",cause=\"Metadata GC Threshold\",} 0.139";
+
+        inputStream = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
+        metricFamilyMap = OnlineParser.parseMetrics(inputStream);
+
+        assertNotNull(metricFamilyMap);
+        assertEquals(2, metricFamilyMap.values().size());
+
+        metricFamily = metricFamilyMap.get("jvm_gc_pause_seconds_count");
+        assertEquals("jvm_gc_pause_seconds_count", metricFamily.getName());
+        assertEquals(1.0, metricFamily.getMetricList().get(0).getValue());
+
+        metricFamily1 = metricFamilyMap.get("jvm_gc_pause_seconds_sum");
+        assertEquals("jvm_gc_pause_seconds_sum", metricFamily1.getName());
+        assertEquals(0.139, metricFamily1.getMetricList().get(0).getValue());
+    }
+
+    @Test
+    void testParseMetricsWithEmptyLabelsAndCrLf() throws Exception {
+        String str = "# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.\r\n"
+                + "# TYPE go_gc_duration_seconds summary\r\n"
+                + "jvm_gc_pause_seconds_count 1.0\r\n"
+                + "jvm_gc_pause_seconds_sum{} 0.139";
+
+        InputStream inputStream = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
+        Map<String, MetricFamily> metricFamilyMap = OnlineParser.parseMetrics(inputStream);
+
+        assertNotNull(metricFamilyMap);
+        assertEquals(2, metricFamilyMap.values().size());
+
+        MetricFamily metricFamily = metricFamilyMap.get("jvm_gc_pause_seconds_count");
+        assertEquals("jvm_gc_pause_seconds_count", metricFamily.getName());
+        assertEquals(1.0, metricFamily.getMetricList().get(0).getValue());
+
+        MetricFamily metricFamily1 = metricFamilyMap.get("jvm_gc_pause_seconds_sum");
+        assertEquals("jvm_gc_pause_seconds_sum", metricFamily1.getName());
+        assertEquals(0.139, metricFamily1.getMetricList().get(0).getValue());
+
+    }
+
+    @Test
+    void testParseMetricsWithEmptyLabelsAndLf() throws Exception {
+        String str = "# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.\n"
+                + "# TYPE go_gc_duration_seconds summary\n"
+                + "jvm_gc_pause_seconds_count 1.0\n"
+                + "jvm_gc_pause_seconds_sum{} 0.139";
+
+        InputStream inputStream = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
+        Map<String, MetricFamily> metricFamilyMap = OnlineParser.parseMetrics(inputStream);
+
+        assertNotNull(metricFamilyMap);
+        assertEquals(2, metricFamilyMap.values().size());
+
+        MetricFamily metricFamily = metricFamilyMap.get("jvm_gc_pause_seconds_count");
+        assertEquals("jvm_gc_pause_seconds_count", metricFamily.getName());
+        assertEquals(1.0, metricFamily.getMetricList().get(0).getValue());
+
+        MetricFamily metricFamily1 = metricFamilyMap.get("jvm_gc_pause_seconds_sum");
+        assertEquals("jvm_gc_pause_seconds_sum", metricFamily1.getName());
+        assertEquals(0.139, metricFamily1.getMetricList().get(0).getValue());
+    }
+
+    @Test
+    void testParseMetricsWithMixedLineEndings() throws Exception {
+        String str = "# HELP go_gc_duration_seconds A summary of the pause duration of garbage collection cycles.\r\n"
+                + "# TYPE go_gc_duration_seconds summary\n"
+                + "jvm_gc_pause_seconds_count 1.0\n"
+                + "jvm_gc_pause_seconds_sum{} 0.139\r\n";
+
+        InputStream inputStream = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
+        Map<String, MetricFamily> metricFamilyMap = OnlineParser.parseMetrics(inputStream);
+
+        assertNotNull(metricFamilyMap);
+        assertEquals(2, metricFamilyMap.values().size());
+
+        MetricFamily metricFamily = metricFamilyMap.get("jvm_gc_pause_seconds_count");
+        assertEquals("jvm_gc_pause_seconds_count", metricFamily.getName());
+        assertEquals(1.0, metricFamily.getMetricList().get(0).getValue());
+
+        MetricFamily metricFamily1 = metricFamilyMap.get("jvm_gc_pause_seconds_sum");
+        assertEquals("jvm_gc_pause_seconds_sum", metricFamily1.getName());
+        assertEquals(0.139, metricFamily1.getMetricList().get(0).getValue());
+    }
 }


### PR DESCRIPTION
## What's changed?

Please refer to: [#3739](https://github.com/apache/hertzbeat/issues/3739)

Prometheus streaming parsing supports CRLF.

> Step1：After reproducing the issue, I found that if the input data is in CRLF format, such as:
```
jvm_gc_pause_seconds_count{action="end of major GC",cause="Metadata GC Threshold",} 1.0 \r\n
```

> Step2：When processing the xx method, an exception may occur due to the termination character check.
```
i = parseOneDouble(inputStream, stringBuilder).maybeSpace().maybeEol().maybeEof().noElse();

i = skipOneLong(inputStream).maybeSpace().maybeEol().maybeEof().noElse();
```

> Step3：After consulting the Prometheus documentation, I found that while it specifies `Encoding UTF-8, \n line endings`, it does not explicitly mention the case of `\r\n`.

However, after reviewing VictoriaMetrics' parsing approach, I found that it handles input containing `\r\n` in a compatible manner.
```
func unmarshalRow(dst []Row, s string, tagsPool []Tag, noEscapes bool, errLogger func(s string)) ([]Row, []Tag) {
	// Key processing: Remove the \r character at the end of the line
	if len(s) > 0 && s[len(s)-1] == '\r' {
		s = s[:len(s)-1]
	}
	// ... Other processing logic
	return dst, tagsPool
}
```

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
