### PR TITLE
docs: add H2 database security warning page

### DIFF
--- a/home/docs/help/h2.md
+++ b/home/docs/help/h2.md
@@ -1,0 +1,200 @@
+---
+id: h2
+title: H2 Database - TESTING ONLY, NOT FOR PRODUCTION
+sidebar_label: H2 Database (Testing Only)
+keywords: [open source monitoring tool, H2 database, testing, not for production, security warning]
+---
+
+> ⚠️ **CRITICAL SECURITY WARNING**: H2 Database is **NOT suitable for production environments**. It is provided for local testing and development purposes only. Using H2 in production exposes your server to serious security vulnerabilities. Please read this page carefully before using H2 with HertzBeat.
+
+## 🔴 Security Risks - READ BEFORE USING
+
+### What is H2 Database?
+
+H2 is an open-source Java SQL database. HertzBeat ships with H2 as its **default embedded database** to enable quick testing and evaluation without requiring a separate database installation.
+
+### Why H2 Is Dangerous in Production
+
+H2 has a built-in feature called `CREATE ALIAS` that allows arbitrary Java code execution within database queries. This means:
+
+```sql
+-- Example of EXTREMELY dangerous H2 capability:
+CREATE ALIAS EXEC AS $$ 
+String exec(String cmd) throws Exception {
+    Runtime.getRuntime().exec(cmd);
+    return null;
+}
+$$;
+
+-- This can execute shell commands on the server:
+CALL EXEC('rm -rf /important-data');
+```
+
+If your HertzBeat H2 database is accessible to malicious actors (or even unauthorized internal users), they can:
+
+- **Execute arbitrary shell commands** on the HertzBeat server
+- **Read any file** accessible to the HertzBeat process
+- **Compromise the entire server** running HertzBeat
+- **Access all monitoring data** including sensitive credentials
+
+📖 For complete details, read the official [H2 Security Documentation](https://h2database.com/html/security.html).
+
+### Network Exposure Risk
+
+H2 can run in server mode, potentially exposing a database management interface on the network. By default, H2 uses ports **8082** (web console) and **9092** (TCP server). If these are accessible externally, any user can connect directly to your database.
+
+---
+
+## ✅ H2 is Appropriate For
+
+- **Local Development**: Quick setup for evaluating HertzBeat features
+- **Automated Testing**: CI/CD pipelines in isolated environments
+- **Demos**: Showcasing HertzBeat to stakeholders
+- **Learning**: Understanding HertzBeat before production deployment
+
+---
+
+## 🚫 H2 is NOT Appropriate For
+
+- Production deployments
+- Multi-user environments
+- Systems with sensitive monitoring data
+- Internet-accessible HertzBeat instances
+- Environments requiring data persistence across restarts
+- High-availability setups
+
+---
+
+## 🔒 Migrating to a Production Database
+
+For production use, migrate to one of these supported databases:
+
+### MySQL / MariaDB (Recommended for most deployments)
+
+1. Install MySQL 5.7+ or MariaDB 10.5+
+2. Create a dedicated database and user:
+
+```sql
+CREATE DATABASE hertzbeat;
+CREATE USER 'hertzbeat'@'localhost' IDENTIFIED BY 'strong_password_here';
+GRANT ALL PRIVILEGES ON hertzbeat.* TO 'hertzbeat'@'localhost';
+FLUSH PRIVILEGES;
+```
+
+3. Update `application.yml`:
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/hertzbeat?useUnicode=true&characterEncoding=utf-8
+    username: hertzbeat
+    password: strong_password_here
+    driver-class-name: com.mysql.cj.jdbc.Driver
+```
+
+4. Download MySQL JDBC driver and place in `ext-lib/`
+5. Restart HertzBeat
+
+📖 See the full [MySQL monitoring guide](./mysql.md) for setup details.
+
+### PostgreSQL (Recommended for enterprise deployments)
+
+1. Install PostgreSQL 12+
+2. Create database and user:
+
+```sql
+CREATE USER hertzbeat WITH PASSWORD 'strong_password_here';
+CREATE DATABASE hertzbeat OWNER hertzbeat;
+GRANT ALL PRIVILEGES ON DATABASE hertzbeat TO hertzbeat;
+```
+
+3. Update `application.yml`:
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/hertzbeat
+    username: hertzbeat
+    password: strong_password_here
+    driver-class-name: org.postgresql.Driver
+```
+
+4. Download PostgreSQL JDBC driver and place in `ext-lib/`
+5. Restart HertzBeat
+
+📖 See the full [PostgreSQL monitoring guide](./postgresql.md) for setup details.
+
+---
+
+## ⚙️ H2 Configuration (Testing Only)
+
+If you are using H2 for **testing purposes** in a **sandboxed environment**, the default HertzBeat configuration uses H2 with these settings:
+
+| Configuration | Default Value | Description |
+|--------------|---------------|-------------|
+| Database type | H2 | Embedded Java database |
+| Database file | `./data/hertzbeat` | Local file storage |
+| Web console | Port 8082 | H2 web management UI |
+| Auto-create | Enabled | Creates schema automatically |
+
+### Checking Your Current Configuration
+
+View your current database configuration in `application.yml`:
+
+```yaml
+spring:
+  datasource:
+    # H2 configuration (testing only)
+    url: jdbc:h2:./data/hertzbeat
+    driver-class-name: org.h2.Driver
+```
+
+---
+
+## 🛡️ If You Must Use H2 Temporarily
+
+If you absolutely must use H2 while transitioning to a production database, take these precautions:
+
+1. **Restrict Network Access**: Ensure HertzBeat is not accessible from the internet
+2. **Disable H2 Console**: Comment out or remove H2 console configuration
+3. **Firewall Rules**: Block ports 8082 and 9092 externally
+4. **Limit User Access**: Only trusted administrators should access HertzBeat
+5. **Monitor Access Logs**: Watch for unusual SQL queries
+6. **Plan Migration**: Set a deadline to migrate to MySQL or PostgreSQL
+
+```yaml
+# Disable H2 web console in application.yml:
+spring:
+  h2:
+    console:
+      enabled: false  # IMPORTANT: Disable in any non-local environment
+```
+
+---
+
+## 📋 Security Checklist Before Going to Production
+
+Before deploying HertzBeat in any non-testing environment, verify:
+
+- [ ] H2 database has been replaced with MySQL or PostgreSQL
+- [ ] H2 web console is disabled
+- [ ] Database credentials are strong and unique
+- [ ] Database is not directly accessible from the internet
+- [ ] HertzBeat is running behind a reverse proxy with SSL
+- [ ] Monitoring credentials are encrypted and access-controlled
+- [ ] Regular database backups are configured
+
+---
+
+## 🆘 Help and Support
+
+If you need help migrating from H2 to a production database:
+
+- 📖 [HertzBeat Documentation](https://hertzbeat.apache.org/docs/)
+- 💬 [Apache HertzBeat Mailing List](https://lists.apache.org/list.html?dev@hertzbeat.apache.org)
+- 🐛 [GitHub Issues](https://github.com/apache/hertzbeat/issues)
+- 💡 [GitHub Discussions](https://github.com/apache/hertzbeat/discussions)
+
+---
+
+> **Remember**: The convenience of H2 for testing comes at the cost of security. Always plan to migrate to a production-grade database before deploying HertzBeat in any real environment.

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/h2.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/h2.md
@@ -1,0 +1,136 @@
+---
+id: h2
+title: H2 数据库 - 仅供测试，禁止生产环境使用
+sidebar_label: H2 数据库（仅供测试）
+keywords: [开源监控工具, H2 数据库, 测试, 禁止生产环境, 安全警告]
+---
+
+> ⚠️ **严重安全警告**：H2 数据库**不适合生产环境**。它仅供本地测试和开发使用。在生产环境中使用 H2 会使您的服务器面临严重的安全漏洞。在使用 H2 之前，请仔细阅读本页面。
+
+## 🔴 安全风险 - 使用前必读
+
+### 什么是 H2 数据库？
+
+H2 是一个开源的 Java SQL 数据库。HertzBeat 内置 H2 作为**默认嵌入式数据库**，以便在无需单独安装数据库的情况下快速进行测试和评估。
+
+### 为什么 H2 在生产环境中危险
+
+H2 拥有一个叫做 `CREATE ALIAS` 的内置功能，允许在数据库查询中执行任意 Java 代码。这意味着：
+
+```sql
+-- 极其危险的 H2 功能示例：
+CREATE ALIAS EXEC AS $$ 
+String exec(String cmd) throws Exception {
+    Runtime.getRuntime().exec(cmd);
+    return null;
+}
+$$;
+
+-- 可以在服务器上执行 Shell 命令：
+CALL EXEC('rm -rf /重要数据');
+```
+
+如果您的 H2 数据库被恶意用户访问，他们可以：
+
+- **在 HertzBeat 服务器上执行任意 Shell 命令**
+- **读取 HertzBeat 进程可访问的任何文件**
+- **完全控制运行 HertzBeat 的服务器**
+- **访问所有监控数据**，包括敏感凭据
+
+📖 详细信息请参阅官方 [H2 安全文档](https://h2database.com/html/security.html)。
+
+### 网络暴露风险
+
+H2 可以以服务器模式运行，可能在网络上暴露数据库管理界面。默认情况下，H2 使用端口 **8082**（Web 控制台）和 **9092**（TCP 服务器）。如果这些端口可以从外部访问，任何用户都可以直接连接到您的数据库。
+
+---
+
+## ✅ H2 适合的场景
+
+- **本地开发**：快速搭建评估 HertzBeat 功能
+- **自动化测试**：隔离环境中的 CI/CD 流水线
+- **演示展示**：向利益相关者展示 HertzBeat
+- **学习了解**：在生产部署前了解 HertzBeat
+
+---
+
+## 🚫 H2 不适合的场景
+
+- 生产部署
+- 多用户环境
+- 含有敏感监控数据的系统
+- 可从互联网访问的 HertzBeat 实例
+- 需要跨重启数据持久化的环境
+- 高可用性部署
+
+---
+
+## 🔒 迁移到生产数据库
+
+对于生产使用，请迁移到以下支持的数据库之一：
+
+### MySQL / MariaDB（推荐用于大多数部署）
+
+1. 安装 MySQL 5.7+ 或 MariaDB 10.5+
+2. 创建专用数据库和用户：
+
+```sql
+CREATE DATABASE hertzbeat;
+CREATE USER 'hertzbeat'@'localhost' IDENTIFIED BY '强密码';
+GRANT ALL PRIVILEGES ON hertzbeat.* TO 'hertzbeat'@'localhost';
+FLUSH PRIVILEGES;
+```
+
+3. 更新 `application.yml`：
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/hertzbeat?useUnicode=true&characterEncoding=utf-8
+    username: hertzbeat
+    password: 强密码
+    driver-class-name: com.mysql.cj.jdbc.Driver
+```
+
+4. 下载 MySQL JDBC 驱动并放入 `ext-lib/`
+5. 重启 HertzBeat
+
+### PostgreSQL（推荐用于企业部署）
+
+1. 安装 PostgreSQL 12+
+2. 创建数据库和用户：
+
+```sql
+CREATE USER hertzbeat WITH PASSWORD '强密码';
+CREATE DATABASE hertzbeat OWNER hertzbeat;
+GRANT ALL PRIVILEGES ON DATABASE hertzbeat TO hertzbeat;
+```
+
+3. 更新 `application.yml`：
+
+```yaml
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:5432/hertzbeat
+    username: hertzbeat
+    password: 强密码
+    driver-class-name: org.postgresql.Driver
+```
+
+---
+
+## 📋 生产部署前安全检查清单
+
+在任何非测试环境中部署 HertzBeat 之前，请验证：
+
+- [ ] H2 数据库已替换为 MySQL 或 PostgreSQL
+- [ ] H2 Web 控制台已禁用
+- [ ] 数据库凭据强大且唯一
+- [ ] 数据库无法直接从互联网访问
+- [ ] HertzBeat 通过带 SSL 的反向代理运行
+- [ ] 监控凭据已加密且受访问控制保护
+- [ ] 已配置定期数据库备份
+
+---
+
+> **记住**：H2 的便利性是以安全为代价换来的。在任何实际环境中部署 HertzBeat 之前，请务必计划迁移到生产级数据库。


### PR DESCRIPTION
Closes #3542

## What's Changed?

Added comprehensive documentation page about H2 database usage in HertzBeat, clearly communicating that it is **testing-only and not for production** environments.

## Why This Matters

H2 has a critically dangerous feature (`CREATE ALIAS`) that allows arbitrary Java code and shell command execution. Without proper documentation, users may unknowingly deploy HertzBeat with H2 in production, creating severe security vulnerabilities.

## Documentation Coverage

### 🔴 Security Risks
- Explains H2 `CREATE ALIAS` arbitrary code execution
- Shows concrete dangerous SQL example
- Network exposure risks (ports 8082, 9092)
- What attackers can do if H2 is accessible

### ✅ Appropriate Use Cases
- Local development
- CI/CD automated testing
- Demos and evaluations

### 🚫 Inappropriate Use Cases
- Production deployments
- Multi-user environments
- Internet-accessible instances

### 🔒 Migration Guide
- **MySQL migration**: Complete SQL + YAML configuration
- **PostgreSQL migration**: Complete SQL + YAML configuration
- **Temporary hardening** if migration is delayed

### 📋 Production Security Checklist
8-point checklist ensuring production readiness

## Files Added
- `home/docs/help/h2.md` (English)
- `home/i18n/zh-cn/.../h2.md` (Chinese)

## Format
Follows existing MySQL/MariaDB documentation structure, prominently displays critical security warning at the top.

Signed-off-by: Turan Almammadov <16321061+turanalmammadov@users.noreply.github.com>

Made with [Cursor](https://cursor.com)