### PR TITLE
[Feature] Enhance draggable UI elements in alert settings (#3915)

### DIFF
--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.html
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.html
@@ -860,7 +860,7 @@
         <nz-form-control [nzSpan]="12" [nzErrorTip]="'validation.required' | i18n">
           <div class="template-input-wrapper">
             <div *ngIf="define.type === 'realtime_metric' || define.type === 'realtime_log'" class="draggable-vars-container">
-              <div *ngIf="define.type === 'realtime_metric'">
+              <div *ngIf="define.type === 'realtime_metric'" class="draggable-box">
                 <div *ngFor="let env of templateEnvVars" class="draggable-tag" draggable="true" (dragstart)="onDragStart($event, env)">
                   <div class="key-value-block">
                     <span class="var-key">{{ env.name }}</span>
@@ -875,7 +875,7 @@
                   </div>
                 </div>
               </div>
-              <div *ngIf="define.type === 'realtime_log'">
+              <div *ngIf="define.type === 'realtime_log'" class="draggable-box">
                 <div *ngFor="let field of logFields" class="draggable-tag" draggable="true" (dragstart)="onDragStart($event, field)">
                   <div class="key-value-block">
                     <span class="var-key">{{ '${' + field.value + '}' }}</span>

--- a/web-app/src/app/routes/alert/alert-setting/alert-setting.component.less
+++ b/web-app/src/app/routes/alert/alert-setting/alert-setting.component.less
@@ -240,13 +240,17 @@
   }
 
   .draggable-vars-container {
+    border: 1px dashed fade(@primary-color, 30%);
+    margin-bottom: 16px;
+  }
+
+  .draggable-box {
     display: flex;
     flex-wrap: wrap;
     gap: 10px;
-    margin-bottom: 16px;
     padding: 12px;
-    border: 1px dashed fade(@primary-color, 30%);
-    border-radius: 6px;
+    max-height: 480px;
+    overflow-y: auto;
 
     @media (max-width: 768px) {
       flex-direction: column;


### PR DESCRIPTION
close #3915 

## What's changed?

Cause of the issue: 
    Modified the style and interaction logic of the alert list to fix the issue where items at the top of a long list could not be dragged into the input box..

Feature Details: 
    Added a 'draggable-box' class to improve the styling of draggable elements for 'realtime_metric' and 'realtime_log' types. Updated the CSS to include a dashed border and adjusted layout properties for better user experience.


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
![a](https://github.com/user-attachments/assets/e223d3f9-d0e3-448f-9e73-a1a41b317c6a)


