### PR TITLE
[fix] Fix notice rule label matching against grouped alerts

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/impl/NoticeConfigServiceImpl.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/impl/NoticeConfigServiceImpl.java
@@ -69,18 +69,18 @@ import java.util.stream.Collectors;
 @Transactional(rollbackFor = Exception.class)
 @Slf4j
 public class NoticeConfigServiceImpl implements NoticeConfigService, CommandLineRunner {
-    
+
     private static final Map<Byte, NoticeTemplate> PRESET_TEMPLATE = new HashMap<>(16);
-    
+
     @Autowired
     private NoticeReceiverDao noticeReceiverDao;
 
     @Autowired
     private NoticeRuleDao noticeRuleDao;
-    
+
     @Autowired
     private NoticeTemplateDao noticeTemplateDao;
-    
+
     @Autowired
     @Lazy
     private AlertNoticeDispatch dispatcherAlarm;
@@ -212,24 +212,30 @@ public class NoticeConfigServiceImpl implements NoticeConfigService, CommandLine
         }
 
         // The temporary rule is to forward all, and then implement more matching rules: alarm status selection, monitoring type selection, etc.
+        // TODO: This matches an already-grouped alert against notice rules (group-then-route). It cannot fully
+        //  separate alerts that were grouped together but should reach different receivers, so a rule matched by
+        //  one alert still notifies the whole group. The ideal design is route-then-group (like Alertmanager):
+        //  route each single alert by its labels first, then group per receiver. Tracked as a follow-up to #3852.
         return rules.stream()
                 .filter(rule -> {
                     if (!rule.isFilterAll()) {
-                        // filter labels
+                        // filter labels: a rule matches when ANY single alert in the group carries
                         if (rule.getLabels() != null && !rule.getLabels().isEmpty()) {
-                            boolean labelMatch = rule.getLabels().entrySet().stream().allMatch(labelItem -> {
-                                if (!alert.getCommonLabels().containsKey(labelItem.getKey())) {
+                            List<SingleAlert> singleAlerts = alert.getAlerts();
+                            boolean labelMatch = singleAlerts != null && singleAlerts.stream().anyMatch(singleAlert -> {
+                                Map<String, String> alertLabels = singleAlert.getLabels();
+                                if (alertLabels == null) {
                                     return false;
                                 }
-                                String alertLabelValue = alert.getCommonLabels().get(labelItem.getKey());
-                                return Objects.equals(labelItem.getValue(), alertLabelValue);
+                                return rule.getLabels().entrySet().stream().allMatch(labelItem ->
+                                        Objects.equals(labelItem.getValue(), alertLabels.get(labelItem.getKey())));
                             });
                             if (!labelMatch) {
                                 return false;
                             }
                         }
                     }
-                    
+
                     LocalDateTime nowDate = LocalDateTime.now();
                     // filter day
                     int currentDayOfWeek = nowDate.toLocalDate().getDayOfWeek().getValue();

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/service/NoticeConfigServiceTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/service/NoticeConfigServiceTest.java
@@ -22,10 +22,13 @@ import org.apache.hertzbeat.alert.dao.NoticeRuleDao;
 import org.apache.hertzbeat.alert.dao.NoticeTemplateDao;
 import org.apache.hertzbeat.alert.notice.AlertNoticeDispatch;
 import org.apache.hertzbeat.alert.service.impl.NoticeConfigServiceImpl;
+import org.apache.hertzbeat.common.cache.CacheFactory;
 import org.apache.hertzbeat.common.entity.alerter.GroupAlert;
 import org.apache.hertzbeat.common.entity.alerter.NoticeReceiver;
 import org.apache.hertzbeat.common.entity.alerter.NoticeRule;
 import org.apache.hertzbeat.common.entity.alerter.NoticeTemplate;
+import org.apache.hertzbeat.common.entity.alerter.SingleAlert;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,9 +42,12 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -283,5 +289,94 @@ class NoticeConfigServiceTest {
         final NoticeTemplate noticeTemplate = null;
         noticeConfigService.sendTestMsg(noticeReceiver);
         verify(dispatcherAlarm, times(1)).sendNoticeMsg(eq(noticeReceiver), eq(noticeTemplate), any(GroupAlert.class));
+    }
+
+    @AfterEach
+    void tearDown() {
+        CacheFactory.clearNoticeCache();
+    }
+
+    private GroupAlert buildGroupAlertWithPartialLabel() {
+        SingleAlert alertA = SingleAlert.builder()
+                .labels(new HashMap<>(Map.of("alertname", "cpu", "instance", "s1", "department", "algorithm")))
+                .build();
+        SingleAlert alertB = SingleAlert.builder()
+                .labels(new HashMap<>(Map.of("alertname", "cpu", "instance", "s2")))
+                .build();
+        return GroupAlert.builder()
+                .commonLabels(new HashMap<>(Map.of("alertname", "cpu")))
+                .alerts(Arrays.asList(alertA, alertB))
+                .build();
+    }
+
+    /**
+     * A rule scoped to a label carried by only part of the group's alerts must still match,
+     * even though that label is absent from commonLabels. Regression test for issue #3852.
+     */
+    @Test
+    void getReceiverFilterRuleMatchesLabelOnPartialAlert() {
+        NoticeRule rule = new NoticeRule();
+        rule.setId(1L);
+        rule.setName("algorithm-team");
+        rule.setFilterAll(false);
+        rule.setLabels(new HashMap<>(Map.of("department", "algorithm")));
+        CacheFactory.setNoticeCache(List.of(rule));
+
+        List<NoticeRule> matched = noticeConfigService.getReceiverFilterRule(buildGroupAlertWithPartialLabel());
+
+        assertEquals(1, matched.size());
+        assertEquals(1L, matched.get(0).getId());
+    }
+
+    /**
+     * A rule whose label value is not present on any alert in the group must not match.
+     */
+    @Test
+    void getReceiverFilterRuleSkipsRuleWithUnmatchedLabel() {
+        NoticeRule rule = new NoticeRule();
+        rule.setId(2L);
+        rule.setName("infra-team");
+        rule.setFilterAll(false);
+        rule.setLabels(new HashMap<>(Map.of("department", "infra")));
+        CacheFactory.setNoticeCache(List.of(rule));
+
+        List<NoticeRule> matched = noticeConfigService.getReceiverFilterRule(buildGroupAlertWithPartialLabel());
+
+        assertTrue(matched.isEmpty());
+    }
+
+    /**
+     * A rule requiring several labels matches only when a single alert carries all of them,
+     * preventing false matches assembled across different alerts in the group.
+     */
+    @Test
+    void getReceiverFilterRuleRequiresAllLabelsOnSameAlert() {
+        NoticeRule rule = new NoticeRule();
+        rule.setId(3L);
+        rule.setName("algorithm-on-s2");
+        rule.setFilterAll(false);
+        rule.setLabels(new HashMap<>(Map.of("department", "algorithm", "instance", "s2")));
+        CacheFactory.setNoticeCache(List.of(rule));
+
+        List<NoticeRule> matched = noticeConfigService.getReceiverFilterRule(buildGroupAlertWithPartialLabel());
+
+        assertTrue(matched.isEmpty());
+    }
+
+    /**
+     * A forward-all rule keeps matching regardless of labels.
+     */
+    @Test
+    void getReceiverFilterRuleForwardAllAlwaysMatches() {
+        NoticeRule rule = new NoticeRule();
+        rule.setId(4L);
+        rule.setName("forward-all");
+        rule.setFilterAll(true);
+        CacheFactory.setNoticeCache(List.of(rule));
+
+        List<NoticeRule> matched = noticeConfigService.getReceiverFilterRule(buildGroupAlertWithPartialLabel());
+
+        assertEquals(1, matched.size());
+        assertEquals(4L, matched.get(0).getId());
     }
 }


### PR DESCRIPTION
## What's changed?

close #3852 

The issue is that the rule label routing matches `GroupAlert.commonLabels`, which is the intersection of all alert labels in that group. Since there are only grouped rules and the alert labels within the group do not match, labels are excluded from this intersection. As a result, the notification policy for that label will never match, and only the “Forward All” rule will be triggered.

This PR changes the matching logic to check the alerts at the bottom of the group: the rule is matched when any alert in the group contains all the tags specified in the rule.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

> Step1
<img width="827" height="240" alt="capcap-260710-173741" src="https://github.com/user-attachments/assets/2f51b805-2876-4c73-a4e7-2419530f38ec" />

> Step2
<img width="1013" height="366" alt="capcap-260710-174426" src="https://github.com/user-attachments/assets/8f05fe35-17ac-4924-9ea0-1efe58c31738" />

> Step3
<img width="1070" height="396" alt="capcap-260710-174112" src="https://github.com/user-attachments/assets/19ac9e41-0eb3-4af5-a842-2528e1d25350" />

> Step4
<img width="1332" height="556" alt="capcap-260710-175749" src="https://github.com/user-attachments/assets/c8c35c86-576f-48f6-8d7d-061dc3d2109a" />

> Preview
<img width="856" height="605" alt="capcap-260710-175804" src="https://github.com/user-attachments/assets/f1051f62-9d64-44b3-8737-dcc07599ae9a" />
