### PR TITLE
[fix] fixed the JMX service URL validation issue

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/jmx/JmxCollectImpl.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/jmx/JmxCollectImpl.java
@@ -18,9 +18,11 @@
 package org.apache.hertzbeat.collector.collect.jmx;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -106,31 +108,42 @@ public class JmxCollectImpl extends AbstractCollect {
     }
 
     /**
-     * Validate JMX URL 
-     * 
+     * Validate JMX URL
+     *
      * @param url JMX URL to validate
      * @throws IllegalArgumentException if URL is potentially malicious
      */
     private void validateJmxUrl(String url) throws IllegalArgumentException {
-        // Only allow service:jmx:rmi protocol
-        Assert.isTrue(url.startsWith("service:jmx:rmi:"), "Only service:jmx:rmi protocol is supported");
+        JMXServiceURL serviceUrl;
+        try {
+            serviceUrl = new JMXServiceURL(url);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Invalid JMX URL", e);
+        }
+        Assert.isTrue("rmi".equalsIgnoreCase(serviceUrl.getProtocol()), "Only service:jmx:rmi protocol is supported");
 
-        String[] disallowedPatterns = { "ldap:", "rmi:", "iiop:", "nis:", "dns:", "corbaname:", "http:", "https:" };
+        String lowerUrl = url.toLowerCase(Locale.ROOT);
+        String[] disallowedPatterns = {"ldap:", "iiop:", "nis:", "dns:", "corbaname:", "http:", "https:"};
         for (String pattern : disallowedPatterns) {
-            if (url.contains(pattern) && !pattern.equals("rmi:///jndi/rmi:")) {
+            if (lowerUrl.contains(pattern)) {
                 throw new IllegalArgumentException("Potentially unsafe JNDI protocol detected in URL: " + pattern);
             }
         }
 
+        String lowerPath = serviceUrl.getURLPath().toLowerCase(Locale.ROOT);
+        if (lowerPath.startsWith("/jndi/") && !lowerPath.startsWith("/jndi/rmi://")) {
+            throw new IllegalArgumentException("Only rmi JNDI protocol is supported");
+        }
+
         // Check for suspicious patterns
-        if (url.contains("${") || url.contains("$[") || url.contains(":#") || url.contains(":/")) {
+        if (url.contains("${") || url.contains("$[") || url.contains(":#")) {
             throw new IllegalArgumentException("Potentially malicious pattern detected in JMX URL");
         }
     }
 
     /**
-     * Validate hostname format 
-     * 
+     * Validate hostname format
+     *
      * @param hostname Hostname to validate
      * @return true if hostname is valid
      */

--- a/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/jmx/JmxCollectImplTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/jmx/JmxCollectImplTest.java
@@ -50,7 +50,7 @@ class JmxCollectImplTest {
             JmxProtocol jmx = JmxProtocol.builder().build();
             jmx.setUrl("/stub/");
             Metrics metrics = Metrics.builder().jmx(jmx).build();
-            
+
             jmxCollect.preCheck(metrics);
         });
     }
@@ -68,4 +68,25 @@ class JmxCollectImplTest {
     void supportProtocol() {
         assert DispatchConstants.PROTOCOL_JMX.equals(jmxCollect.supportProtocol());
     }
+
+    @Test
+    void preCheckShouldAcceptSupportedJmxRmiUrl() {
+        JmxProtocol jmx = JmxProtocol.builder()
+            .url("service:jmx:rmi:///jndi/rmi://127.0.0.1:9999/jmxrmi")
+            .build();
+        Metrics metrics = Metrics.builder().jmx(jmx).build();
+
+        assertDoesNotThrow(() -> jmxCollect.preCheck(metrics));
+    }
+
+    @Test
+    void preCheckShouldRejectUnsafeJndiProtocolInJmxRmiUrl() {
+        JmxProtocol jmx = JmxProtocol.builder()
+            .url("service:jmx:rmi:///jndi/ldap://127.0.0.1:1389/jmxrmi")
+            .build();
+        Metrics metrics = Metrics.builder().jmx(jmx).build();
+
+        assertThrows(IllegalArgumentException.class, () -> jmxCollect.preCheck(metrics));
+    }
+
 }


### PR DESCRIPTION
## What's changed?

close #4144 

Fixed two logic bugs in `JmxCollectImpl#validateJmxUrl` that caused all valid URLs to be incorrectly rejected:
- The guard condition for "rmi:" in `disallowedPatterns` is always true, causing valid URLs to be rejected
- The `url.contains(":/")` condition at the end will match all valid JMX URLs

## Modification details
- Switch to JMXServiceURL resolution + precise validation of the path prefix.
- Switch to using Locale.ROOT case normalization to prevent bypassing.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

<img width="1507" height="831" alt="image" src="https://github.com/user-attachments/assets/0df816f6-7577-4788-9d22-f63bc200beb5" />
