### PR TITLE
[CI] update Docker build-push-action version

### DIFF
--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -56,7 +56,7 @@ jobs:
           verbose: true
 
       - name: Build Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         with:
           context: ./dist
           file: ./script/docker/server/Dockerfile


### PR DESCRIPTION
## Related Issue
Fixed: #4086

## What's changed?

<!-- Describe Your PR Here -->
ASF policy requires all third-party GitHub Actions to be pinned to a commit SHA
and approved via the ASF infrastructure allowlist.

This change aligns the workflow with the approved patterns defined in:
https://github.com/apache/infrastructure-actions

Do we need to update to tag v7?

``` yaml
docker/build-push-action:
  10e90e3645eae34f1e60eeb005ba3a3d33f178e8:
    tag: v6.19.2
    expires_at: 2026-06-14
  d08e5c354a6adb9ed34480a06d141179aa583294:
    tag: v7.0.0
```

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
