### PR TITLE
fix some bug in service discovery:

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/sd/DnsSdCollectImpl.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/sd/DnsSdCollectImpl.java
@@ -43,7 +43,7 @@ import java.util.Arrays;
 @Slf4j
 public class DnsSdCollectImpl extends AbstractCollect {
 
-    private static final int DEFAULT_TIME_OUT = 3;
+    private static final int DEFAULT_TIME_OUT = 3000;
 
     @Override
     public void preCheck(Metrics metrics) throws IllegalArgumentException {

--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/component/sd/ServiceDiscoveryWorker.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/component/sd/ServiceDiscoveryWorker.java
@@ -110,7 +110,9 @@ public class ServiceDiscoveryWorker implements InitializingBean {
                             fieldsValue.put(cell.getField().getName(), value);
                         });
                         final String host = fieldsValue.get(FILED_HOST);
-                        final String port = fieldsValue.getOrDefault(FILED_PORT, defaultPort);
+                        final String port = Optional.ofNullable(fieldsValue.get(FILED_PORT))
+                                .filter(p -> !p.isEmpty())
+                                .orElse(defaultPort);
                         final String keyStr = host + ":" + port;
                         if (subMonitorBindMap.containsKey(keyStr)) {
                             subMonitorBindMap.remove(keyStr);

--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/MonitorServiceImpl.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/MonitorServiceImpl.java
@@ -181,6 +181,7 @@ public class MonitorServiceImpl implements MonitorService {
         Job appDefine = appService.getAppDefine(app);
         if (!isStatic) {
             appDefine.setSd(true);
+            monitor.setHost("unknow");
         }
         if (CommonConstants.PROMETHEUS.equals(monitor.getApp())) {
             appDefine.setApp(CommonConstants.PROMETHEUS_APP_PREFIX + monitor.getName());


### PR DESCRIPTION
## What's changed?

1/ extend timeout setting in DnsSdCollectImpl from 3ms to 3000ms. 3ms is too small. 
2/ when add to sd monitor, set host name to unkonw, so the error after this will be muted. 
3/ in service discovery worker, if port is empty string then get the port from monitor's parameters.

## Checklist

- [X]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [X]  I have written the necessary doc or comment.
- [X]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
