### PR TITLE
[fix] Fix startup_failure: pin third-party actions to ASF-allowlisted SHAs

### DIFF
--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -101,7 +101,7 @@ jobs:
           path: dist/
 
       - name: Build Image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./dist
           file: ./script/docker/server/Dockerfile

--- a/.github/workflows/collector-native-build.yml
+++ b/.github/workflows/collector-native-build.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up GraalVM JDK 25
-        uses: graalvm/setup-graalvm@f744c72a42b1995d7b0cbc314bde4bace7ac1fe1
+        uses: graalvm/setup-graalvm@186d0493a2df5eb62df5ecc498883d18fd58c303  # v1.6.2
         with:
           distribution: graalvm-community
           java-version: '25'

--- a/.github/workflows/doc-build-test.yml
+++ b/.github/workflows/doc-build-test.yml
@@ -51,7 +51,7 @@ jobs:
           python-version: '3.8'
 
       - name: Check Markdown
-        uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101
+        uses: DavidAnson/markdownlint-cli2-action@8de2aa07cae85fd17c0b35642db70cf5495f1d25  # v24.0.0
         with:
           globs: |
             ./home/README.md

--- a/.github/workflows/mcp-bashserver-test.yml
+++ b/.github/workflows/mcp-bashserver-test.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30  # stable
         with:
           toolchain: ${{ env.RUST_VERSION }}
           components: rustfmt, clippy

--- a/.github/workflows/monitor-e2e-test.yml
+++ b/.github/workflows/monitor-e2e-test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build with Maven
         run: mvnd -B clean package -Prelease -Dmaven.test.skip=true --file pom.xml
       - name: Build Image
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
         with:
           context: ./dist
           file: ./script/docker/server/Dockerfile

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -57,13 +57,13 @@ jobs:
     - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
     - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
     - name: Log in to Docker Hub
-      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2
+      uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0
       with:
         username: ${{ secrets.DOCKERHUB_USER }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build and Push Server
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
       with:
         context: ./dist
         file: ./script/docker/server/Dockerfile
@@ -72,7 +72,7 @@ jobs:
         tags: apache/hertzbeat:nightly
 
     - name: Build and Push Collector
-      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a  # v7.3.0
       with:
         context: ./dist
         file: ./script/docker/collector/Dockerfile


### PR DESCRIPTION
## What's changed?

| Action | New ref | Files |
|---|---|---|
| `docker/build-push-action` | `53b7df9` (v7.3.0) | backend-build-test, monitor-e2e-test, nightly-build (×2) |
| `docker/login-action` | `af1e73f` (v4.4.0) | nightly-build |
| `DavidAnson/markdownlint-cli2-action` | `8de2aa0` (v24.0.0) | doc-build-test |
| `dtolnay/rust-toolchain` | `4be7066` (stable) | mcp-bashserver-test |
| `graalvm/setup-graalvm` | `186d049` (v1.6.2) | collector-native-build |

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
