### PR TITLE
[improve] Optimize Tooltip display logic and support scrollable content

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-data-chart/monitor-data-chart.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-data-chart/monitor-data-chart.component.ts
@@ -202,7 +202,7 @@ export class MonitorDataChartComponent implements OnInit, OnDestroy {
       },
       tooltip: {
         trigger: 'axis',
-        extraCssText: 'max-width: 580px; max-height: 400px;  overflow-y: auto;',
+        extraCssText: 'max-width: 580px; max-height: 400px; overflow-y: auto;',
         enterable: true,
         renderMode: 'html',
         appendToBody: true,


### PR DESCRIPTION
## What's changed?

Currently, the chart Tooltip is rendered inside the chart container or limited by the parent layout. This causes the Tooltip to be occluded or clipped by the global navigation Sidebar (on the left) and the Header (at the top) when the chart is positioned near the screen edges.

- Moves the Tooltip DOM from the ECharts DOM hierarchy directly to the document.body. This ensures the Tooltip is no longer restricted by the chart's container size or the z-index of layout components like the Header and Sidebar.

<img width="845" height="660" alt="11" src="https://github.com/user-attachments/assets/60fc09e0-3465-4a23-9b15-a2682a88b579" />

<img width="911" height="547" alt="33" src="https://github.com/user-attachments/assets/c6fc282e-769a-45e9-a05f-db2dde7f6dec" />


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
