### PR TITLE
[fix] cancel the overwritten timeout in cyclicJob to fix HashedWheelTimeout memory leak

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-common/src/main/java/org/apache/hertzbeat/collector/timer/TimerDispatcher.java
+++ b/hertzbeat-collector/hertzbeat-collector-common/src/main/java/org/apache/hertzbeat/collector/timer/TimerDispatcher.java
@@ -140,7 +140,7 @@ public class TimerDispatcher implements TimerDispatch, DisposableBean {
         // whether is the job has been canceled
         if (currentCyclicTaskMap.containsKey(jobId)) {
             Timeout timeout = wheelTimer.newTimeout(timerTask, interval, TimeUnit.SECONDS);
-            currentCyclicTaskMap.put(timerTask.getJob().getId(), timeout);
+            cancelPreviousTimeout(currentCyclicTaskMap.put(timerTask.getJob().getId(), timeout));
         }
     }
 

--- a/hertzbeat-collector/hertzbeat-collector-common/src/test/java/org/apache/hertzbeat/collector/timer/TimerDispatcherTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-common/src/test/java/org/apache/hertzbeat/collector/timer/TimerDispatcherTest.java
@@ -20,7 +20,9 @@ package org.apache.hertzbeat.collector.timer;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.hertzbeat.collector.constants.ScheduleTypeEnum;
+import org.apache.hertzbeat.collector.dispatch.MetricsTaskDispatch;
 import org.apache.hertzbeat.collector.dispatch.entrance.internal.CollectResponseEventListener;
 import org.apache.hertzbeat.common.entity.job.Job;
 import org.apache.hertzbeat.common.entity.job.Metrics;
@@ -136,7 +138,7 @@ public class TimerDispatcherTest {
         long interval = 600L; // 10 minutes in seconds
         long spendTime = 300000L; // 5 minutes in milliseconds
         long dispatchTime = System.currentTimeMillis() - spendTime;
-        
+
         when(job.getScheduleType()).thenReturn(ScheduleTypeEnum.INTERVAL.getType());
         when(job.getDispatchTime()).thenReturn(dispatchTime);
         when(job.getInterval()).thenReturn(interval);
@@ -159,7 +161,7 @@ public class TimerDispatcherTest {
         long interval = 600L; // 10 minutes in seconds
         long spendTime = 1200000L; // 20 minutes in milliseconds (more than interval)
         long dispatchTime = System.currentTimeMillis() - spendTime;
-        
+
         when(job.getScheduleType()).thenReturn(ScheduleTypeEnum.INTERVAL.getType());
         when(job.getDispatchTime()).thenReturn(dispatchTime);
         when(job.getInterval()).thenReturn(interval);
@@ -245,6 +247,35 @@ public class TimerDispatcherTest {
         assertNotSame(firstTimeout, updatedTimeout);
         assertTrue(firstTimeout.isCancelled());
         assertFalse(updatedTimeout.isCancelled());
+    }
+
+    @Test
+    void testCyclicJobCancelsPreviousTimeoutForSameJob() {
+        Job job = Job.builder()
+                .id(1L)
+                .app("test")
+                .isCyclic(true)
+                .configmap(List.of())
+                .metrics(List.of(Metrics.builder().interval(60L).build()))
+                .build();
+        timerDispatcher.addJob(job, null);
+        Timeout t0 = currentCyclicTaskMap().get(1L);
+
+        WheelTimerTask timerTask = new WheelTimerTask(job, (MetricsTaskDispatch) timeout -> {
+        });
+
+        timerDispatcher.cyclicJob(timerTask, 60L, TimeUnit.SECONDS);
+        Timeout t1 = currentCyclicTaskMap().get(1L);
+
+        timerDispatcher.cyclicJob(timerTask, 60L, TimeUnit.SECONDS);
+        Timeout t2 = currentCyclicTaskMap().get(1L);
+
+        assertNotSame(t0, t1);
+        assertNotSame(t1, t2);
+        assertFalse(t2.isCancelled());
+
+        assertTrue(t0.isCancelled(), "T0 orphaned: overwritten by cyclicJob but never cancelled");
+        assertTrue(t1.isCancelled(), "T1 orphaned: overwritten by cyclicJob but never cancelled");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## What's changed?

close #3534 

`TimerDispatcher.cyclicJob(WheelTimerTask, long, TimeUnit)` overwrites the per-job entry in `currentCyclicTaskMap` with a bare `put`, **without cancelling the previously scheduled `Timeout`**:

```java
Timeout timeout = wheelTimer.newTimeout(timerTask, interval, TimeUnit.SECONDS);
currentCyclicTaskMap.put(timerTask.getJob().getId(), timeout); // previous timeout leaked
```

Since HashedWheelTimer is one-shot, a cyclic job re-arms itself by calling cyclicJob each round. If cyclicJob is called more than once for the same job while a previously scheduled timeout is still pending, the previous timeout is orphaned: the map no longer references it and nobody cancels it, yet it still fires. Each orphan fires a redundant collection round which re-arms again, so the orphaned HashedWheelTimeout instances accumulate without bound. This matches the heap symptom reported in #3534 (millions of HashedWheelTimeout / LinkedBlockingQueue$Node instances under sustained load).


### Example timeline (interval = 600s, one collection that takes ~300s)

```markdown
T+0s      round starts; collection begins (will take ~300s)
T+240..260s  timeout monitor (scans every 20s) detects the 4-min timeout
             -> logs "[Collect Timeout]"
             -> dispatchCollectData -> cyclicJob-1  (schedules next round, fires ~T+600s)
T+300s    collection finally succeeds
             -> dispatchCollectData -> cyclicJob-2  (Prometheus list-path calls
                cyclicJob unconditionally)
             -> overwrites the map entry but does NOT cancel cyclicJob #1's timeout
             -> that timeout (fires ~T+600s) is now an ORPHAN in the wheel

```

Each such round leaks one `HashedWheelTimeout`. Because every orphan later fires a redundant round that also times-out-and-recovers, the orphans compound, matching the millions of `HashedWheelTimeout` / `LinkedBlockingQueue$Node` instances in the heap dump of #3534.

## Fix

Cancel the displaced timeout when overwriting, exactly like addJob.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
