### PR TITLE
fix: use UTF-8 to solve Chineses bug

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/prometheus/parser/OnlineParserSingleTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/prometheus/parser/OnlineParserSingleTest.java
@@ -444,6 +444,27 @@ public class OnlineParserSingleTest {
         assertEquals("NT AUTHORITY\nLocalService", metricFamily.getMetricList().get(0).getLabels().get(3).getValue());
     }
 
+    @Test
+    void testParseMetricsWithChineseLabels() throws Exception {
+        String str = "ST22{Dump_Name=\"Dump总数\",HostName=\"SAP_DEV\",instance_hostname=\"sapdev\"} 2\n";
+        InputStream inputStream = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8));
+        Map<String, MetricFamily> metricFamilyMap = parseMetrics(inputStream, "ST22");
+
+        assertNotNull(metricFamilyMap);
+        MetricFamily metricFamily = metricFamilyMap.get("ST22");
+        assertNotNull(metricFamily);
+        assertEquals("ST22", metricFamily.getName());
+        assertEquals(1, metricFamily.getMetricList().size());
+        assertEquals(2.0, metricFamily.getMetricList().get(0).getValue());
+
+        // Verify Chinese label value is correctly parsed
+        MetricFamily.Label dumpNameLabel = metricFamily.getMetricList().get(0).getLabels().stream()
+            .filter(label -> "Dump_Name".equals(label.getName()))
+            .findFirst().orElse(null);
+        assertNotNull(dumpNameLabel);
+        assertEquals("Dump总数", dumpNameLabel.getValue());
+    }
+
     private Map<String, MetricFamily> parseMetrics(InputStream inputStream, String metric) throws IOException {
         return OnlineParser.parseMetrics(inputStream, metric);
     }


### PR DESCRIPTION
## What's changed?
Incorrect UTF-8 validation logic: The validation in OnlineParser.java: lines 419-421 incorrectly identifies valid Chinese strings as invalid.
Byte stream processing issue: The original parser reads the InputStream byte by byte and cannot correctly handle UTF-8 multi-byte characters (Chinese characters occupy 3 bytes).
Close #3791

<!-- Describe Your PR Here -->
Change the byte-by-byte parsing based on InputStream to UTF-8 string parsing
add test for this change

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
