### PR TITLE
[ci] fix markdown lint ci

### DIFF
--- a/.github/workflows/doc-build-test.yml
+++ b/.github/workflows/doc-build-test.yml
@@ -39,7 +39,7 @@ jobs:
           python-version: '3.8'
 
       - name: Check Markdown
-        uses: DavidAnson/markdownlint-cli2-action@v16
+        uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e
         with:
           globs: './home/**/*.md'
 


### PR DESCRIPTION
## What's changed?

- reslove #3832

The `davidanson/markdownlint-cli2-action@v16` action is no longer permitted in apache/hertzbeat.

Updating to a verified version from the GitHub Marketplace: [992badcdf24e3b8eb7e87ff9287fe931bcb00c6e](https://github.com/DavidAnson/markdownlint-cli2-action/commit/992badcdf24e3b8eb7e87ff9287fe931bcb00c6e).


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
