### PR TITLE
[improve] Improving the operation of threshold rules and the output of expression logs

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/impl/AlertDefineServiceImpl.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/impl/AlertDefineServiceImpl.java
@@ -106,14 +106,14 @@ public class AlertDefineServiceImpl implements AlertDefineService {
 
     @Override
     public void addAlertDefine(AlertDefine alertDefine) throws RuntimeException {
-        alertDefine = alertDefineDao.save(alertDefine);
+        alertDefine = alertDefineDao.saveAndFlush(alertDefine);
         periodicAlertRuleScheduler.updateSchedule(alertDefine);
         CacheFactory.clearAlertDefineCache();
     }
 
     @Override
     public void modifyAlertDefine(AlertDefine alertDefine) throws RuntimeException {
-        alertDefineDao.save(alertDefine);
+        alertDefineDao.saveAndFlush(alertDefine);
         periodicAlertRuleScheduler.updateSchedule(alertDefine);
         CacheFactory.clearAlertDefineCache();
     }

--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/impl/DataSourceServiceImpl.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/impl/DataSourceServiceImpl.java
@@ -87,7 +87,7 @@ public class DataSourceServiceImpl implements DataSourceService {
         try {
             return evaluate(expr, executor);
         } catch (AlertExpressionException ae) {
-            log.error("Calculate query parse error {}: {}", datasource, ae.getMessage());
+            log.error("Calculate query parse error, datasource: {}, expr: {}, msg: {}", datasource, expr, ae.getMessage(), ae);
             throw ae;
         } catch (Exception e) {
             log.error("Error executing query on datasource {}: {}", datasource, e.getMessage());

--- a/hertzbeat-manager/src/test/java/org/apache/hertzbeat/manager/service/AlertDefineServiceIntegrationTest.java
+++ b/hertzbeat-manager/src/test/java/org/apache/hertzbeat/manager/service/AlertDefineServiceIntegrationTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.manager.service;
+
+import org.apache.hertzbeat.alert.dao.AlertDefineDao;
+import org.apache.hertzbeat.alert.service.AlertDefineService;
+import org.apache.hertzbeat.common.entity.alerter.AlertDefine;
+import org.apache.hertzbeat.manager.AbstractSpringIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test case for {@link AlertDefineService}
+ */
+public class AlertDefineServiceIntegrationTest extends AbstractSpringIntegrationTest {
+
+    @Autowired
+    private AlertDefineService alertDefineService;
+    @Autowired
+    private AlertDefineDao alertDefineDao;
+
+    private List<Long> createdIds = new ArrayList<>();
+
+    @BeforeEach
+    void setUp() {
+        createdIds.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        for (Long id : createdIds) {
+            if (alertDefineDao.existsById(id)) {
+                alertDefineDao.deleteById(id);
+            }
+        }
+    }
+
+    @Test
+    void testAddAlertDefine() {
+        AlertDefine alertDefine = AlertDefine.builder()
+                .name("test-cpu-alert")
+                .expr("usage > 80")
+                .times(3)
+                .type("periodic")
+                .enable(true)
+                .period(10)
+                .template("CPU usage is excessively high: ${usage}%")
+                .creator("integration-test")
+                .modifier("integration-test")
+                .gmtCreate(LocalDateTime.now())
+                .gmtUpdate(LocalDateTime.now())
+                .build();
+        assertNull(alertDefine.getId());
+        assertDoesNotThrow(() -> alertDefineService.addAlertDefine(alertDefine));
+
+        assertNotNull(alertDefine.getId());
+        assertTrue(alertDefine.getId() > 0);
+
+        createdIds.add(alertDefine.getId());
+
+        AlertDefine savedAlertDefine = alertDefineDao.findById(alertDefine.getId()).orElse(null);
+        assertNotNull(savedAlertDefine);
+        assertEquals("usage > 80", savedAlertDefine.getExpr());
+        assertEquals("integration-test", savedAlertDefine.getCreator());
+    }
+
+    @Test
+    void testModifyAlertDefine() {
+        AlertDefine alertDefine = AlertDefine.builder()
+                .name("test-cpu-alert")
+                .expr("usage > 80")
+                .times(3)
+                .type("periodic")
+                .enable(true)
+                .period(10)
+                .template("CPU usage is excessively high: ${usage}%")
+                .creator("integration-test")
+                .modifier("integration-test")
+                .gmtCreate(LocalDateTime.now())
+                .gmtUpdate(LocalDateTime.now())
+                .build();
+        assertNull(alertDefine.getId());
+        assertDoesNotThrow(() -> alertDefineService.modifyAlertDefine(alertDefine));
+
+        assertNotNull(alertDefine.getId());
+        assertTrue(alertDefine.getId() > 0);
+
+        createdIds.add(alertDefine.getId());
+
+        AlertDefine savedAlertDefine = alertDefineDao.findById(alertDefine.getId()).orElse(null);
+        assertNotNull(savedAlertDefine);
+        assertEquals("usage > 80", savedAlertDefine.getExpr());
+        assertEquals("integration-test", savedAlertDefine.getCreator());
+    }
+
+}


### PR DESCRIPTION
## What's changed?

improve #3773

When using IDENTITY with generation strategies, the ID cannot be obtained before the insertion operation completes. Since entity inserts are typically deferred until commit time, the ID becomes available only after the transaction is flushed or committed.

1. Using saveAndFlush to handle errors and updates
2. Improve PromQL parsing exception logging output

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
