### PR TITLE
[improve] Improve LogRealTimeAlertE2eTest group alert flakiness

### DIFF
--- a/hertzbeat-e2e/hertzbeat-log-e2e/src/test/java/org/apache/hertzbeat/log/alert/LogRealTimeAlertE2eTest.java
+++ b/hertzbeat-e2e/hertzbeat-log-e2e/src/test/java/org/apache/hertzbeat/log/alert/LogRealTimeAlertE2eTest.java
@@ -140,7 +140,7 @@ public class LogRealTimeAlertE2eTest {
         capturedGroupAlerts.clear();
 
         // Wait for group alert to be generated via AlarmCommonReduce
-        await().atMost(Duration.ofSeconds(60))
+        await().atMost(TEST_WAIT_TIMEOUT)
                 .pollInterval(Duration.ofSeconds(3))
                 .untilAsserted(() -> assertFalse(capturedGroupAlerts.isEmpty(),
                         "Should have generated high frequency warning group alert"));

--- a/hertzbeat-e2e/hertzbeat-log-e2e/src/test/resources/vector.yml
+++ b/hertzbeat-e2e/hertzbeat-log-e2e/src/test/resources/vector.yml
@@ -123,4 +123,4 @@ sinks:
       # Batch settings for better throughput
       batch:
         max_bytes: 524288
-        timeout_secs: 5
+        timeout_secs: 1


### PR DESCRIPTION
## What's changed?

CI failure on LogRealTimeAlertE2eTest.testRealTimeLogAlertWithGroupAlert: ConditionTimeout after 60s, group alert never captured.                                                  
                                 
The alert pipeline has a hard-coded 30s watermark delay in TimeService, so a 10s window can't close until maxEventTs ≥ windowEnd + 30s. Combined with Vector's 5s batch interval and the 5s watermark broadcast cycle, the first group alert can't fire before ~46s after Vector starts — leaving only ~14s of headroom in a 60s budget, which CI scheduling jitter consumes.      

## Changes

- LogRealTimeAlertE2eTest.java: group test budget 60s → TEST_WAIT_TIMEOUT (120s), matching the individual test.                                                               
- vector.yml: batch.timeout_secs: 5 → 1, so maxEventTs advances each second and windows close sooner.
- Local: 2 tests pass in 82s.     

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
