### PR TITLE
[fix] fix monitor list showing previous page as unavailable when paging

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-list/monitor-list.component.ts
@@ -114,13 +114,7 @@ export class MonitorListComponent implements OnInit, OnDestroy {
       clearInterval(this.intervalId);
     }
 
-    if (this.previousMonitors) {
-      this.previousMonitors.forEach(monitor => {
-        if (monitor._graceTimer) {
-          clearTimeout(monitor._graceTimer);
-        }
-      });
-    }
+    this.clearGraceTimers();
   }
 
   onAppChanged(): void {
@@ -160,7 +154,8 @@ export class MonitorListComponent implements OnInit, OnDestroy {
   }
 
   sync() {
-    this.loadMonitorTable(this.currentSortField, this.currentSortOrder);
+    // Reconcile only on auto-refresh so externally removed monitors fade out instead of blinking away.
+    this.loadMonitorTable(this.currentSortField, this.currentSortOrder, true);
   }
 
   getAppIconName(app: string | undefined): string {
@@ -178,7 +173,7 @@ export class MonitorListComponent implements OnInit, OnDestroy {
     return icon;
   }
 
-  loadMonitorTable(sortField?: string | null, sortOrder?: string | null) {
+  loadMonitorTable(sortField?: string | null, sortOrder?: string | null, reconcile: boolean = false) {
     this.tableLoading = true;
     let monitorInit$ = this.monitorSvc
       .searchMonitors(this.app, this.labels, this.filterContent, this.filterStatus, this.pageIndex - 1, this.pageSize, sortField, sortOrder)
@@ -189,7 +184,7 @@ export class MonitorListComponent implements OnInit, OnDestroy {
           this.checkedMonitorIds.clear();
           if (message.code === 0) {
             let page = message.data;
-            this.monitors = this.reconcileMonitorStates(page.content);
+            this.monitors = reconcile ? this.reconcileMonitorStates(page.content) : this.resetMonitorStates(page.content);
             this.pageIndex = page.number + 1;
             this.total = page.totalElements;
           } else {
@@ -214,7 +209,8 @@ export class MonitorListComponent implements OnInit, OnDestroy {
           this.checkedMonitorIds.clear();
           if (message.code === 0) {
             let page = message.data;
-            this.monitors = this.reconcileMonitorStates(page.content);
+            // Pagination changes the result set, so reconcile here would flag the previous page as "disappeared" (#4156).
+            this.monitors = this.resetMonitorStates(page.content);
             this.pageIndex = page.number + 1;
             this.total = page.totalElements;
           } else {
@@ -663,6 +659,25 @@ export class MonitorListComponent implements OnInit, OnDestroy {
         }
       }
     );
+  }
+
+  // Replace the list as-is for result-set swaps (load, pagination, filter, post-CRUD reload), without keeping stale rows.
+  private resetMonitorStates(newMonitors: Monitor[]): Monitor[] {
+    this.clearGraceTimers();
+    const processedMonitors = newMonitors.map(monitor => ({
+      ...monitor,
+      _displayStatus: 'ACTIVE' as const
+    }));
+    this.previousMonitors = [...processedMonitors];
+    return processedMonitors;
+  }
+
+  private clearGraceTimers(): void {
+    this.previousMonitors?.forEach(monitor => {
+      if (monitor._graceTimer) {
+        clearTimeout(monitor._graceTimer);
+      }
+    });
   }
 
   private reconcileMonitorStates(newMonitors: Monitor[]): Monitor[] {


### PR DESCRIPTION
## What's changed?

close #4156 

when paging through the monitor list, the previous page's monitors lingered as greyed-out "unavailable" rows on the new page until the next auto-refresh.

`reconcileMonitorStates()` ran on every load. It treats any monitor missing from the new response as removed and fades it out for 5s — correct for the 2-minute auto-refresh, but wrong for pagination, where the previous page is naturally absent and got misflagged as "disappeared".

## Modification details

Reconciliation now runs only on auto-refresh (sync()). Pagination and other reloads use a new resetMonitorStates() that replaces the list directly and clears pending grace timers, so no stale rows carry over.
  
## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

## Effect

user-initiated actions (paging, delete, enable/disable, import) apply immediately; only the background auto-refresh keeps the graceful fade for externally-removed monitors.

<img width="1350" height="626" alt="Jun-18-2026 17-51-27" src="https://github.com/user-attachments/assets/48c5c5b8-ab7e-4ba9-b4ee-9cdd44d1f611" />

> Fade-out effect

<img width="1704" height="576" alt="capcap-260618-164850" src="https://github.com/user-attachments/assets/04b73809-38b4-48e6-9c00-1515574a1889" />
