### PR TITLE
[fix]Fixed issue where refresh did not take effect

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-detail/monitor-detail.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-detail/monitor-detail.component.ts
@@ -206,10 +206,13 @@ export class MonitorDetailComponent implements OnInit, OnDestroy {
             this.metricsInfo = message.data.metrics || [];
             this.metrics = this.metricsInfo.map((metric: any) => metric.name);
 
-            if (this.metrics && this.metrics.length > 0) {
-              this.loadInitialMetrics();
-              this.setupIntersectionObserver();
-            }
+            setTimeout(() => {
+              this.cdr.detectChanges();
+              if (this.metrics && this.metrics.length > 0) {
+                this.loadInitialMetrics();
+                this.setupIntersectionObserver();
+              }
+            }, 0);
           } else {
             console.warn(message.msg);
           }
@@ -437,6 +440,8 @@ export class MonitorDetailComponent implements OnInit, OnDestroy {
       if (this.countDownTime == 0) {
         if (this.whichTabIndex == 1) {
           this.loadMetricChart();
+        } else if (this.whichTabIndex == 2) {
+          this.loadFavoriteMetrics();
         } else {
           this.loadRealTimeMetric();
         }
@@ -490,11 +495,13 @@ export class MonitorDetailComponent implements OnInit, OnDestroy {
     if (this.favoriteMetricsSet.size === 0) {
       return;
     }
-
-    // Convert favorites indicator to array
-    this.favoriteMetrics = Array.from(this.favoriteMetricsSet);
-    this.displayedFavoriteMetrics = this.favoriteMetrics.slice(0, this.favoritePageSize);
-    this.hasMoreFavorites = this.favoriteMetrics.length > this.favoritePageSize;
+    setTimeout(() => {
+      // Convert favorites indicator to array
+      this.favoriteMetrics = Array.from(this.favoriteMetricsSet);
+      this.displayedFavoriteMetrics = this.favoriteMetrics.slice(0, this.favoritePageSize);
+      this.hasMoreFavorites = this.favoriteMetrics.length > this.favoritePageSize;
+      this.cdr.detectChanges();
+    }, 0);
 
     this.loadFavoriteChartDefinitions();
 


### PR DESCRIPTION
## What's changed?

There is currently a timing issue with Angular's change detection, causing refreshes to fail. This will prevent both automatic and manual refreshes from attempting to retrieve indicator data.

For example:

>  Monitor Real-Time Detail 
![bug1](https://github.com/user-attachments/assets/9266b3b0-569f-4fd7-855d-e7eb12d3aecd)

>  Favorites 
![bug2](https://github.com/user-attachments/assets/3121ede8-34c2-4b08-9ed2-c20b9254e78a)


Modification details: 
1. Defer critical logic to the next event loop, initialize functionality only after the DOM is ready, ensuring the DOM is fully updated.


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

> Monitor Real-Time Detail (Auto Refresh)

![realtime_auto](https://github.com/user-attachments/assets/2ff11d32-3c15-418d-8da9-9bb07d13d4b3)

> Monitor Real-Time Detail (Manual Refresh)

![realtime_manual](https://github.com/user-attachments/assets/477b71fd-4027-4375-8732-011ff625b79e)

>  Favorites (Auto Refresh)

![favorites_auto](https://github.com/user-attachments/assets/97618526-a010-45da-8b5a-dfd96ee2a924)

>  Favorites (Manual Refresh)

![favorites_manual](https://github.com/user-attachments/assets/2365d2fb-10fd-4a96-8a85-2c9c6b3dd582)

>  Favorites - Monitor Historical Chart Detail (Auto Refresh)

![favorites_history_auto](https://github.com/user-attachments/assets/b8cbc6d5-500d-4cf0-b587-8a251c7c6d0d)

>  Favorites - Monitor Historical Chart Detail (Manual Refresh)

![favorites_history_manual](https://github.com/user-attachments/assets/7f4ba492-b421-4692-a37d-d85194b66af1)

