### PR TITLE
improvement: improve log severity text input

### DIFF
--- a/web-app/src/app/routes/log/log-manage/log-manage.component.html
+++ b/web-app/src/app/routes/log/log-manage/log-manage.component.html
@@ -39,7 +39,24 @@
         [(ngModel)]="severityNumber"
         style="width: 120px"
       />
-      <input *nzSpaceItem nz-input [placeholder]="'log.manage.severity-text' | i18n" [(ngModel)]="severityText" style="width: 120px" />
+      <input
+        *nzSpaceItem
+        type="text"
+        nz-input
+        [(ngModel)]="severityText"
+        [placeholder]="'log.manage.severity-text'| i18n"
+        [nzAutocomplete]="severityTextAuto"
+        style="width: 120px"
+      />
+      <nz-autocomplete #severityTextAuto>
+        <nz-auto-option nzValue="TRACE">TRACE</nz-auto-option>
+        <nz-auto-option nzValue="DEBUG">DEBUG</nz-auto-option>
+        <nz-auto-option nzValue="INFO">INFO</nz-auto-option>
+        <nz-auto-option nzValue="WARN">WARN</nz-auto-option>
+        <nz-auto-option nzValue="ERROR">ERROR</nz-auto-option>
+        <nz-auto-option nzValue="FATAL">FATAL</nz-auto-option>
+      </nz-autocomplete>
+      <!-- <input *nzSpaceItem nz-input [placeholder]="'log.manage.severity-text' | i18n" [(ngModel)]="severityText" /> -->
       <button *nzSpaceItem nz-button nzType="primary" (click)="query()">
         <i nz-icon nzType="search"></i> {{ 'log.manage.search' | i18n }}
       </button>

--- a/web-app/src/app/routes/log/log-manage/log-manage.component.ts
+++ b/web-app/src/app/routes/log/log-manage/log-manage.component.ts
@@ -43,6 +43,7 @@ import { NzTableModule } from 'ng-zorro-antd/table';
 import { NzTagModule } from 'ng-zorro-antd/tag';
 import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 import { NgxEchartsModule } from 'ngx-echarts';
+import { NzAutocompleteModule } from 'ng-zorro-antd/auto-complete';
 
 import { LogEntry } from '../../../pojo/LogEntry';
 import { LogService } from '../../../service/log.service';
@@ -71,7 +72,8 @@ import { LogService } from '../../../service/log.service';
     NzModalModule,
     NzCheckboxModule,
     NzPopoverModule,
-    NzListModule
+    NzListModule,
+    NzAutocompleteModule
   ],
   templateUrl: './log-manage.component.html',
   styleUrl: './log-manage.component.less'

--- a/web-app/src/app/routes/log/log-stream/log-stream.component.html
+++ b/web-app/src/app/routes/log/log-stream/log-stream.component.html
@@ -104,11 +104,26 @@
         <div class="filter-item">
           <label class="filter-label">{{ 'log.stream.severity-text' | i18n }}</label>
           <nz-input-group [nzPrefix]="severityTextTemplate" class="filter-input">
-            <input type="text" nz-input [(ngModel)]="filterSeverityText" [placeholder]="'log.stream.severity-text-placeholder' | i18n" />
+            <input
+              type="text"
+              nz-input
+              [(ngModel)]="filterSeverityText"
+              [placeholder]="'log.stream.severity-text-placeholder' | i18n"
+              [nzAutocomplete]="severityTextAuto"
+            />
           </nz-input-group>
           <ng-template #severityTextTemplate>
             <i nz-icon nzType="file-text"></i>
           </ng-template>
+
+          <nz-autocomplete #severityTextAuto>
+            <nz-auto-option nzValue="TRACE">TRACE</nz-auto-option>
+            <nz-auto-option nzValue="DEBUG">DEBUG</nz-auto-option>
+            <nz-auto-option nzValue="INFO">INFO</nz-auto-option>
+            <nz-auto-option nzValue="WARN">WARN</nz-auto-option>
+            <nz-auto-option nzValue="ERROR">ERROR</nz-auto-option>
+            <nz-auto-option nzValue="FATAL">FATAL</nz-auto-option>
+          </nz-autocomplete>
         </div>
 
         <div class="filter-item">

--- a/web-app/src/app/routes/log/log-stream/log-stream.component.ts
+++ b/web-app/src/app/routes/log/log-stream/log-stream.component.ts
@@ -30,6 +30,7 @@ import { NzDividerComponent } from 'ng-zorro-antd/divider';
 import { NzEmptyModule } from 'ng-zorro-antd/empty';
 import { NzInputModule } from 'ng-zorro-antd/input';
 import { NzModalModule } from 'ng-zorro-antd/modal';
+import { NzAutocompleteModule } from 'ng-zorro-antd/auto-complete';
 import { NzSelectModule } from 'ng-zorro-antd/select';
 import { NzSwitchModule } from 'ng-zorro-antd/switch';
 import { NzTagModule } from 'ng-zorro-antd/tag';
@@ -52,6 +53,7 @@ interface ExtendedLogEntry {
     FormsModule,
     NzCardModule,
     NzInputModule,
+    NzAutocompleteModule,
     NzSelectModule,
     NzButtonModule,
     NzTagModule,


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
It has built-in common log severity texts, which users can either select directly or enter manually.


<img width="2878" height="1476" alt="image" src="https://github.com/user-attachments/assets/b1a94be8-bfac-4a1d-8b33-468d70a01902" />
<img width="2878" height="1446" alt="image" src="https://github.com/user-attachments/assets/7f4843c0-2447-4182-ae16-6342f4478456" />


## Checklist

- [X]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
