### PR TITLE
[improve] nitpicking  "Dispatch ALl" on en-US.json

### DIFF
--- a/web-app/src/assets/i18n/en-US.json
+++ b/web-app/src/assets/i18n/en-US.json
@@ -119,7 +119,7 @@
   "alert.notice.receiver.type": "Notice Type",
   "alert.notice.receiver.type.placeholder": "Select a notice type",
   "alert.notice.rule": "Notice Policy",
-  "alert.notice.rule.all": "Dispatch ALl",
+  "alert.notice.rule.all": "Dispatch All",
   "alert.notice.rule.delete": "Delete Notice Policy",
   "alert.notice.rule.edit": "Edit Notice Policy",
   "alert.notice.rule.name": "Policy Name",


### PR DESCRIPTION
## What's changed?

- improve / fix capitalization error from "Dispatch ALl" to "Dispatch All"
<img width="1248" height="344" alt="image" src="https://github.com/user-attachments/assets/860600d6-c82c-4071-98b3-62605d38f6ba" />


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
