### PR TITLE
bugfix Update delete dashboard response message to success

### DIFF
--- a/hertzbeat-grafana/src/main/java/org/apache/hertzbeat/grafana/controller/DashboardController.java
+++ b/hertzbeat-grafana/src/main/java/org/apache/hertzbeat/grafana/controller/DashboardController.java
@@ -102,6 +102,6 @@ public class DashboardController {
             log.error("delete dashboard error", e);
             return ResponseEntity.ok(Message.fail(FAIL_CODE, "delete dashboard fail"));
         }
-        return ResponseEntity.ok(Message.fail(FAIL_CODE, "delete dashboard fail"));
+        return ResponseEntity.ok(Message.success("delete dashboard success"));
     }
 }


### PR DESCRIPTION
## What's changed?

changed the `DashboardController#deleteDashboardByMonitorId()`,

if deleteDashboard successful,must return`Message.success()`,not `Message.fail()`

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.
