### PR TITLE
fix: avoid blocking modify monitor by redundant detect call

### DIFF
--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/MonitorServiceImpl.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/MonitorServiceImpl.java
@@ -431,12 +431,6 @@ public class MonitorServiceImpl implements MonitorService {
                 newJobId = collectJobScheduling.updateAsyncCollectJob(appDefine, collector);
             }
             monitor.setJobId(newJobId);
-
-            // execute only in non paused status
-            try {
-                detectMonitor(monitor, params, collector);
-            } catch (Exception ignored) {
-            }
         }
 
         // After the update is successfully released, refresh the database
@@ -451,6 +445,8 @@ public class MonitorServiceImpl implements MonitorService {
             // force update gmtUpdate time, due the case: monitor not change, param change.
             // we also think monitor change
             monitor.setGmtUpdate(LocalDateTime.now());
+            // preserve the live status owned by the real-time collection path; the modify request must not overwrite it
+            monitor.setStatus(preMonitor.getStatus());
             // update or open grafana dashboard
             if (monitor.getApp().equals(CommonConstants.PROMETHEUS) && grafanaDashboard != null) {
                 if (grafanaDashboard.isEnabled()) {

--- a/hertzbeat-manager/src/test/java/org/apache/hertzbeat/manager/service/MonitorServiceTest.java
+++ b/hertzbeat-manager/src/test/java/org/apache/hertzbeat/manager/service/MonitorServiceTest.java
@@ -65,6 +65,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.aggregator.ArgumentsAccessor;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -632,6 +633,46 @@ class MonitorServiceTest {
 
         assertThrows(MonitorDatabaseException.class,
                 () -> monitorService.modifyMonitor(dto.getMonitor(), dto.getParams(), null, null));
+    }
+
+    @Test
+    void testModifyMonitorPreservesLiveStatus() {
+        long monitorId = 1L;
+        List<Param> params = Collections.singletonList(Param.builder()
+                .field("field")
+                .paramValue("value")
+                .build());
+        Monitor preMonitor = Monitor.builder().jobId(1L).intervals(1).app("app").name("memory").instance("host")
+                .id(monitorId).status(CommonConstants.MONITOR_UP_CODE).build();
+        Monitor monitor = Monitor.builder().jobId(1L).intervals(1).app("app").name("memory").instance("host")
+                .id(monitorId).status(CommonConstants.MONITOR_PAUSED_CODE).build();
+        Job job = new Job();
+        job.setApp(monitor.getApp());
+        when(monitorDao.findById(monitorId)).thenReturn(Optional.of(preMonitor));
+        when(tagService.determineNewLabels(any())).thenReturn(Collections.emptyList());
+        when(appService.getAppDefine(monitor.getApp())).thenReturn(job);
+        when(collectJobScheduling.updateAsyncCollectJob(any(Job.class))).thenReturn(1L);
+
+        monitorService.modifyMonitor(monitor, params, null, null);
+
+        ArgumentCaptor<Monitor> monitorCaptor = ArgumentCaptor.forClass(Monitor.class);
+        verify(monitorDao).save(monitorCaptor.capture());
+        assertEquals(CommonConstants.MONITOR_UP_CODE, monitorCaptor.getValue().getStatus());
+
+        reset(monitorDao, tagService, appService, collectJobScheduling, paramDao, collectorMonitorBindDao);
+        long pausedMonitorId = 2L;
+        Monitor pausedPreMonitor = Monitor.builder().jobId(2L).intervals(1).app("app").name("memory").instance("host")
+                .id(pausedMonitorId).status(CommonConstants.MONITOR_PAUSED_CODE).build();
+        Monitor pausedMonitor = Monitor.builder().jobId(2L).intervals(1).app("app").name("memory").instance("host")
+                .id(pausedMonitorId).status(CommonConstants.MONITOR_UP_CODE).build();
+        when(monitorDao.findById(pausedMonitorId)).thenReturn(Optional.of(pausedPreMonitor));
+        when(tagService.determineNewLabels(any())).thenReturn(Collections.emptyList());
+
+        monitorService.modifyMonitor(pausedMonitor, params, null, null);
+
+        monitorCaptor = ArgumentCaptor.forClass(Monitor.class);
+        verify(monitorDao).save(monitorCaptor.capture());
+        assertEquals(CommonConstants.MONITOR_PAUSED_CODE, monitorCaptor.getValue().getStatus());
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

This makes `modifyMonitor` in `MonitorServiceImpl` no longer block on a synchronous detection pass. Previously the update path called `detectMonitor` inline, which runs a synchronous collection on the request thread and could block for a long time, eventually timing out the API even though the save itself succeeded.

Removing that synchronous detect on its own would let the final full-row save persist the status carried on the request, overwriting the live status that the real-time collection path maintains (raised in review). So the change also preserves the existing status before the save, `monitor.setStatus(preMonitor.getStatus())`, on the common path that both the active and paused branches reach. The collector continues to refresh the status on its next scheduled run.

A unit test (`testModifyMonitorPreservesLiveStatus`) covers both that a live monitor keeps its status across a modify and that a paused monitor is not flipped.

Resolves #3812

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
