### PR TITLE
[fix] fix Dockerfile directory creation error

### DIFF
--- a/script/docker/collector/Dockerfile
+++ b/script/docker/collector/Dockerfile
@@ -24,7 +24,7 @@ ARG VERSION
 # Install SSH
 RUN  sed -i 's#http://#https://#g' /etc/apt/sources.list.d/ubuntu.sources && \
     apt-get update && apt-get install -y openssh-server
-RUN mkdir /var/run/sshd
+RUN mkdir -p /var/run/sshd
 
 ADD apache-hertzbeat-collector-${VERSION}-bin.tar.gz /opt/
 

--- a/script/docker/server/Dockerfile
+++ b/script/docker/server/Dockerfile
@@ -22,7 +22,7 @@ MAINTAINER Apache HertzBeat "dev@hertzbeat.apache.org"
 # Install SSH And Locales
 RUN  sed -i 's#http://#https://#g' /etc/apt/sources.list.d/ubuntu.sources && \
      apt-get update && apt-get install -y openssh-server && apt-get install -y locales
-RUN mkdir /var/run/sshd
+RUN mkdir -p /var/run/sshd
 # Build zh_CN en_US locale resource package
 RUN localedef -c -f UTF-8 -i zh_CN zh_CN.UTF-8
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8


### PR DESCRIPTION
## What's changed?

This PR fixes the Docker image build failure caused by `mkdir /var/run/sshd`.

The base image `eclipse-temurin:25-jdk` is a floating tag and now resolves to an Ubuntu 26.04/resolute based image. With the current `openssh-server` package, `/run/sshd` is already created during package installation. Since `/var/run` points to `/run`, running `mkdir /var/run/sshd` fails with: mkdir: /var/run/sshd: File exists


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.