### PR TITLE
[bugfix] correct typo in sureness monitor delete verb definition

### DIFF
--- a/script/sureness.yml
+++ b/script/sureness.yml
@@ -25,7 +25,7 @@ resourceRole:
   - /api/monitor/**===get===[admin,user,guest]
   - /api/monitor/**===post===[admin,user]
   - /api/monitor/**===put===[admin,user]
-  - /api/monitor/**===delete==[admin]
+  - /api/monitor/**===delete===[admin]
   - /api/monitors/**===get===[admin,user,guest]
   - /api/monitors/**===post===[admin,user]
   - /api/monitors/**===put===[admin,user]


### PR DESCRIPTION
## What's changed?

In the script/sureness.yml file there is a typo in the permission definitions for one of the DELETE calls. Instead of using three equals signs, two were used. This is invalid and defaults to the lower levelled user (a standard user), being able to call the DELETE verb when only an admin user is expected to be able to perform this operation.

By default, Sureness defaults to allow. This is a low severity security issue.

As a result, a non-admin user can use the DELETE verb to delete monitors.

I've rectified this by simply fixing the typo'd definition.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [x] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
