### PR TITLE
[bugfix]: fix for the collector tab click effect error

### DIFF
--- a/web-app/src/app/routes/dashboard/dashboard.component.html
+++ b/web-app/src/app/routes/dashboard/dashboard.component.html
@@ -402,7 +402,7 @@
               </span>
             </ng-template>
             <nz-card-tab>
-              <nz-tabset nzSize="small" [(nzSelectedIndex)]="collectorsTabSelectedIndex">
+              <nz-tabset nzSize="small" [(nzSelectedIndex)]="collectorsTabSelectedIndexes[i]">
                 <nz-tab [nzTitle]="'collector.status' | i18n" />
                 <nz-tab [nzTitle]="'collector.task' | i18n" />
                 <nz-tab [nzTitle]="'collector.start-time' | i18n" />
@@ -410,7 +410,7 @@
                 <nz-tab [nzTitle]="'collector.node' | i18n" />
               </nz-tabset>
             </nz-card-tab>
-            <ng-container *ngIf="collectorsTabSelectedIndex === 0">
+            <ng-container *ngIf="collectorsTabSelectedIndexes[i] === 0">
               <div class="rounded-lg" style="text-align: center; width: 100%; background-color: transparent; padding: 2%">
                 <span [style]="'font-size: x-large; font-weight: bolder;' + (item.collector.status == 0 ? 'color: green' : 'color: red')">
                   {{
@@ -419,7 +419,7 @@
                 </span>
               </div>
             </ng-container>
-            <ng-container *ngIf="collectorsTabSelectedIndex === 1">
+            <ng-container *ngIf="collectorsTabSelectedIndexes[i] === 1">
               <div class="rounded-lg" style="text-align: center; width: 100%; background-color: transparent; padding: 2%">
                 <span style="font-size: xxx-large; font-weight: bolder">
                   {{ item.pinMonitorNum + item.dispatchMonitorNum }}
@@ -431,19 +431,19 @@
                 >
               </div>
             </ng-container>
-            <ng-container *ngIf="collectorsTabSelectedIndex === 2">
+            <ng-container *ngIf="collectorsTabSelectedIndexes[i] === 2">
               <div class="rounded-lg" style="text-align: center; width: 100%; background-color: transparent; padding: 2%">
                 <span style="font-size: x-large; font-weight: bolder">{{
                   (item.collector.gmtUpdate | date : 'YYYY-MM-dd HH:mm:ss')?.trim()
                 }}</span>
               </div>
             </ng-container>
-            <ng-container *ngIf="collectorsTabSelectedIndex === 3">
+            <ng-container *ngIf="collectorsTabSelectedIndexes[i] === 3">
               <div class="rounded-lg" style="text-align: center; width: 100%; background-color: transparent; padding: 2%">
                 <span style="font-size: x-large; font-weight: bolder">{{ item.collector.ip }}</span>
               </div>
             </ng-container>
-            <ng-container *ngIf="collectorsTabSelectedIndex === 4">
+            <ng-container *ngIf="collectorsTabSelectedIndexes[i] === 4">
               <div class="rounded-lg" style="text-align: center; width: 100%; background-color: transparent; padding: 2%">
                 <span style="font-size: x-large; font-weight: bolder">{{ item.collector.name }}</span>
               </div>

--- a/web-app/src/app/routes/dashboard/dashboard.component.ts
+++ b/web-app/src/app/routes/dashboard/dashboard.component.ts
@@ -174,7 +174,7 @@ export class DashboardComponent implements OnInit, OnDestroy {
   // collector list
   collectorsLoading: boolean = false;
   collectors!: CollectorSummary[];
-  collectorsTabSelectedIndex = 0;
+  collectorsTabSelectedIndexes: { [key: number]: number } = {};
 
   // alert list
   alerts!: SingleAlert[];


### PR DESCRIPTION
## What's changed?

Fixed the issue where clicking a tab on one collector card would erroneously change the active tab for all other collector cards in the Manager Dashboard (#3930).

**Root Cause:**
The `collectorsTabSelectedIndex` variable in `dashboard.component.ts` was shared across all collector cards rendered in the `*ngFor` loop.

**Fix:**
- Replaced the single `collectorsTabSelectedIndex` property with a `collectorsTabSelectedIndexes` map.
- Updated `dashboard.component.html` to bind each card's tab index to its specific index (`collectorsTabSelectedIndexes[i]`), ensuring independent state management.


https://github.com/user-attachments/assets/bdda0a17-a20a-4f79-9d0a-8e654a7b61e7


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.