### PR TITLE
ci: reduce repeated setup and nightly rebuild work

### DIFF
--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: ./script/ci/github-actions/setup-deps
 
       - name: Build with Maven
-        run: mvnd clean -B package -Prelease -Dmaven.test.skip=false --file pom.xml
+        run: mvnd clean -B package -pl '!hertzbeat-e2e' -Prelease -Dmaven.test.skip=false --file pom.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v4.0.1
@@ -58,6 +58,47 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
+
+      - name: Upload backend distribution
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-dist-${{ github.run_id }}
+          path: dist/
+          retention-days: 1
+          compression-level: 0
+
+  backend-maven-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./script/ci/github-actions/setup-deps
+
+      - name: Build backend Maven E2E modules
+        run: |
+          mvnd clean -B package \
+            -pl hertzbeat-e2e/hertzbeat-collector-common-e2e,hertzbeat-e2e/hertzbeat-collector-kafka-e2e,hertzbeat-e2e/hertzbeat-collector-basic-e2e,hertzbeat-e2e/hertzbeat-collector-mysql-r2dbc-e2e,hertzbeat-e2e/hertzbeat-log-e2e \
+            -am \
+            -Dmaven.test.skip=false \
+            --file pom.xml
+
+      - name: Upload Maven E2E coverage reports to Codecov
+        uses: codecov/codecov-action@v4.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          verbose: true
+
+  backend-image-e2e:
+    needs: backend-build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download backend distribution
+        uses: actions/download-artifact@v4
+        with:
+          name: backend-dist-${{ github.run_id }}
+          path: dist/
 
       - name: Build Image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
@@ -69,12 +110,9 @@ jobs:
 
       - name: Run E2E
         run: |
-          sudo curl -L https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
-          sudo chmod u+x /usr/local/bin/docker-compose
-
           cd e2e
-          sudo docker-compose version
-          sudo docker-compose up --exit-code-from testing --remove-orphans
+          docker compose version
+          docker compose up --exit-code-from testing --remove-orphans
 
       # upload application logs
       - name: Upload logs & API test reports

--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -38,6 +38,10 @@ on:
       - 'script/**'
       - 'material/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   backend-build:
     runs-on: ubuntu-latest
@@ -81,4 +85,3 @@ jobs:
           path: |
             e2e/logs/
             e2e/report/
-

--- a/.github/workflows/doc-build-test.yml
+++ b/.github/workflows/doc-build-test.yml
@@ -27,6 +27,10 @@ on:
     paths:
       - 'home/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   docs-build:
     runs-on: ubuntu-latest
@@ -37,6 +41,11 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+          cache-dependency-path: home/pnpm-lock.yaml
       - uses: actions/setup-python@v4
         with:
           python-version: '3.8'

--- a/.github/workflows/doc-deploy.yml
+++ b/.github/workflows/doc-deploy.yml
@@ -27,6 +27,10 @@ on:
   # Allow manual workflow trigger
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 # Set permissions for deployment
 permissions:
   contents: write
@@ -48,6 +52,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: pnpm
+          cache-dependency-path: home/pnpm-lock.yaml
 
       # Setup pnpm
       - name: Setup pnpm

--- a/.github/workflows/frontend-build-test.yml
+++ b/.github/workflows/frontend-build-test.yml
@@ -30,6 +30,10 @@ on:
     paths:
       - 'web-app/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,6 +42,11 @@ jobs:
     - uses: pnpm/action-setup@v4
       with:
         version: 10
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: pnpm
+        cache-dependency-path: web-app/pnpm-lock.yaml
     - name: Install
       working-directory: web-app
       run: pnpm install

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -26,6 +26,10 @@ on:
   pull_request:
     branches: [ master, dev ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-license-header:
     name: check-license-header

--- a/.github/workflows/mcp-bashserver-test.yml
+++ b/.github/workflows/mcp-bashserver-test.yml
@@ -27,10 +27,6 @@ on:
       - 'mcp-servers/mcp-bash-server/**'
       - '.github/workflows/mcp-bashserver-test.yml'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.88.0

--- a/.github/workflows/mcp-bashserver-test.yml
+++ b/.github/workflows/mcp-bashserver-test.yml
@@ -27,6 +27,10 @@ on:
       - 'mcp-servers/mcp-bash-server/**'
       - '.github/workflows/mcp-bashserver-test.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_VERSION: 1.88.0

--- a/.github/workflows/monitor-e2e-test.yml
+++ b/.github/workflows/monitor-e2e-test.yml
@@ -27,6 +27,11 @@ on:
     - cron: '0 1 * * *'
   push:
     branches: [ action* ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-license-header:
     name: Monitor E2E Test

--- a/.github/workflows/monitor-e2e-test.yml
+++ b/.github/workflows/monitor-e2e-test.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./script/ci/github-actions/setup-deps
       - name: Build with Maven
-        run: mvn clean -B package -Prelease -Dmaven.test.skip=true --file pom.xml
+        run: mvnd -B clean package -Prelease -Dmaven.test.skip=true --file pom.xml
       - name: Build Image
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
         with:
@@ -51,8 +51,6 @@ jobs:
           tags: apache/hertzbeat:test
       - name: Run K8s Monitor E2E Test
         run: |
-          sudo curl -L https://github.com/docker/compose/releases/download/v2.23.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
-          sudo chmod u+x /usr/local/bin/docker-compose
           cd e2e/k8s
-          sudo docker-compose version
-          sudo docker-compose up --exit-code-from testing --remove-orphans
+          docker compose version
+          docker compose up --exit-code-from testing --remove-orphans

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -24,6 +24,10 @@ on:
   push:
     branches: [ action* ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -34,6 +38,11 @@ jobs:
     - uses: pnpm/action-setup@v4
       with:
         version: 10
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: pnpm
+        cache-dependency-path: web-app/pnpm-lock.yaml
 
     - name: Build the Frontend
       run: |
@@ -43,10 +52,8 @@ jobs:
 
     - name: Build the Backend
       run: |
-        mvn clean install
-        mvn clean package -Prelease -DskipTests
-        cd hertzbeat-collector
-        mvn clean package -Pcluster -DskipTests
+        mvnd -B clean install -Prelease -DskipTests
+        mvnd -B -f hertzbeat-collector/hertzbeat-collector-collector/pom.xml package -Pcluster -DskipTests
 
     - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
     - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -52,7 +52,8 @@ jobs:
 
     - name: Build the Backend
       run: |
-        mvnd -B clean install -Prelease -DskipTests
+        mvnd -B clean install
+        mvnd -B -f hertzbeat-startup/pom.xml package -Prelease -DskipTests
         mvnd -B -f hertzbeat-collector/hertzbeat-collector-collector/pom.xml package -Pcluster -DskipTests
 
     - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -52,9 +52,7 @@ jobs:
 
     - name: Build the Backend
       run: |
-        mvnd -B clean install
-        mvnd -B -f hertzbeat-startup/pom.xml package -Prelease -DskipTests
-        mvnd -B -f hertzbeat-collector/hertzbeat-collector-collector/pom.xml package -Pcluster -DskipTests
+        mvnd -B clean package -Prelease,Pcluster -Dmaven.test.skip=false --file pom.xml
 
     - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
     - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd

--- a/script/ci/github-actions/setup-deps/action.yml
+++ b/script/ci/github-actions/setup-deps/action.yml
@@ -28,22 +28,31 @@ runs:
         java-version: 25
         cache: maven
 
+    - name: Validate mvnd runner support
+      shell: bash
+      run: |
+        if [ "${RUNNER_OS}" != "Linux" ] || [ "${RUNNER_ARCH}" != "X64" ]; then
+          echo "setup-deps currently supports mvnd only on Linux/X64 runners; got ${RUNNER_OS}/${RUNNER_ARCH}" >&2
+          exit 1
+        fi
+
     - name: Cache mvnd
       id: mvnd-cache
       uses: actions/cache@v4
       with:
         path: ~/.local/mvnd
-        key: ${{ runner.os }}-${{ runner.arch }}-mvnd-2.0.0-rc-3
+        key: mvnd-2.0.0-rc-3-linux-amd64
 
     - name: Install mvnd
       if: steps.mvnd-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         MVND_VERSION=2.0.0-rc-3
-        curl -sL https://dlcdn.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-linux-amd64.zip -o mvnd.zip
+        MVND_PLATFORM=linux-amd64
+        curl -sL https://dlcdn.apache.org/maven/mvnd/${MVND_VERSION}/maven-mvnd-${MVND_VERSION}-${MVND_PLATFORM}.zip -o mvnd.zip
         unzip -q mvnd.zip
         mkdir -p $HOME/.local
-        mv maven-mvnd-${MVND_VERSION}-linux-amd64 $HOME/.local/mvnd
+        mv maven-mvnd-${MVND_VERSION}-${MVND_PLATFORM} $HOME/.local/mvnd
 
     - name: Export mvnd environment
       shell: bash

--- a/script/ci/github-actions/setup-deps/action.yml
+++ b/script/ci/github-actions/setup-deps/action.yml
@@ -26,8 +26,17 @@ runs:
       with:
         distribution: "zulu"
         java-version: 25
+        cache: maven
+
+    - name: Cache mvnd
+      id: mvnd-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/mvnd
+        key: ${{ runner.os }}-${{ runner.arch }}-mvnd-2.0.0-rc-3
 
     - name: Install mvnd
+      if: steps.mvnd-cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         MVND_VERSION=2.0.0-rc-3
@@ -35,6 +44,10 @@ runs:
         unzip -q mvnd.zip
         mkdir -p $HOME/.local
         mv maven-mvnd-${MVND_VERSION}-linux-amd64 $HOME/.local/mvnd
+
+    - name: Export mvnd environment
+      shell: bash
+      run: |
         echo "$HOME/.local/mvnd/bin" >> $GITHUB_PATH
         echo "MVND_HOME=$HOME/.local/mvnd" >> $GITHUB_ENV
 


### PR DESCRIPTION
## What's changed?

This PR now contains two CI optimization stages that keep the workflow scope intact but reduce repeated setup work and shorten the backend PR critical path:

### Stage 1
- cache Maven dependencies in the shared Java setup action
- cache the downloaded `mvnd` distribution in the shared Java setup action
- add `concurrency` to cancel superseded workflow runs for the same branch/PR
- add pnpm cache setup for frontend/docs workflows
- align the mvnd cache key with the actual Linux/X64 artifact and fail fast on unsupported runners

### Stage 2
- split the backend PR workflow so the heavy Maven `hertzbeat-e2e` subtree runs in its own parallel required job
- keep the core backend build focused on non-E2E modules while still producing `dist/` for the Docker image + API E2E lane
- upload Codecov coverage from both the core backend lane and the Maven-E2E lane
- switch monitor/backend compose-based flows to native `docker compose` instead of downloading legacy `docker-compose` each run
- keep nightly backend tests enabled while collapsing duplicated packaging work into a single Maven invocation

This branch intentionally does **not** modify `MCP Bash Server CI`: editing that workflow currently surfaces an unrelated enterprise action-allowlist failure (`dtolnay/rust-toolchain@stable`), which should be handled separately.

## Why this should help

Baseline evidence from the current repo before stage 2:
- `Backend CI` green runs around `14m35s`, with about `12m33s` spent in one Maven step
- that Maven step also included the `hertzbeat-e2e` subtree, whose reactor summary contained several long modules such as `hertzbeat-log-e2e` (`3m42s`) and `hertzbeat-collector-basic-e2e` (`1m38s`)
- Docker image build + API E2E were only about `84s` combined

The intended result is:
- the core backend lane reports much sooner because it no longer waits on the Maven E2E subtree
- the Docker image + API E2E lane starts from the uploaded `dist/` artifact as soon as the core build is done
- the Maven E2E subtree still runs as a separate required parallel check instead of being dropped
- repeat pushes waste less runner time because older runs are auto-cancelled

## Validation

- parsed changed workflow YAML files and the shared composite action with `python3` + `yaml.safe_load`
- ran `git diff --check`
- locally validated that the new explicit Maven E2E module selector expands to the intended leaf modules before failing on the local machine's JDK < 25
- confirmed local `docker compose version` availability for the compose-command migration

## Checklist

- [x] I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
