### PR TITLE
[fix] Prevent NPE when VictoriaMetrics compression is unset

### DIFF
--- a/hertzbeat-warehouse/src/main/java/org/apache/hertzbeat/warehouse/store/history/tsdb/vm/VictoriaMetricsProperties.java
+++ b/hertzbeat-warehouse/src/main/java/org/apache/hertzbeat/warehouse/store/history/tsdb/vm/VictoriaMetricsProperties.java
@@ -39,7 +39,7 @@ public record VictoriaMetricsProperties(@DefaultValue("false") boolean enabled,
 
     record InsertConfig(@DefaultValue("100") int bufferSize,
                         @DefaultValue("3") int flushInterval,
-                        Compression compression) {
+                        @DefaultValue Compression compression) {
     }
 
     record Compression(@DefaultValue("false") boolean enabled) {

--- a/hertzbeat-warehouse/src/test/java/org/apache/hertzbeat/warehouse/store/history/tsdb/vm/VictoriaMetricsPropertiesTest.java
+++ b/hertzbeat-warehouse/src/test/java/org/apache/hertzbeat/warehouse/store/history/tsdb/vm/VictoriaMetricsPropertiesTest.java
@@ -18,9 +18,13 @@
 package org.apache.hertzbeat.warehouse.store.history.tsdb.vm;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.boot.context.properties.source.MapConfigurationPropertySource;
 import org.springframework.boot.test.context.SpringBootTest;
 
 /**
@@ -56,6 +60,18 @@ class VictoriaMetricsPropertiesTest {
         assertThat(properties.insert().flushInterval()).isEqualTo(3);
         assertThat(properties.insert().compression()).isNotNull();
         assertThat(properties.insert().compression().enabled()).isTrue();
+    }
+
+    @Test
+    void compressionShouldDefaultToDisabledWhenNotConfigured() {
+        var source = new MapConfigurationPropertySource(Map.of(
+                "warehouse.store.victoria-metrics.insert.buffer-size", "999"));
+        var defaultProperties = new Binder(source)
+                .bind("warehouse.store.victoria-metrics", VictoriaMetricsProperties.class)
+                .get();
+
+        assertThat(defaultProperties.insert().compression()).isNotNull();
+        assertThat(defaultProperties.insert().compression().enabled()).isFalse();
     }
 
 }


### PR DESCRIPTION
Default the nested compression configuration during property binding and cover both explicit and omitted values.

Fixes #4058

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
