### PR TITLE
[Fix]: fix TAG type mismatch by introducing schema version for TDengine

### DIFF
--- a/hertzbeat-warehouse/src/main/java/org/apache/hertzbeat/warehouse/store/history/tsdb/tdengine/TdEngineDataStorage.java
+++ b/hertzbeat-warehouse/src/main/java/org/apache/hertzbeat/warehouse/store/history/tsdb/tdengine/TdEngineDataStorage.java
@@ -68,8 +68,14 @@ public class TdEngineDataStorage extends AbstractHistoryDataStorage {
     private static final String INSTANCE_NULL = "''";
     private static final String CONSTANTS_CREATE_DATABASE = "CREATE DATABASE IF NOT EXISTS %s";
     private static final String INSERT_TABLE_DATA_SQL = "INSERT INTO `%s` USING `%s` TAGS (%s) VALUES %s";
-    private static final String CREATE_SUPER_TABLE_SQL = "CREATE STABLE IF NOT EXISTS `%s` %s TAGS (monitor BIGINT)";
+    private static final String CREATE_SUPER_TABLE_SQL = "CREATE STABLE IF NOT EXISTS `%s` %s TAGS (instance NCHAR(128))";
     private static final String NO_SUPER_TABLE_ERROR = "Table does not exist";
+    /**
+     * schema version suffix - increment when TAG definition changes.
+     * v1: instance BIGINT (original monitorId like 123456789)
+     * v2: instance NCHAR(128) (supports string instance values like 127.0.0.1:8080)
+     */
+    private static final String SUPER_TABLE_VERSION = "_v2";
 
     private static final String QUERY_HISTORY_WITH_INSTANCE_SQL =
             "SELECT ts, metric_labels, `%s` FROM `%s` WHERE metric_labels = '%s' AND ts >= now - %s order by ts desc";
@@ -185,7 +191,7 @@ public class TdEngineDataStorage extends AbstractHistoryDataStorage {
         String instance = metricsData.getInstance();
         String app = metricsData.getApp();
         String metrics = metricsData.getMetrics();
-        String superTable = getTable(app, metrics, "_super");
+        String superTable = getSuperTable(app, metrics);
         String table = getTable(app, metrics, instance);
         StringBuilder sqlBuffer = new StringBuilder();
         int i = 0;
@@ -246,7 +252,7 @@ public class TdEngineDataStorage extends AbstractHistoryDataStorage {
                 sqlBuffer.append(" ").append(String.format(sqlRowBuffer.toString(), formatStringValue(JsonUtil.toJson(labels))));
             }
 
-            String insertDataSql = String.format(INSERT_TABLE_DATA_SQL, table, superTable, instance, sqlBuffer);
+            String insertDataSql = String.format(INSERT_TABLE_DATA_SQL, table, superTable, "'" + formatStringValue(instance) + "'", sqlBuffer);
 
             if (log.isDebugEnabled()) {
                 log.debug(insertDataSql);
@@ -325,7 +331,12 @@ public class TdEngineDataStorage extends AbstractHistoryDataStorage {
                     .replace("[", "_")
                     .replace("]", "_");
         }
-        return app + "_" + metrics + "_" + instance;
+        return app + "_" + metrics + "_" + instance + SUPER_TABLE_VERSION;
+    }
+
+    @NotNull
+    private static String getSuperTable(String app, String metrics) {
+        return app + "_" + metrics + "_super" + SUPER_TABLE_VERSION;
     }
 
     private String formatStringValue(String value) {


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->
Please refer to #3961 

This PR resolves the issue where the monitor TAG was incorrectly defined as BIGINT in v1.8.0, causing insertion failures for string-based instance
1. appended a _v2 suffix to both Super Table and Sub-table names (e.g., ..._super_v2). This bypasses TDengine's limitation where TAG column types cannot be modified after table creation.
2. Updated monitor TAG type to NCHAR(128) in the new v2 schema.
<img width="2559" height="1398" alt="image" src="https://github.com/user-attachments/assets/08236fb5-e49e-429f-b17a-1a5c2fe096ef" />
<img width="2559" height="1398" alt="image" src="https://github.com/user-attachments/assets/ce200b09-77bc-43dd-b302-7b04cd490925" />

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
