### PR TITLE
[docs] Fix HTTP Service Discovery API response format

### DIFF
--- a/home/docs/help/http_sd.md
+++ b/home/docs/help/http_sd.md
@@ -18,21 +18,23 @@ HTTP Service Discovery allows HertzBeat to discover service instances by calling
 You need to provide or develop an HTTP API that meets the following requirements:
 
 1. **HTTP Method**: Support GET requests
-2. **Response Format**: Return JSON format data
-3. **Response Structure**: Must contain a `targets` field, which is a string array. Each string is a service instance address in the format `host:port`
+2. **Response Format**: Return JSON array format
+3. **Response Structure**: Must be an array format, each element contains a `target` field (note: singular), which is a string array. Each string is a service instance address in the format `host:port`
 4. **Accessibility**: The API must be accessible from HertzBeat
 
 #### API Response Example
 
 ```json
-{
-  "targets": [
-    "192.168.1.101:8080",
-    "192.168.1.102:8080",
-    "192.168.1.103:8080",
-    "api.example.com:443"
-  ]
-}
+[
+  {
+    "target": [
+      "192.168.1.101:8080",
+      "192.168.1.102:8080",
+      "192.168.1.103:8080",
+      "api.example.com:443"
+    ]
+  }
+]
 ```
 
 ### Configuration parameter
@@ -81,13 +83,15 @@ Suppose you have a service management API:
 - **Response**:
 
   ```json
-  {
-    "targets": [
-      "10.0.1.10:8080",
-      "10.0.1.11:8080",
-      "10.0.1.12:8080"
-    ]
-  }
+  [
+    {
+      "target": [
+        "10.0.1.10:8080",
+        "10.0.1.11:8080",
+        "10.0.1.12:8080"
+      ]
+    }
+  ]
   ```
 
 Configuration example:
@@ -134,7 +138,7 @@ Configuration example:
 
 ### Notes
 
-- **Response Format**: The API response must be in JSON format and contain a `targets` field (string array)
+- **Response Format**: The API response must be in JSON array format, each element contains a `target` field (note: singular, string array)
 - **Address Format**: Each target address should be in the format `host:port`, for example:
   - `192.168.1.100:8080`
   - `api.example.com:443`
@@ -171,21 +175,23 @@ Configuration example:
 
 #### Response with Additional Metadata
 
-While the basic requirement is just the `targets` field, your API can include additional metadata for future extensions:
+While the basic requirement is just the `target` field, your API can include additional metadata for future extensions:
 
 ```json
-{
-  "targets": [
-    "192.168.1.10:8080"
-  ],
-  "labels": {
-    "env": "production",
-    "version": "1.0.0"
+[
+  {
+    "target": [
+      "192.168.1.10:8080"
+    ],
+    "labels": {
+      "env": "production",
+      "version": "1.0.0"
+    }
   }
-}
+]
 ```
 
-Note: Currently, only the `targets` field is used for service discovery, but future versions may support using label information.
+Note: Currently, only the `target` field is used for service discovery, but future versions may support using label information.
 
 ### API Implementation Examples
 
@@ -197,16 +203,16 @@ Note: Currently, only the `targets` field is used for service discovery, but fut
 public class ServiceDiscoveryController {
 
     @GetMapping("/services")
-    public Map<String, Object> getServices() {
-        List`<String>` targets = Arrays.asList(
+    public List<Map<String, Object>> getServices() {
+        List<String> targets = Arrays.asList(
             "192.168.1.10:8080",
             "192.168.1.11:8080",
             "192.168.1.12:8080"
         );
 
         Map<String, Object> response = new HashMap<>();
-        response.put("targets", targets);
-        return response;
+        response.put("target", targets);
+        return Collections.singletonList(response);
     }
 }
 ```
@@ -221,8 +227,8 @@ app.get('/api/services', (req, res) => {
     '192.168.1.12:8080'
   ];
 
-  res.json({
-    targets: targets
-  });
+  res.json([{
+    target: targets
+  }]);
 });
 ```

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/http_sd.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/http_sd.md
@@ -18,21 +18,23 @@ HTTP 服务发现允许 HertzBeat 通过调用您的自定义 HTTP API 来发现
 您需要提供或开发一个满足以下要求的 HTTP API：
 
 1. **HTTP 方法**：支持 GET 请求
-2. **响应格式**：返回 JSON 格式数据
-3. **响应结构**：必须包含 `targets` 字段，该字段为字符串数组，每个字符串是一个服务实例地址，格式为 `host:port`
+2. **响应格式**：返回 JSON 格式数组
+3. **响应结构**：必须是数组格式，每个元素包含 `target` 字段（注意是单数），该字段为字符串数组，每个字符串是一个服务实例地址，格式为 `host:port`
 4. **可访问性**：该 API 必须可从 HertzBeat 访问
 
 #### API 响应示例
 
 ```json
-{
-  "targets": [
-    "192.168.1.101:8080",
-    "192.168.1.102:8080",
-    "192.168.1.103:8080",
-    "api.example.com:443"
-  ]
-}
+[
+  {
+    "target": [
+      "192.168.1.101:8080",
+      "192.168.1.102:8080",
+      "192.168.1.103:8080",
+      "api.example.com:443"
+    ]
+  }
+]
 ```
 
 ### 配置参数
@@ -81,13 +83,15 @@ HTTP 服务发现允许 HertzBeat 通过调用您的自定义 HTTP API 来发现
 - **响应**：
 
   ```json
-  {
-    "targets": [
-      "10.0.1.10:8080",
-      "10.0.1.11:8080",
-      "10.0.1.12:8080"
-    ]
-  }
+  [
+    {
+      "target": [
+        "10.0.1.10:8080",
+        "10.0.1.11:8080",
+        "10.0.1.12:8080"
+      ]
+    }
+  ]
   ```
 
 配置示例：
@@ -134,7 +138,7 @@ HTTP 服务发现允许 HertzBeat 通过调用您的自定义 HTTP API 来发现
 
 ### 注意事项
 
-- **响应格式**：API 响应必须是 JSON 格式且包含 `targets` 字段（字符串数组）
+- **响应格式**：API 响应必须是 JSON 数组格式，每个元素包含 `target` 字段（注意是单数，字符串数组）
 - **地址格式**：每个目标地址应为 `host:port` 格式，例如：
   - `192.168.1.100:8080`
   - `api.example.com:443`
@@ -171,21 +175,23 @@ HTTP 服务发现允许 HertzBeat 通过调用您的自定义 HTTP API 来发现
 
 #### 包含额外元数据的响应
 
-虽然基本要求只是 `targets` 字段，但您的 API 可以包含额外的元数据以供未来扩展使用：
+虽然基本要求只是 `target` 字段，但您的 API 可以包含额外的元数据以供未来扩展使用：
 
 ```json
-{
-  "targets": [
-    "192.168.1.10:8080"
-  ],
-  "labels": {
-    "env": "production",
-    "version": "1.0.0"
+[
+  {
+    "target": [
+      "192.168.1.10:8080"
+    ],
+    "labels": {
+      "env": "production",
+      "version": "1.0.0"
+    }
   }
-}
+]
 ```
 
-注意：目前仅使用 `targets` 字段进行服务发现，但未来版本可能支持使用标签信息。
+注意：目前仅使用 `target` 字段进行服务发现，但未来版本可能支持使用标签信息。
 
 ### API 实现示例
 
@@ -197,16 +203,16 @@ HTTP 服务发现允许 HertzBeat 通过调用您的自定义 HTTP API 来发现
 public class ServiceDiscoveryController {
 
     @GetMapping("/services")
-    public Map<String, Object> getServices() {
-        List`<String>` targets = Arrays.asList(
+    public List<Map<String, Object>> getServices() {
+        List<String> targets = Arrays.asList(
             "192.168.1.10:8080",
             "192.168.1.11:8080",
             "192.168.1.12:8080"
         );
 
         Map<String, Object> response = new HashMap<>();
-        response.put("targets", targets);
-        return response;
+        response.put("target", targets);
+        return Collections.singletonList(response);
     }
 }
 ```
@@ -221,8 +227,8 @@ app.get('/api/services', (req, res) => {
     '192.168.1.12:8080'
   ];
 
-  res.json({
-    targets: targets
-  });
+  res.json([{
+    target: targets
+  }]);
 });
 ```

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/version-1.7.x/help/http_sd.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/version-1.7.x/help/http_sd.md
@@ -18,21 +18,23 @@ HTTP 服务发现允许 HertzBeat 通过调用您的自定义 HTTP API 来发现
 您需要提供或开发一个满足以下要求的 HTTP API：
 
 1. **HTTP 方法**：支持 GET 请求
-2. **响应格式**：返回 JSON 格式数据
-3. **响应结构**：必须包含 `targets` 字段，该字段为字符串数组，每个字符串是一个服务实例地址，格式为 `host:port`
+2. **响应格式**：返回 JSON 格式数组
+3. **响应结构**：必须是数组格式，每个元素包含 `target` 字段（注意是单数），该字段为字符串数组，每个字符串是一个服务实例地址，格式为 `host:port`
 4. **可访问性**：该 API 必须可从 HertzBeat 访问
 
 #### API 响应示例
 
 ```json
-{
-  "targets": [
-    "192.168.1.101:8080",
-    "192.168.1.102:8080",
-    "192.168.1.103:8080",
-    "api.example.com:443"
-  ]
-}
+[
+  {
+    "target": [
+      "192.168.1.101:8080",
+      "192.168.1.102:8080",
+      "192.168.1.103:8080",
+      "api.example.com:443"
+    ]
+  }
+]
 ```
 
 ### 配置参数
@@ -81,13 +83,15 @@ HTTP 服务发现允许 HertzBeat 通过调用您的自定义 HTTP API 来发现
 - **响应**：
 
   ```json
-  {
-    "targets": [
-      "10.0.1.10:8080",
-      "10.0.1.11:8080",
-      "10.0.1.12:8080"
-    ]
-  }
+  [
+    {
+      "target": [
+        "10.0.1.10:8080",
+        "10.0.1.11:8080",
+        "10.0.1.12:8080"
+      ]
+    }
+  ]
   ```
 
 配置示例：
@@ -134,7 +138,7 @@ HTTP 服务发现允许 HertzBeat 通过调用您的自定义 HTTP API 来发现
 
 ### 注意事项
 
-- **响应格式**：API 响应必须是 JSON 格式且包含 `targets` 字段（字符串数组）
+- **响应格式**：API 响应必须是 JSON 数组格式，每个元素包含 `target` 字段（注意是单数，字符串数组）
 - **地址格式**：每个目标地址应为 `host:port` 格式，例如：
   - `192.168.1.100:8080`
   - `api.example.com:443`
@@ -171,21 +175,23 @@ HTTP 服务发现允许 HertzBeat 通过调用您的自定义 HTTP API 来发现
 
 #### 包含额外元数据的响应
 
-虽然基本要求只是 `targets` 字段，但您的 API 可以包含额外的元数据以供未来扩展使用：
+虽然基本要求只是 `target` 字段，但您的 API 可以包含额外的元数据以供未来扩展使用：
 
 ```json
-{
-  "targets": [
-    "192.168.1.10:8080"
-  ],
-  "labels": {
-    "env": "production",
-    "version": "1.0.0"
+[
+  {
+    "target": [
+      "192.168.1.10:8080"
+    ],
+    "labels": {
+      "env": "production",
+      "version": "1.0.0"
+    }
   }
-}
+]
 ```
 
-注意：目前仅使用 `targets` 字段进行服务发现，但未来版本可能支持使用标签信息。
+注意：目前仅使用 `target` 字段进行服务发现，但未来版本可能支持使用标签信息。
 
 ### API 实现示例
 
@@ -197,16 +203,16 @@ HTTP 服务发现允许 HertzBeat 通过调用您的自定义 HTTP API 来发现
 public class ServiceDiscoveryController {
 
     @GetMapping("/services")
-    public Map<String, Object> getServices() {
-        List`<String>` targets = Arrays.asList(
+    public List<Map<String, Object>> getServices() {
+        List<String> targets = Arrays.asList(
             "192.168.1.10:8080",
             "192.168.1.11:8080",
             "192.168.1.12:8080"
         );
 
         Map<String, Object> response = new HashMap<>();
-        response.put("targets", targets);
-        return response;
+        response.put("target", targets);
+        return Collections.singletonList(response);
     }
 }
 ```
@@ -221,8 +227,8 @@ app.get('/api/services', (req, res) => {
     '192.168.1.12:8080'
   ];
 
-  res.json({
-    targets: targets
-  });
+  res.json([{
+    target: targets
+  }]);
 });
 ```

--- a/home/versioned_docs/version-1.7.x/help/http_sd.md
+++ b/home/versioned_docs/version-1.7.x/help/http_sd.md
@@ -18,21 +18,23 @@ HTTP Service Discovery allows HertzBeat to discover service instances by calling
 You need to provide or develop an HTTP API that meets the following requirements:
 
 1. **HTTP Method**: Support GET requests
-2. **Response Format**: Return JSON format data
-3. **Response Structure**: Must contain a `targets` field, which is a string array. Each string is a service instance address in the format `host:port`
+2. **Response Format**: Return JSON array format
+3. **Response Structure**: Must be an array format, each element contains a `target` field (note: singular), which is a string array. Each string is a service instance address in the format `host:port`
 4. **Accessibility**: The API must be accessible from HertzBeat
 
 #### API Response Example
 
 ```json
-{
-  "targets": [
-    "192.168.1.101:8080",
-    "192.168.1.102:8080",
-    "192.168.1.103:8080",
-    "api.example.com:443"
-  ]
-}
+[
+  {
+    "target": [
+      "192.168.1.101:8080",
+      "192.168.1.102:8080",
+      "192.168.1.103:8080",
+      "api.example.com:443"
+    ]
+  }
+]
 ```
 
 ### Configuration parameter
@@ -81,13 +83,15 @@ Suppose you have a service management API:
 - **Response**:
 
   ```json
-  {
-    "targets": [
-      "10.0.1.10:8080",
-      "10.0.1.11:8080",
-      "10.0.1.12:8080"
-    ]
-  }
+  [
+    {
+      "target": [
+        "10.0.1.10:8080",
+        "10.0.1.11:8080",
+        "10.0.1.12:8080"
+      ]
+    }
+  ]
   ```
 
 Configuration example:
@@ -134,7 +138,7 @@ Configuration example:
 
 ### Notes
 
-- **Response Format**: The API response must be in JSON format and contain a `targets` field (string array)
+- **Response Format**: The API response must be in JSON array format, each element contains a `target` field (note: singular, string array)
 - **Address Format**: Each target address should be in the format `host:port`, for example:
   - `192.168.1.100:8080`
   - `api.example.com:443`
@@ -171,21 +175,23 @@ Configuration example:
 
 #### Response with Additional Metadata
 
-While the basic requirement is just the `targets` field, your API can include additional metadata for future extensions:
+While the basic requirement is just the `target` field, your API can include additional metadata for future extensions:
 
 ```json
-{
-  "targets": [
-    "192.168.1.10:8080"
-  ],
-  "labels": {
-    "env": "production",
-    "version": "1.0.0"
+[
+  {
+    "target": [
+      "192.168.1.10:8080"
+    ],
+    "labels": {
+      "env": "production",
+      "version": "1.0.0"
+    }
   }
-}
+]
 ```
 
-Note: Currently, only the `targets` field is used for service discovery, but future versions may support using label information.
+Note: Currently, only the `target` field is used for service discovery, but future versions may support using label information.
 
 ### API Implementation Examples
 
@@ -197,16 +203,16 @@ Note: Currently, only the `targets` field is used for service discovery, but fut
 public class ServiceDiscoveryController {
 
     @GetMapping("/services")
-    public Map<String, Object> getServices() {
-        List`<String>` targets = Arrays.asList(
+    public List<Map<String, Object>> getServices() {
+        List<String> targets = Arrays.asList(
             "192.168.1.10:8080",
             "192.168.1.11:8080",
             "192.168.1.12:8080"
         );
 
         Map<String, Object> response = new HashMap<>();
-        response.put("targets", targets);
-        return response;
+        response.put("target", targets);
+        return Collections.singletonList(response);
     }
 }
 ```
@@ -221,8 +227,8 @@ app.get('/api/services', (req, res) => {
     '192.168.1.12:8080'
   ];
 
-  res.json({
-    targets: targets
-  });
+  res.json([{
+    target: targets
+  }]);
 });
 ```


### PR DESCRIPTION
## What's changed?

<!-- Describe Your PR Here -->

The API response format example in the HTTP Service Discovery document does not match the actual code implementation, resulting in deserialization errors when users implement the API according to the document.

All error examples in the following 4 document files have been fixed

Incorrect format in the document:
```json
{
  "targets": [
    "192.168.1.101:8080",
    "192.168.1.102:8080"
  ]
}
```

log:
```text
2026-01-26 15:57:13 [1000000000-http_sd-target-3115] ERROR org.apache.hertzbeat.common.util.JsonUtil - Cannot deserialize value of type java.util.ArrayList<org.apache.hertzbeat.common.entity.sd.ServiceDiscoveryResponseEntity> from Object value (token JsonToken.START_OBJECT)
at [Source: REDACTED (StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION disabled); line: 1, column: 1]
com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize value of type java.util.ArrayList<org.apache.hertzbeat.common.entity.sd.ServiceDiscoveryResponseEntity> from Object value (token JsonToken.START_OBJECT)
at [Source: REDACTED (StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION disabled); line: 1, column: 1]
at com.fasterxml.jackson.databind.exc.MismatchedInputException.from(MismatchedInputException.java:59)
at com.fasterxml.jackson.databind.DeserializationContext.reportInputMismatch(DeserializationContext.java:1767)
at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1541)
at com.fasterxml.jackson.databind.DeserializationContext.handleUnexpectedToken(DeserializationContext.java:1488)
at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.handleNonArray(CollectionDeserializer.java:402)
at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:254)
at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:30)
at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4917)
at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3860)
at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3843)
at org.apache.hertzbeat.common.util.JsonUtil.fromJson(JsonUtil.java:82)
at org.apache.hertzbeat.collector.collect.sd.HttpSdCollectImpl.collect(HttpSdCollectImpl.java:87)
at org.apache.hertzbeat.collector.dispatch.MetricsCollect.run(MetricsCollect.java:202)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
at java.base/java.lang.Thread.run(Thread.java:840)
```

Code implementation in HttpSdCollectImpl.java:
```java
String responseBody = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
TypeReference<List<ServiceDiscoveryResponseEntity>> typeReference = new TypeReference<>() {};
final List<ServiceDiscoveryResponseEntity> responseEntityList = JsonUtil.fromJson(responseBody, typeReference);
if (CollectionUtils.isEmpty(responseEntityList)) {
    return;
}
```

Entity definition in ServiceDiscoveryResponseEntity.java:
```java
/**
 * Service Discovery Response Entity
 */
@Data
@Builder
@AllArgsConstructor
@NoArgsConstructor
public class ServiceDiscoveryResponseEntity {
    private List<String> target;
}
```

The expected format of the actual code:
```java
[
  {
    "target": [
      "192.168.1.101:8080",
      "192.168.1.102:8080"
    ]
  }
]
```

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
