### PR TITLE
add initial connection event for SSE emitter

### DIFF
--- a/hertzbeat-log/src/main/java/org/apache/hertzbeat/log/notice/LogSseManager.java
+++ b/hertzbeat-log/src/main/java/org/apache/hertzbeat/log/notice/LogSseManager.java
@@ -96,6 +96,16 @@ public class LogSseManager {
         emitter.onError((ex) -> removeEmitter(clientId));
 
         emitters.put(clientId, new SseSubscriber(emitter, filters));
+        try {
+            String initEventId = "init-" + System.currentTimeMillis();
+            emitter.send(SseEmitter.event()
+                .id(initEventId)
+                .name("CONNECTED")
+                .data("Connection established successfully"));
+        } catch (IOException e) {
+            log.warn("Failed to send initial event to client {}: {}", clientId, e.getMessage());
+            removeEmitter(clientId);
+        }
         return emitter;
     }
 


### PR DESCRIPTION
- Send CONNECTED event when creating SSE emitter to confirm connection
- Validate connection availability immediately on establishment
- Enable frontend to display connection status in real-time
- Clean up invalid emitters early if initial send fails

## What's changed?

<!-- Describe Your PR Here -->


## Checklist

- [ ]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
