### PR TITLE
[bugfix] Modify the search predicate from 'host' to 'instance' field

### DIFF
--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/MonitorServiceImpl.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/MonitorServiceImpl.java
@@ -552,7 +552,7 @@ public class MonitorServiceImpl implements MonitorService {
 
     @Override
     public Page<Monitor> getMonitors(List<Long> monitorIds, String app, String search, Byte status, String sort,
-                                     String order, int pageIndex, int pageSize, String labels) {
+            String order, int pageIndex, int pageSize, String labels) {
         Specification<Monitor> specification = (root, query, criteriaBuilder) -> {
             List<Predicate> andList = new ArrayList<>();
             if (!CollectionUtils.isEmpty(monitorIds)) {
@@ -724,11 +724,11 @@ public class MonitorServiceImpl implements MonitorService {
             appCount.setApp(item.getApp());
             switch (item.getStatus()) {
                 case CommonConstants.MONITOR_UP_CODE ->
-                        appCount.setAvailableSize(appCount.getAvailableSize() + item.getSize());
+                    appCount.setAvailableSize(appCount.getAvailableSize() + item.getSize());
                 case CommonConstants.MONITOR_DOWN_CODE ->
-                        appCount.setUnAvailableSize(appCount.getUnAvailableSize() + item.getSize());
+                    appCount.setUnAvailableSize(appCount.getUnAvailableSize() + item.getSize());
                 case CommonConstants.MONITOR_PAUSED_CODE ->
-                        appCount.setUnManageSize(appCount.getUnManageSize() + item.getSize());
+                    appCount.setUnManageSize(appCount.getUnManageSize() + item.getSize());
                 default -> {
                 }
             }


### PR DESCRIPTION
## What's changed?

fixed: #3908 

The field `host` in the database table `hzb_monitor` has been renamed to `instance`.

### Test Result

Before

<img width="1415" height="673" alt="before" src="https://github.com/user-attachments/assets/4db0debb-1af8-4dbf-8fb3-7f8bea8881c5" />

After

<img width="1413" height="515" alt="after" src="https://github.com/user-attachments/assets/6b6219eb-ec72-41ae-9db7-ab5d9e7b90a8" />


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
