### PR TITLE
Fix typo: occured to occurred

### DIFF
--- a/home/blog/2023-12-11-hertzbeat-v1.4.3.md
+++ b/home/blog/2023-12-11-hertzbeat-v1.4.3.md
@@ -94,7 +94,7 @@ Detailed config refer to [Install HertzBeat via Docker](https://hertzbeat.apache
 * support victoriametrics as metrics data storage by @tomsun28 in [https://github.com/apache/hertzbeat/pull/1361](https://github.com/apache/hertzbeat/pull/1361)
 * Add time type to support query_time of mysql and mariadb by @Clownsw in [https://github.com/apache/hertzbeat/pull/1364](https://github.com/apache/hertzbeat/pull/1364)
 * add Clownsw as a contributor for code by @allcontributors in [https://github.com/apache/hertzbeat/pull/1365](https://github.com/apache/hertzbeat/pull/1365)
-* Error occured when I followed running steps to start Front-web by @Calvin979 in [https://github.com/apache/hertzbeat/pull/1366](https://github.com/apache/hertzbeat/pull/1366)
+* Error occurred when I followed running steps to start Front-web by @Calvin979 in [https://github.com/apache/hertzbeat/pull/1366](https://github.com/apache/hertzbeat/pull/1366)
 * add Calvin979 as a contributor for doc by @allcontributors in [https://github.com/apache/hertzbeat/pull/1367](https://github.com/apache/hertzbeat/pull/1367)
 * enriches the cncf landscape by @tomsun28 in [https://github.com/apache/hertzbeat/pull/1368](https://github.com/apache/hertzbeat/pull/1368)
 * Fix flaky test in CollectUtilTest by @bbelide2 in [https://github.com/apache/hertzbeat/pull/1371](https://github.com/apache/hertzbeat/pull/1371)

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-12-11-hertzbeat-v1.4.3.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-12-11-hertzbeat-v1.4.3.md
@@ -113,7 +113,7 @@ keywords: [open source monitoring system, alerting system]
 - support victoriametrics as metrics data storage by @tomsun28 in [https://github.com/apache/hertzbeat/pull/1361](https://github.com/apache/hertzbeat/pull/1361)
 - Add time type to support query_time of mysql and mariadb by @Clownsw in [https://github.com/apache/hertzbeat/pull/1364](https://github.com/apache/hertzbeat/pull/1364)
 - add Clownsw as a contributor for code by @allcontributors in [https://github.com/apache/hertzbeat/pull/1365](https://github.com/apache/hertzbeat/pull/1365)
-- Error occured when I followed running steps to start Front-web by @Calvin979 in [https://github.com/apache/hertzbeat/pull/1366](https://github.com/apache/hertzbeat/pull/1366)
+- Error occurred when I followed running steps to start Front-web by @Calvin979 in [https://github.com/apache/hertzbeat/pull/1366](https://github.com/apache/hertzbeat/pull/1366)
 - add Calvin979 as a contributor for doc by @allcontributors in [https://github.com/apache/hertzbeat/pull/1367](https://github.com/apache/hertzbeat/pull/1367)
 - enriches the cncf landscape by @tomsun28 in [https://github.com/apache/hertzbeat/pull/1368](https://github.com/apache/hertzbeat/pull/1368)
 - Fix flaky test in CollectUtilTest by @bbelide2 in [https://github.com/apache/hertzbeat/pull/1371](https://github.com/apache/hertzbeat/pull/1371)


### PR DESCRIPTION
Fixes typo in blog files where 'occured' should be 'occurred'.