### PR TITLE
[doc] add questdb init doc to sidebar and unify label

### DIFF
--- a/.github/workflows/doc-build-test.yml
+++ b/.github/workflows/doc-build-test.yml
@@ -35,6 +35,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'

--- a/.github/workflows/doc-build-test.yml
+++ b/.github/workflows/doc-build-test.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: pnpm/action-setup@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
@@ -53,10 +54,10 @@ jobs:
           grep -vFf ./script/ci/exclude_files.txt all_md_files.txt > to_check.txt
           xargs -P 8 -a to_check.txt -I{} markdown-link-check -c ./script/ci/link_check.json -q "{}"
 
-      - name: NPM INSTALL
+      - name: PNPM INSTALL
         working-directory: home
-        run: npm install
+        run: pnpm install
 
-      - name: NPM BUILD
+      - name: PNPM BUILD
         working-directory: home
-        run: npm run build
+        run: pnpm run build

--- a/home/docs/start/questdb-init.md
+++ b/home/docs/start/questdb-init.md
@@ -4,7 +4,7 @@ id: questdb-init
 
 title: Installation and Initialization of Time-Series Database Service QuestDB (Optional)
 
-sidebar_label: Metric Data Storage - QuestDB
+sidebar_label: Metrics Store QuestDB
 
 ---
 

--- a/home/sidebars.json
+++ b/home/sidebars.json
@@ -46,6 +46,7 @@
             "start/victoria-metrics-init",
             "start/iotdb-init",
             "start/influxdb-init",
+            "start/questdb-init",
             "start/postgresql-change",
             "start/mysql-change"
           ]

--- a/home/versioned_docs/version-1.8.0/start/questdb-init.md
+++ b/home/versioned_docs/version-1.8.0/start/questdb-init.md
@@ -4,7 +4,7 @@ id: questdb-init
 
 title: Installation and Initialization of Time-Series Database Service QuestDB (Optional)
 
-sidebar_label: Metric Data Storage - QuestDB
+sidebar_label: Metrics Store QuestDB
 
 ---
 

--- a/home/versioned_sidebars/version-1.8.0-sidebars.json
+++ b/home/versioned_sidebars/version-1.8.0-sidebars.json
@@ -55,6 +55,7 @@
             "start/victoria-metrics-init",
             "start/iotdb-init",
             "start/influxdb-init",
+            "start/questdb-init",
             "start/postgresql-change",
             "start/mysql-change"
           ]


### PR DESCRIPTION
## What's changed?

Related: #3731

<!-- Describe Your PR Here -->

- add `start/questdb-init` to the home docs sidebar
- add `start/questdb-init` to the `version-1.8.0` sidebar
- rename the QuestDB doc sidebar label from `Metric Data Storage - QuestDB` to `Metrics Store QuestDB`

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
