### PR TITLE
style: adjust grid layout width of form labels

### DIFF
--- a/web-app/src/app/routes/setting/plugins/plugin.component.html
+++ b/web-app/src/app/routes/setting/plugins/plugin.component.html
@@ -147,14 +147,14 @@
   <div *nzModalContent class="-inner-content">
     <form [formGroup]="pluginForm" nz-form>
       <nz-form-item>
-        <nz-form-label [nzSpan]="6" nzRequired="true" nzFor="name">{{ 'plugin.name' | i18n }}</nz-form-label>
+        <nz-form-label [nzSpan]="8" nzRequired="true" nzFor="name">{{ 'plugin.name' | i18n }}</nz-form-label>
         <nz-form-control [nzSpan]="14" [nzErrorTip]="'validation.required' | i18n">
           <input nz-input formControlName="name" id="name" />
         </nz-form-control>
       </nz-form-item>
 
       <nz-form-item>
-        <nz-form-label [nzSpan]="6" nzRequired="true" nzFor="jarFile">{{ 'plugin.jar.file' | i18n }}</nz-form-label>
+        <nz-form-label [nzSpan]="8" nzRequired="true" nzFor="jarFile">{{ 'plugin.jar.file' | i18n }}</nz-form-label>
         <nz-form-control [nzSpan]="14" [nzErrorTip]="'validation.required' | i18n">
           <nz-upload
             nzAccept=".jar"
@@ -175,7 +175,7 @@
       </nz-form-item>
 
       <nz-form-item>
-        <nz-form-label [nzSpan]="6" nzRequired="true" nzFor="enableStatus">{{ 'plugin.status' | i18n }}</nz-form-label>
+        <nz-form-label [nzSpan]="8" nzRequired="true" nzFor="enableStatus">{{ 'plugin.status' | i18n }}</nz-form-label>
         <nz-form-control [nzSpan]="14">
           <nz-switch formControlName="enableStatus" required></nz-switch>
         </nz-form-control>


### PR DESCRIPTION
## What's changed?

Adjusted the grid layout of the form in the plugin component:
- Increased `nz-form-label` span from `6` to `8` .
- Kept `nz-form-control` at `14` to maintain a more balanced visual width and prevent input stretching.

| Before | After |
| :--- | :--- |
| <img width="880" height="438" alt="2" src="https://github.com/user-attachments/assets/83776cf1-9163-413f-b56a-e35a106ed10a" />| <img width="870" height="407" alt="1" src="https://github.com/user-attachments/assets/81f7f69a-c7a2-4207-926a-e3e48ec23410" />  |

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
