### PR TITLE
 [improve] bump grpc-java from 1.56.1 to 1.76.3

### DIFF
--- a/hertzbeat-log/pom.xml
+++ b/hertzbeat-log/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <awaitility.version>4.2.0</awaitility.version>
-        <grpc.version>1.56.1</grpc.version>
+        <grpc.version>1.76.3</grpc.version>
     </properties>
 
     <dependencies>

--- a/hertzbeat-log/pom.xml
+++ b/hertzbeat-log/pom.xml
@@ -30,7 +30,6 @@
 
     <properties>
         <awaitility.version>4.2.0</awaitility.version>
-        <grpc.version>1.76.3</grpc.version>
     </properties>
 
     <dependencies>
@@ -72,21 +71,18 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
         </dependency>
-        <!-- OTLP gRPC server -->
+        <!-- OTLP gRPC server, version managed by grpc-bom in the root pom -->
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>${grpc.version}</version>
         </dependency>
         <!-- awaitility for async testing -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
         <influxdb.version>2.23</influxdb.version>
         <spring-cloud-starter-openfeign.version>3.0.5</spring-cloud-starter-openfeign.version>
         <greptimedb.version>0.11.0</greptimedb.version>
+        <grpc.version>1.76.3</grpc.version>
         <arrow.version>18.1.0</arrow.version>
         <snappy-java.version>1.1.10.7</snappy-java.version>
         <sshd-sftp.version>2.13.1</sshd-sftp.version>
@@ -578,6 +579,14 @@
                         <artifactId>protobuf-java</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <!-- grpc: managed -->
+            <dependency>
+                <groupId>io.grpc</groupId>
+                <artifactId>grpc-bom</artifactId>
+                <version>${grpc.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## What's changed?

Upgrade the gRPC dependencies (`grpc-netty-shaded` / `grpc-protobuf` / `grpc-stub`) in the `hertzbeat-log` module from `1.56.1` to `1.76.3`.

## Verification:

- `mvn -pl hertzbeat-log -am test` passes on JDK 25: all 17 test classes green, including `OtlpGrpcServerConfigTest` which starts a real OTLP gRPC server.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
