### PR TITLE
[feature] add Kapa widget script to docusaurus configuration

### DIFF
--- a/home/docusaurus.config.js
+++ b/home/docusaurus.config.js
@@ -279,7 +279,7 @@ module.exports = {
       },
       copyright:
         `
-        <div style="text-align: left;margin-top:20px">         
+        <div style="text-align: left;margin-top:20px">
           <a href="https://apache.org/" style="display: flex; align-items: center; justify-content:center">
             <img src="/img/icons/asf_logo.svg" alt="Apache logo" style="width:auto;height:140px">
           </a>
@@ -399,5 +399,15 @@ module.exports = {
       },
     ],
   ],
-  themes: ['@docusaurus/theme-live-codeblock']
+  themes: ['@docusaurus/theme-live-codeblock'],
+  scripts: [
+    {
+      src: "https://widget.kapa.ai/kapa-widget.bundle.js",
+      "data-website-id": "cb9dd0e9-5736-4572-be75-fd2ebe7443b0",
+      "data-project-name": "Apache HertzBeat",
+      "data-project-color": "#444FD9",
+      "data-project-logo": "https://hertzbeat.apache.org/zh-cn/assets/files/hertzbeat-logo-f92c500146ae43b9cb901600cd274d67.png",
+      async: true,
+    },
+  ],
 }


### PR DESCRIPTION
This pull request adds a new third-party script to the Docusaurus configuration to enable the Kapa AI widget on the site. No other significant changes are included.

- **Integration of Kapa AI Widget:**
  - Added a script configuration for the Kapa AI widget in `home/docusaurus.config.js`, including widget source, website ID, project name, color, and logo, with the script set to load asynchronously.