### PR TITLE
[docs] refactor blog list UI to card grid

### DIFF
--- a/home/README.md
+++ b/home/README.md
@@ -25,6 +25,22 @@ pnpm start
 
 This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
 
+## Writing Blog Posts
+
+Add a concise `description` to the front matter of new blog posts. It is used
+for blog cards and page metadata, so it should summarize the article rather
+than repeat its title, salutation, or first section heading.
+
+```yaml
+---
+title: Apache HertzBeat 1.8.0 Release
+description: Apache HertzBeat 1.8.0 adds AI tooling, new monitoring integrations, and major performance improvements.
+---
+```
+
+Aim for one sentence of roughly 100–160 characters in English or 50–80
+characters in Chinese. Localized posts should provide a localized description.
+
 ## Team Page
 
 ### Member

--- a/home/blog/2022-06-01-hertzbeat-v1.0.md
+++ b/home/blog/2022-06-01-hertzbeat-v1.0.md
@@ -3,7 +3,8 @@ title: Cloud Monitoring System HertzBeat v1.0 Officially Released
 author: tom
 author_title: tom
 author_url: https://github.com/tomsun28
-tags: [opensource]
+tags: [releases]
+cover_headline: HertzBeat 1.0
 ---
 
 HertzBeat, incubated by Dromara and open-sourced by TanCloud, is an open-source monitoring and alerting project that supports a variety of monitoring types including websites, APIs, PING, ports, databases, full-site, operating systems, middleware, etc.

--- a/home/blog/2022-06-19-hertzbeat-v1.1.0.md
+++ b/home/blog/2022-06-19-hertzbeat-v1.1.0.md
@@ -3,7 +3,8 @@ title: Cloud Monitoring System HertzBeat v1.1.0 Released! Start Your Monitoring 
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+cover_headline: HertzBeat 1.1.0
 ---
 
 [HertzBeat](https://github.com/apache/hertzbeat), incubated by [Dromara](https://dromara.org) and open-sourced by [TanCloud](https://tancloud.cn), is an open-source monitoring and alerting project that supports various monitoring types such as websites, APIs, PING, ports, databases, entire sites, operating systems, middleware, etc. It features threshold alarms, notification alerts (email, webhook, DingTalk, WeChat Work, Lark robots), and a user-friendly visual interface.

--- a/home/blog/2022-06-22-one-step-up.md
+++ b/home/blog/2022-06-22-one-step-up.md
@@ -3,7 +3,8 @@ title: HertzBeat Monitoring System v1.1.0 Released! Start Your Monitoring Journe
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28
-tags: [opensource]
+tags: [releases]
+cover_headline: HertzBeat 1.1.0
 ---
 
 [HertzBeat](https://github.com/apache/hertzbeat), incubated by [Dromara](https://dromara.org) and open-sourced by [TanCloud](https://tancloud.cn), is an open-source monitoring and alerting project that supports website, API, PING, port, database, site-wide, operating system, middleware monitoring types, and more. It features threshold alarms, alarm notifications (email, webhook, DingTalk, WeChat Work, Feishu bot), and a user-friendly visual interface.

--- a/home/blog/2022-07-10-hertzbeat-v1.1.1.md
+++ b/home/blog/2022-07-10-hertzbeat-v1.1.1.md
@@ -1,9 +1,11 @@
 ---
-title: HertzBeat v1.1.1 is Publish！   
+title: HertzBeat v1.1.1 is Publish！
+description: HertzBeat 1.1.1 enhances custom monitoring with reusable collected metrics, improves alert channel configuration, and fixes stability issues.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+cover_headline: HertzBeat 1.1.1
 ---
 
 > Friendly Cloud Monitoring Tool.

--- a/home/blog/2022-09-04-hertzbeat-v1.1.3.md
+++ b/home/blog/2022-09-04-hertzbeat-v1.1.3.md
@@ -1,9 +1,11 @@
 ---
 title: Cloud monitoring system HertzBeat v1.1.3 released!
+description: HertzBeat 1.1.3 adds Kafka monitoring, SSL certificate expiration monitoring, longer history queries, and monitoring interface improvements.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+cover_headline: HertzBeat 1.1.3
 ---
 
 ## V1.1.3

--- a/home/blog/2022-09-10-ssl-practice.md
+++ b/home/blog/2022-09-10-ssl-practice.md
@@ -3,7 +3,8 @@ title: Best Practices for SSL Certificate Expiration Monitoring
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [tutorials]
+cover_headline: SSL Certificate Expiry Monitoring
 ---
 
 First of all, I would like to wish all the students who see it a happy mid-autumn festival, good health, and try to get rich on the basis of good health.

--- a/home/blog/2022-10-08-hertzbeat-v1.2.0.md
+++ b/home/blog/2022-10-08-hertzbeat-v1.2.0.md
@@ -1,9 +1,11 @@
 ---
-title: HertzBeat v1.2.0 Released! Easy-to-use and friendly open source real-time monitoring tool   
+title: HertzBeat v1.2.0 Released! Easy-to-use and friendly open source real-time monitoring tool
+description: HertzBeat 1.2.0 introduces more powerful JSONPath collection, metric unit conversion, a refreshed interface, and a Spring Boot 2.7 upgrade.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+cover_headline: HertzBeat 1.2.0
 ---
 
 ## v1.2.0

--- a/home/blog/2022-11-28-hertzbeat-v1.2.2.md
+++ b/home/blog/2022-11-28-hertzbeat-v1.2.2.md
@@ -1,9 +1,11 @@
 ---
-title: HertzBeat v1.2.2！Support K8S Monitor And More.     
+title: HertzBeat v1.2.2！Support K8S Monitor And More.
+description: HertzBeat 1.2.2 expands monitoring to Kubernetes, Docker, Spring Boot, Nacos, DM and openGauss, with experimental PromQL collection.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+cover_headline: HertzBeat 1.2.2
 ---
 
 ## v1.2.2

--- a/home/blog/2022-12-19-new-committer.md
+++ b/home/blog/2022-12-19-new-committer.md
@@ -3,7 +3,9 @@ title: 恭喜 HertzBeat 迎来了两位新晋社区Committer
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [community]
+cover_headline: Two New Committers
+cover_kicker: New Committer
 ---
 
 > 非常高兴 HertzBeat 迎来了两位新晋社区Committer, 两位都是来自互联网公司的开发工程师，让我们来了解下他们的开源经历吧！

--- a/home/blog/2022-12-28-hertzbeat-v1.2.3.md
+++ b/home/blog/2022-12-28-hertzbeat-v1.2.3.md
@@ -1,9 +1,11 @@
 ---
-title: HertzBeat v1.2.3！Support Prometheus,ShenYu and IotDb    
+title: HertzBeat v1.2.3！Support Prometheus,ShenYu and IotDb
+description: HertzBeat 1.2.3 adds Prometheus exporter collection, Apache ShenYu and IoTDB monitoring, SMS notifications, and usability improvements.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+cover_headline: HertzBeat 1.2.3
 ---
 
 ## v1.2.3

--- a/home/blog/2023-01-05-monitor-iotdb.md
+++ b/home/blog/2023-01-05-monitor-iotdb.md
@@ -3,7 +3,8 @@ title: Use HertzBeat Monitoring IoTDB
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [tutorials]
+cover_headline: Monitoring Apache IoTDB
 ---
 
 ## Use HertzBeat to monitor the Internet of Things database IoTDB, and it will be done in 5 minutes

--- a/home/blog/2023-01-08-monitor-shenyu.md
+++ b/home/blog/2023-01-08-monitor-shenyu.md
@@ -3,7 +3,8 @@ title: HertzBeat's Monitoring Practice for API Gateway Apache ShenYu
 author: tom
 author_title: tom
 author_url: https://github.com/tomsun28
-tags: [opensource, practice]
+tags: [tutorials]
+cover_headline: Monitoring Apache ShenYu
 ---
 
 ## Monitoring practice for API gateway Apache ShenYu using HertzBeat, 5 minutes

--- a/home/blog/2023-02-02-monitor-dynamic-tp.md
+++ b/home/blog/2023-02-02-monitor-dynamic-tp.md
@@ -3,7 +3,8 @@ title: Monitoring Practices for DynamicTp Thread Pooling Framework with HertzBea
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [tutorials]
+cover_headline: Monitoring DynamicTp
 ---
 
 ## Monitoring practice for thread pooling framework DynamicTp using HertzBeat, 5 minutes

--- a/home/blog/2023-02-10-new-committer.md
+++ b/home/blog/2023-02-10-new-committer.md
@@ -1,9 +1,12 @@
 ---
 title: Welcome two new Committers from HertzBeat   
+description: Meet new HertzBeat Committers Gao Chen and TJxiaobao and learn how they contributed alerting, notification, Redis, Docker, and database monitoring features.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [community]
+cover_headline: Two New Committers
+cover_kicker: New Committer
 ---
 
 ![HertzBeat](/img/blog/new-committer.png)

--- a/home/blog/2023-02-11-monitor-mysql.md
+++ b/home/blog/2023-02-11-monitor-mysql.md
@@ -3,8 +3,9 @@ title: Use the open source real-time monitoring tool HertzBeat to monitor and al
 author: tom
 author_title: tom
 author_url: https://github.com/tomsun28
-tags: [opensource, practice]
+tags: [tutorials]
 Keywords: [Open source monitoring tool, open source database monitoring, Mysql database monitoring]
+cover_headline: Monitoring MySQL
 ---
 
 ## Use the open source real-time monitoring tool HertzBeat to monitor and alarm the Mysql database, and it will be done in 5 minutes

--- a/home/blog/2023-02-15-monitor-linux.md
+++ b/home/blog/2023-02-15-monitor-linux.md
@@ -3,8 +3,9 @@ title: Monitoring Linux Operating Systems Using Open Source Real-Time Monitoring
 author: tom
 author_title: tom
 author_url: https://github.com/tomsun28
-tags: [opensource, practice]
+tags: [tutorials]
 keywords: [Open source monitoring tool, operating system monitoring, Linux monitoring]
+cover_headline: Monitoring Linux
 ---
 
 ## Use the open source real-time monitoring tool HertzBeat to monitor and alarm the Linux operating system, and it will be done in 5 minutes

--- a/home/blog/2023-03-15-hertzbeat-v1.3.0.md
+++ b/home/blog/2023-03-15-hertzbeat-v1.3.0.md
@@ -1,10 +1,12 @@
 ---
 title: Open source real-time monitoring tool HertzBeat v1.3.0 released, online customization is coming
+description: HertzBeat 1.3.0 adds custom monitoring pagination, network switch monitoring, Redis cluster metrics, and IoTDB 1.0 storage support.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
 keywords: [open source monitoring system, alerting system, Linux monitoring]
+cover_headline: HertzBeat 1.3.0
 ---
 
 Website: hertzbeat.com | tancloud.cn

--- a/home/blog/2023-03-22-monitor-springboot2.md
+++ b/home/blog/2023-03-22-monitor-springboot2.md
@@ -3,8 +3,9 @@ title: Monitoring SpringBoot2 Metrics with HertzBeat in 5 minutes
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [tutorials]
 keywords: [opensource monitoring, SpringBoot monitoring, alert]
+cover_headline: Monitoring SpringBoot 2
 ---
 
 ## Use the open source real-time monitoring tool HertzBeat to monitor and alarm the SpringBoot2 application, and it will be done in 5 minutes

--- a/home/blog/2023-05-09-hertzbeat-v1.3.1.md
+++ b/home/blog/2023-05-09-hertzbeat-v1.3.1.md
@@ -1,10 +1,12 @@
 ---
 title: Open source real-time monitoring tool HertzBeat v1.3.1 released
+description: HertzBeat 1.3.1 adds new time-series storage options, monitoring import and export, alert silencing, and more monitoring templates.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
 keywords: [open source monitoring system, alerting system, Linux monitoring]
+cover_headline: HertzBeat 1.3.1
 ---
 
 Website: hertzbeat.com | tancloud.cn

--- a/home/blog/2023-05-11-greptimedb-store.md
+++ b/home/blog/2023-05-11-greptimedb-store.md
@@ -3,8 +3,9 @@ title: GreptimeDB & HertzBeat, using the open source temporal database GreptimeD
 author: tom
 author_title: tom
 author_url: https://github.com/tomsun28
-tags: [opensource, practice]
+tags: [tutorials, engineering]
 keywords: [open source monitoring system, open source temporal database, HertzBeat, GreptimeDB]
+cover_headline: GreptimeDB Storage
 ---
 
 ## Using GreptimeDB, an open source temporal database, to store metrics for open source real-time monitoring HertzBeat

--- a/home/blog/2023-07-05-hertzbeat-v1.3.2.md
+++ b/home/blog/2023-07-05-hertzbeat-v1.3.2.md
@@ -1,10 +1,12 @@
 ---
-title: Open source monitoring HertzBeat v1.3.2 released, Easier to use 
+title: Open source monitoring HertzBeat v1.3.2 released, Easier to use
+description: HertzBeat 1.3.2 expands operating-system and database monitoring, adds alert convergence, Kafka queues, and web-based mail configuration.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
 keywords: [open source monitoring system, alerting system, Linux monitoring]
+cover_headline: HertzBeat 1.3.2
 ---
 
 Website: hertzbeat.com | tancloud.cn

--- a/home/blog/2023-08-14-hertzbeat-v1.4.0.md
+++ b/home/blog/2023-08-14-hertzbeat-v1.4.0.md
@@ -1,10 +1,12 @@
 ---
-title: HertzBeat v1.4.0 released, cluster is coming! 
+title: HertzBeat v1.4.0 released, cluster is coming!
+description: HertzBeat 1.4.0 introduces independently deployed collector clusters for horizontal scaling, failover, and isolated-network monitoring.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
 keywords: [open source monitoring system, alerting system, Linux monitoring]
+cover_headline: HertzBeat 1.4.0 Cluster Edition
 ---
 
 ![HertzBeat](/img/home/0.png)

--- a/home/blog/2023-08-28-new-committer.md
+++ b/home/blog/2023-08-28-new-committer.md
@@ -1,10 +1,13 @@
 ---
 title: Welcome to HertzBeat Community Committer!
+description: Qingran Zhao shares his path from using HertzBeat in operations to contributing storage integrations, import and export tools, monitoring templates, and alert channels.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome New Committer
+cover_kicker: New Committer
 ---
 
 ! [hertzBeat](/img/blog/new-committer.png)

--- a/home/blog/2023-09-26-hertzbeat-v1.4.1.md
+++ b/home/blog/2023-09-26-hertzbeat-v1.4.1.md
@@ -1,10 +1,12 @@
 ---
-title: HertzBeat v1.4.1 released, better experience! 
+title: HertzBeat v1.4.1 released, better experience!
+description: HertzBeat 1.4.1 delivers a redesigned login and dashboard experience, collector management, and further monitoring and stability improvements.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
 keywords: [open source monitoring system, alerting system, Linux monitoring]
+cover_headline: HertzBeat 1.4.1
 ---
 
 ![HertzBeat](/img/home/0.png)

--- a/home/blog/2023-11-12-hertzbeat-v1.4.2.md
+++ b/home/blog/2023-11-12-hertzbeat-v1.4.2.md
@@ -1,10 +1,12 @@
 ---
-title: HertzBeat v1.4.2 released, custom notice template! 
+title: HertzBeat v1.4.2 released, custom notice template!
+description: HertzBeat 1.4.2 adds custom notification templates, push-based metrics, Huawei OBS template storage, and EMQX and UDP monitoring.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
 keywords: [open source monitoring system, alerting system, Linux monitoring]
+cover_headline: HertzBeat 1.4.2
 ---
 
 ## What is HertzBeat?

--- a/home/blog/2023-12-11-hertzbeat-v1.4.3.md
+++ b/home/blog/2023-12-11-hertzbeat-v1.4.3.md
@@ -1,10 +1,12 @@
 ---
-title: HertzBeat v1.4.3 released, prometheus-compatible! 
+title: HertzBeat v1.4.3 released, prometheus-compatible!
+description: HertzBeat 1.4.3 expands Prometheus compatibility, adds VictoriaMetrics storage and Spring Gateway monitoring, and improves metric localization.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
 keywords: [open source monitoring system, alerting system]
+cover_headline: HertzBeat 1.4.3
 ---
 
 ## What is HertzBeat?

--- a/home/blog/2024-01-11-new-committer.md
+++ b/home/blog/2024-01-11-new-committer.md
@@ -1,10 +1,13 @@
 ---
 title: Welcome to HertzBeat Community Committer!
+description: Meet new Committers Leo, Zhou Shusheng, and Zhang Yang and their work on push collection, service monitoring templates, documentation, and community projects.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome New Committer
+cover_kicker: New Committer
 ---
 
 ! [hertzBeat](/img/blog/new-committer.png)

--- a/home/blog/2024-01-18-hertzbeat-v1.4.4.md
+++ b/home/blog/2024-01-18-hertzbeat-v1.4.4.md
@@ -1,10 +1,12 @@
 ---
-title: HertzBeat v1.4.4 released now! 
+title: HertzBeat v1.4.4 released now!
+description: HertzBeat 1.4.4 adds SNMP v3 and monitoring for NebulaGraph, Nginx, Hive, DNS, WebSocket, NTP, SMTP, POP3, and Memcached.
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
 keywords: [open source monitoring system, alerting system]
+cover_headline: HertzBeat 1.4.4
 ---
 
 ## What is HertzBeat?

--- a/home/blog/2024-04-17-to-apache.md
+++ b/home/blog/2024-04-17-to-apache.md
@@ -3,8 +3,10 @@ title: The open-source real-time monitoring HertzBeat is donated to the Apache I
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Donated to the Apache Incubator
+cover_kicker: Milestone
 ---
 
 On April 5, 2024, the open-source real-time monitoring system HertzBeat officially passed the Apache Foundation's voting resolution. According to the Apache Foundation mailing list, HertzBeat received 16 binding votes and 1 non-binding vote, with no abstentions or opposing votes, thereby accepting HertzBeat into the Apache Incubator.

--- a/home/blog/2024-05-09-hertzbeat-ospp-subject-introduction.md
+++ b/home/blog/2024-05-09-hertzbeat-ospp-subject-introduction.md
@@ -1,3 +1,9 @@
+---
+tags: [community]
+description: Explore HertzBeat's OSPP projects, including monitoring template marketplaces and collector scheduling, with expected outcomes and contributor guidance.
+cover_headline: OSPP 2024 Project Topics
+---
+
 # [Open Source Summer] HertzBeat project introduction
 
 ## What is HertzBeat?

--- a/home/blog/2024-06-11-hertzbeat-v1.6.0-update.md
+++ b/home/blog/2024-06-11-hertzbeat-v1.6.0-update.md
@@ -1,3 +1,8 @@
+---
+tags: [tutorials]
+cover_headline: Upgrade Guide to 1.6.0
+---
+
 # HertzBeat 1.6.0 Upgrade Guide
 
 **Note: This guide is applicable for upgrading from 1.5.0 to 1.6.0 to version 1.6.0.**

--- a/home/blog/2024-06-15-hertzbeat-v1.6.0.md
+++ b/home/blog/2024-06-15-hertzbeat-v1.6.0.md
@@ -3,8 +3,9 @@ title: HertzBeat First Apache version v1.6.0 released now!
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
 keywords: [open source, monitoring, alerting]
+cover_headline: Apache HertzBeat 1.6.0
 ---
 
 **Hi guys, We are excited to announce that Apache HertzBeat™ has released its first Apache version v1.6.0! 🎉.**

--- a/home/blog/2024-07-07-new-committer.md
+++ b/home/blog/2024-07-07-new-committer.md
@@ -1,10 +1,13 @@
 ---
 title: Welcome to HertzBeat Community Committer!
+description: CrossoverJie shares how his observability experience led him to improve HertzBeat unit tests, collection code quality, and community practices.
 author: crossoverJie
 author_title: crossoverJie
 author_url: https://github.com/crossoverjie
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome crossoverJie
+cover_kicker: New Committer
 ---
 
 ![HertzBeat](/img/blog/new-committer.png)

--- a/home/blog/2024-07-08-new-committer.md
+++ b/home/blog/2024-07-08-new-committer.md
@@ -1,10 +1,13 @@
 ---
 title: Welcome to HertzBeat Community Committer!
+description: Zhangshenghang describes his journey from adding HBase and big-data monitoring to reviewing contributions and helping guide the HertzBeat community.
 author: zhangshenghang
 author_title: zhangshenghang
 author_url: https://github.com/zhangshenghang
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome zhangshenghang
+cover_kicker: New Committer
 ---
 
 ![HertzBeat](/img/blog/new-committer.png)

--- a/home/blog/2024-07-15-new-committer.md
+++ b/home/blog/2024-07-15-new-committer.md
@@ -1,10 +1,13 @@
 ---
 title: Welcome to HertzBeat Community Committer!
+description: Liu Tianyou shares how adopting agentless monitoring led him to contribute documentation, NGQL metric queries, and NebulaGraph cluster monitoring.
 author: LiuTianyou
 author_title: LiuTianyou
 author_url: https://github.com/LiuTianyou
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome LiuTianyou
+cover_kicker: New Committer
 ---
 
 ![HertzBeat](/img/blog/new-committer.png)

--- a/home/blog/2024-07-27-new-committer.md
+++ b/home/blog/2024-07-27-new-committer.md
@@ -1,10 +1,13 @@
 ---
 title: Welcome to HertzBeat Community Committer!
+description: Calvin describes progressing from a documentation fix to contributing DNS and registry monitoring and HTTP service discovery to HertzBeat.
 author: Calvin979
 author_title: Calvin979
 author_url: https://github.com/Calvin979
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome Calvin979
+cover_kicker: New Committer
 ---
 
 ![HertzBeat](/img/blog/new-committer.png)

--- a/home/blog/2024-07-28-new-committer.md
+++ b/home/blog/2024-07-28-new-committer.md
@@ -1,10 +1,13 @@
 ---
 title: Welcome to HertzBeat Community Committer!
+description: Lin Dong shares his path into open source and contributions including WeChat notifications, AI integration, PrestoDB monitoring, bug fixes, and documentation.
 author: linDong
 author_title: linDong
 author_url: https://github.com/Yanshuming1
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome linDong
+cover_kicker: New Committer
 ---
 
 ![HertzBeat](/img/blog/new-committer.png)

--- a/home/blog/2024-07-29-new-committer.md
+++ b/home/blog/2024-07-29-new-committer.md
@@ -1,10 +1,13 @@
 ---
 title: Welcome to HertzBeat Community Committer!
+description: Le Zhang explains how his interface refinements, reusable components, and interaction improvements enhanced HertzBeat usability and maintainability.
 author: kerwin612
 author_title: Le Zhang
 author_url: https://github.com/kerwin612
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome kerwin612
+cover_kicker: New Committer
 ---
 
 ![HertzBeat](/img/blog/new-committer.png)

--- a/home/blog/2024-08-18-new-committer.md
+++ b/home/blog/2024-08-18-new-committer.md
@@ -1,10 +1,13 @@
 ---
 title: Becoming an Apache Committer is a recognition of my participation in open source
+description: Shown Ji reflects on becoming a HertzBeat Committer, contributing through unit tests and code fixes, and helping more developers enter open source.
 author: yuluo-yx
 author_title: Shown Ji
 author_url: https://github.com/yuluo-yx
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system, Apache, Apache Committer, HertzBeat]
+cover_headline: Welcome yuluo-yx
+cover_kicker: New Committer
 ---
 
 ## My open source journey

--- a/home/blog/2024-08-31-new-committer.md
+++ b/home/blog/2024-08-31-new-committer.md
@@ -1,10 +1,13 @@
 ---
 title: Welcome to HertzBeat Community Committer!
+description: Hongyu Liu shares how experience with Apache ShenYu and enterprise middleware monitoring led to deeper HertzBeat contributions and Committership.
 author: aias00
 author_title: Hongyu Liu
 author_url: https://github.com/Aias00
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system, Apache, Apache Committer, HertzBeat]
+cover_headline: Welcome aias00
+cover_kicker: New Committer
 ---
 
 ## Self-Introduction

--- a/home/blog/2024-09-10-new-committer.md
+++ b/home/blog/2024-09-10-new-committer.md
@@ -1,9 +1,10 @@
 ---
 title: Warmly Welcome HertzBeat's New Community Committer!
+description: Yuxuan Zhang recounts joining through OSPP and contributing OpenAI account monitoring, IMAP support, script-based system monitoring, and UI improvements.
 author: zuobiao-zhou
 author_title: Yuxuan Zhang
 author_url: https://github.com/zuobiao-zhou
-tags: [opensource, practice]
+tags: [community]
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome zuobiao-zhou
+cover_kicker: New Committer
 ---
 
 ## Self-Introduction

--- a/home/blog/2024-11-09-hertzbeat-v1.6.1.md
+++ b/home/blog/2024-11-09-hertzbeat-v1.6.1.md
@@ -1,10 +1,12 @@
 ---
 title: Announcement of Apache HertzBeat™ 1.6.1 Release
+description: Apache HertzBeat 1.6.1 expands infrastructure monitoring, adds Prometheus parsing and push support, NGQL queries, SMS alerts, and Docker Compose deployment.
 author: zhangshenghang
 author_title: zhangshenghang
 author_url: https://github.com/zhangshenghang
-tags: [opensource, practice]
+tags: [releases]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Apache HertzBeat 1.6.1
 ---
 
 Dear Community Members,

--- a/home/blog/2024-11-24-custom-development.md
+++ b/home/blog/2024-11-24-custom-development.md
@@ -1,10 +1,12 @@
 ---
 title: How to Participate in Developing Custom Collectors
+description: Learn the HertzBeat collector architecture and how to extend protocols, define monitoring templates, collect metrics, and integrate custom collectors.
 author: zhangshenghang
 author_title: zhangshenghang
 author_url: https://github.com/zhangshenghang
-tags: [opensource, practice]
+tags: [engineering, tutorials]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Developing Custom Collectors
 ---
 
 ## Introduction to the Collector Module

--- a/home/blog/2025-03-03-gsoc-2025.md
+++ b/home/blog/2025-03-03-gsoc-2025.md
@@ -1,10 +1,12 @@
 ---
 title: GSOC Google Summer of Code 2025 Recruitment is Underway | We Look Forward to Your Proposals
+description: Discover the Apache HertzBeat GSoC 2025 project ideas, proposal process, contributor requirements, mentor support, and important application dates.
 author: zhangshenghang
 author_title: zhangshenghang
 author_url: https://github.com/zhangshenghang
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: GSoC 2025 Recruitment
 ---
 
 ## The Origin and Purpose of GSOC

--- a/home/blog/2025-03-10-new-committer.md
+++ b/home/blog/2025-03-10-new-committer.md
@@ -1,9 +1,10 @@
 ---
 title: Warmly Welcome HertzBeat's New Community Committer!
+description: Lixin Diao shares how he moved from small bug fixes to becoming a HertzBeat Committer and offers practical entry points for first-time open-source contributors.
 author: yunfan24
 author_title: Lixin Diao
 author_url: https://github.com/yunfan24
-tags: [opensource, practice]
+tags: [community]
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome yunfan24
+cover_kicker: New Committer
 ---
 🎉 Hello everyone. I'm very glad to receive an invitation from the Apache HertzBeat™ community and officially become a Committer of the project!
 

--- a/home/blog/2025-03-30-how-does-metrics-collection-work.md
+++ b/home/blog/2025-03-30-how-does-metrics-collection-work.md
@@ -1,10 +1,12 @@
 ---
 title: "Behind the Scenes of HertzBeat: How Metric Collection Works"
+description: Follow a monitoring task through HertzBeat's manager, scheduler, collector, protocol handlers, and data pipeline to understand how metrics are collected.
 author: JuJinPark
 author_title: JuJin
 author_url: https://github.com/JuJinPark
-tags: [opensource, practice]
+tags: [engineering]
 keywords: [open source monitoring system]
+cover_headline: How Metric Collection Works
 ---
 ## Behind the Scenes of HertzBeat: How Metric Collection Works
 

--- a/home/blog/2025-04-06-new-pmc.md
+++ b/home/blog/2025-04-06-new-pmc.md
@@ -1,10 +1,12 @@
 ---
 title: From Commiter to PMC： The Journey of Growth at Apache HertzBeat™  
+description: Zhangshenghang reflects on moving from feature development to technical strategy, community governance, contributor mentoring, and long-term project stewardship.
 author: zhangshenghang
 author_title: zhangshenghang
 author_url: https://github.com/zhangshenghang
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Zhangshenghang Joins the PMC
 ---
 
 ## From Committer to PMC: The Transformation and Growth of Roles

--- a/home/blog/2025-04-10-hertzbeat-v1.7.0.md
+++ b/home/blog/2025-04-10-hertzbeat-v1.7.0.md
@@ -1,10 +1,12 @@
 ---
 title: Announcement of Apache HertzBeat™ 1.7.0 Release
+description: Apache HertzBeat 1.7.0 adds per-metric refresh intervals, HTTP service discovery, a redesigned alerting module, and Apache Arrow data structures.
 author: tomsun28
 author_title: tomsun28
 author_url: https://github.com/zhangshenghang
-tags: [opensource, release]
+tags: [releases]
 keywords: [open source monitoring system, alerting system, HertzBeat, release]
+cover_headline: Apache HertzBeat 1.7.0
 ---
 
 Dear Community Members,

--- a/home/blog/2025-04-23-hertzbeat-upgrade-guide-docker-mode.md
+++ b/home/blog/2025-04-23-hertzbeat-upgrade-guide-docker-mode.md
@@ -1,3 +1,9 @@
+---
+tags: [tutorials]
+description: Upgrade a Docker-based HertzBeat deployment safely by backing up configuration and data, replacing the image, and validating the migrated service.
+cover_headline: Upgrade Guide Docker Mode
+---
+
 # HertzBeat Upgrade Guide (Docker Mode)
 
 ## Docker-based Upgrade

--- a/home/blog/2025-04-23-hertzbeat-upgrade-guide-from-v1.6.1-to-v1.7.0-helm-mode.md
+++ b/home/blog/2025-04-23-hertzbeat-upgrade-guide-from-v1.6.1-to-v1.7.0-helm-mode.md
@@ -1,3 +1,9 @@
+---
+tags: [tutorials]
+description: Upgrade HertzBeat from 1.6.1 to 1.7.0 with Helm, including prerequisites, database backup, chart configuration, deployment, and rollback considerations.
+cover_headline: Upgrade Guide Helm Mode
+---
+
 # HertzBeat Upgrade Guide from v1.6.1 to v1.7.0 (Helm Mode)
 
 ## 1. Prerequisites

--- a/home/blog/2025-05-22-new-committer.md
+++ b/home/blog/2025-05-22-new-committer.md
@@ -1,9 +1,10 @@
 ---
 title: Welcome HertzBeat's New Community Committer!
+description: Kang Li describes adopting HertzBeat for internal monitoring and progressing from a database bug fix to storage templates, SSH tunnels, and documentation improvements.
 author: pwallk
 author_title: Kang Li
 author_url: https://github.com/pwallk
-tags: [opensource, practice]
+tags: [community]
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome pwallk
+cover_kicker: New Committer
 ---
 
 > Hello everyone, it's a great honor to be invited by the community to become a Committer of the Apache HertzBeat™ project.

--- a/home/blog/2025-06-10-hertzbeat-v1.7.1.md
+++ b/home/blog/2025-06-10-hertzbeat-v1.7.1.md
@@ -1,10 +1,12 @@
 ---
 title: Announcement of Apache HertzBeat™ 1.7.1 Release
+description: Apache HertzBeat 1.7.1 adds industrial device monitoring, Eureka and Consul discovery, collector-side alerts, OpenTelemetry integration, and an AI assistant.
 author: tomsun28
 author_title: tomsun28
 author_url: https://github.com/zhangshenghang
-tags: [opensource, release]
+tags: [releases]
 keywords: [open source monitoring system, alerting system, HertzBeat, release]
+cover_headline: Apache HertzBeat 1.7.1
 ---
 
 Dear Community Members,

--- a/home/blog/2025-06-29-new-committer.md
+++ b/home/blog/2025-06-29-new-committer.md
@@ -1,9 +1,10 @@
 ---
 title: Welcome HertzBeat's New Community Committer!
+description: Yijun Yin shares how using HertzBeat for lightweight metrics visualization grew into regular code contributions and deeper community participation.
 author: MasamiYui
 author_title: Yijun Yin
 author_url: https://github.com/MasamiYui
-tags: [opensource, practice]
+tags: [community]
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome MasamiYui
+cover_kicker: New Committer
 ---
 
 > Hello everyone, it's a great honor to be invited by the community to become Apache HertzBeat™ Committer.

--- a/home/blog/2025-07-07-hertzbeat-v1.7.2.md
+++ b/home/blog/2025-07-07-hertzbeat-v1.7.2.md
@@ -1,10 +1,12 @@
 ---
 title: Announcement of Apache HertzBeat™ 1.7.2 Release
+description: Apache HertzBeat 1.7.2 adds cloud alert integrations, more service discovery options, Ollama and OpenRouter support, and macOS monitoring.
 author: tomsun28
 author_title: tomsun28
 author_url: https://github.com/zhangshenghang
-tags: [opensource, release]
+tags: [releases]
 keywords: [open source monitoring system, alerting system, HertzBeat, release]
+cover_headline: Apache HertzBeat 1.7.2
 ---
 
 Dear Community Members,

--- a/home/blog/2025-07-11-new-committer.md
+++ b/home/blog/2025-07-11-new-committer.md
@@ -3,7 +3,7 @@ title: Welcome HertzBeat's New Community Committer!
 author: bigcyy
 author_title: Yang Chen
 author_url: https://github.com/bigcyy
-tags: [opensource, practice]
+tags: [community]
 keywords:
   [
     open source monitoring system,
@@ -12,6 +12,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome bigcyy
+cover_kicker: New Committer
 ---
 
 Hello everyone, I'm Yang Chen, currently a graduate student at Chongqing University of Posts and Telecommunications. I'm deeply honored to receive recognition and invitation from the Apache HertzBeat™ community to officially become a project Committer. This marks the true beginning of my open-source journey!

--- a/home/blog/2025-08-24-hertzbeat-graduation.md
+++ b/home/blog/2025-08-24-hertzbeat-graduation.md
@@ -1,8 +1,11 @@
 ---
 title: Apache HertzBeat™ Graduates as an Apache Top-Level Project!
+description: Apache HertzBeat graduates as an Apache Top-Level Project after 17 months of incubation, marking major progress in governance, technology, and global collaboration.
 author: TJxiaobao
 author_url: https://github.com/TJxiaobao
-tags: [opensource, apache]
+tags: [community]
+cover_headline: Graduates as an Apache Top-Level Project
+cover_kicker: Milestone
 ---
 
 > **A Milestone Moment for Our Open-Source Project**

--- a/home/blog/2025-09-06-hertzbeat-v1.7.3.md
+++ b/home/blog/2025-09-06-hertzbeat-v1.7.3.md
@@ -1,10 +1,12 @@
 ---
 title: Announcement of Apache HertzBeat™ 1.7.3 Release
+description: Apache HertzBeat 1.7.3 expands platform monitoring, adds nested JSON parsing and custom VictoriaMetrics labels, and improves collection performance.
 author: LiuTianyou
 author_title: LiuTianyou
 author_url: https://github.com/LiuTianyou
-tags: [opensource, release]
+tags: [releases]
 keywords: [open source monitoring system, alerting system, HertzBeat, release]
+cover_headline: Apache HertzBeat 1.7.3
 ---
 
 Dear Community Members,

--- a/home/blog/2025-10-04-new-pmc.md
+++ b/home/blog/2025-10-04-new-pmc.md
@@ -1,10 +1,12 @@
 ---
 title: From First Encounter with Open Source to Becoming a PMC Member of Apache HertzBeat™
+description: Calvin reflects on progressing from his first documentation fix to becoming a Committer and PMC member responsible for code, mentorship, and community health.
 author: Calvin
 author_title: Calvin
 author_url: https://github.com/Calvin979
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Calvin Joins the PMC
 ---
 
 ## Personal Journey

--- a/home/blog/2025-10-31-new-committer.md
+++ b/home/blog/2025-10-31-new-committer.md
@@ -1,9 +1,10 @@
 ---
 title: Welcome HertzBeat's New Community Committer!
+description: Siguo Duan shares his path to Committer through extensive work on Prometheus parsing, alerting, monitoring integrations, performance, and stability.
 author: Duansg
 author_title: SiGuo Duan
 author_url: https://github.com/Duansg
-tags: [opensource, practice]
+tags: [community]
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome Duansg
+cover_kicker: New Committer
 ---
 
 > Hello everyone, it's a great honor to be invited by the community to become Apache HertzBeat Committer.

--- a/home/blog/2025-12-07-new-committer.md
+++ b/home/blog/2025-12-07-new-committer.md
@@ -1,9 +1,10 @@
 ---
 title: Welcome HertzBeat's New Community Committer!
+description: Ziqiu Guo describes adopting HertzBeat for financial software operations and contributing DolphinScheduler, macOS, and Synology NAS monitoring.
 author: Delei
 author_title: ZiQiu Guo
 author_url: https://github.com/delei
-tags: [opensource, practice]
+tags: [community]
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome Delei
+cover_kicker: New Committer
 ---
 
 > Hello everyone, it's a great honor to be invited by the community to become Apache HertzBeat Committer.

--- a/home/blog/2025-5-19-new-pmc.md
+++ b/home/blog/2025-5-19-new-pmc.md
@@ -1,10 +1,12 @@
 ---
 title: "From User to PPMC Member: Contributing to Open Source with Passion at Apache HertzBeat"
+description: Liu Tianyou reflects on growing from a HertzBeat user into a contributor, Committer, and PMC member focused on collaboration, project health, and mentoring.
 author: liutianyou
 author_title: liutianyou
 author_url: https://github.com/Liutianyou
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: LiuTianyou Joins the PPMC
 ---
 
 ## From Contributor to PMC

--- a/home/blog/2026-02-05-hertzbeat-v1.8.0.md
+++ b/home/blog/2026-02-05-hertzbeat-v1.8.0.md
@@ -1,10 +1,12 @@
 ---
 title: Announcement of Apache HertzBeat™ 1.8.0 Release
+description: Apache HertzBeat 1.8.0 introduces AI chat and MCP tooling, new QuestDB, iDRAC and Jenkins integrations, log monitoring, and major performance improvements.
 author: Apache HertzBeat Community
 author_title: Apache HertzBeat Community
 author_url: https://github.com/apache/hertzbeat
-tags: [opensource, release, v1.8.0]
+tags: [releases]
 keywords: [open source monitoring system, alerting system, HertzBeat, release, v1.8.0, Apache]
+cover_headline: Apache HertzBeat 1.8.0
 ---
 
 Dear Community Members,

--- a/home/blog/tags.yml
+++ b/home/blog/tags.yml
@@ -1,0 +1,19 @@
+releases:
+  label: Releases
+  permalink: releases
+  description: Apache HertzBeat release announcements and product updates.
+
+engineering:
+  label: Engineering
+  permalink: engineering
+  description: Technical deep dives into Apache HertzBeat architecture and internals.
+
+tutorials:
+  label: Tutorials
+  permalink: tutorials
+  description: Guides and best practices for deploying, integrating, and using Apache HertzBeat.
+
+community:
+  label: Community
+  permalink: community
+  description: News, events, milestones, and stories from the Apache HertzBeat community.

--- a/home/docs/community/document.md
+++ b/home/docs/community/document.md
@@ -92,6 +92,38 @@ MD format configuration file in the project: [.markdownlint-cli2.jsonc](https://
 |-- sidebars.js // document sidebar menu configuration
 ```
 
+## Writing a blog post
+
+A post lives in `blog/` and, when translated, in
+`i18n/<locale>/docusaurus-plugin-content-blog/` under the same file name.
+
+```yaml
+---
+title: Announcement of Apache HertzBeat™ 1.8.0 Release
+author: Apache HertzBeat Community
+author_url: https://github.com/apache/hertzbeat
+tags: [releases]
+description: Apache HertzBeat 1.8.0 introduces AI chat and MCP tooling, log monitoring, and major performance improvements.
+cover_headline: Apache HertzBeat 1.8.0
+---
+```
+
+- **`tags`** — start with exactly one category from `blog/tags.yml`
+  (`releases`, `engineering`, `tutorials`, `community`). It drives the category
+  filter on the blog list page. Add free-form topic tags after it if useful.
+- **`description`** — one or two sentences. It becomes the card summary *and* the
+  search-engine snippet. Without it Docusaurus falls back to the first block of
+  the post, which is usually a greeting or a heading.
+- **`cover_headline`** — optional. The blog list renders a cover for every post
+  in the site's visual style; this sets the big line of text on it (e.g.
+  `Welcome Bob`). Without it the text is derived from the version or monitored
+  product found in the title.
+- **`cover_kicker`** — optional. The small pill badge on the generated cover
+  (e.g. `New Committer`). Defaults to the category name. Cover text is English
+  on every locale, matching the shared visual style.
+- **`image`** — optional. A real cover image; when set it replaces the generated
+  cover entirely.
+
 ## Specification
 
 ### Naming convention of  files

--- a/home/docusaurus.config.js
+++ b/home/docusaurus.config.js
@@ -336,7 +336,7 @@ module.exports = {
         },
         blog: {
           showReadingTime: true,
-          postsPerPage: 1,
+          postsPerPage: 9,
           feedOptions: {
             type: 'all',
             copyright: `Copyright © ${new Date().getFullYear()} Apache HertzBeat™.`,
@@ -344,9 +344,12 @@ module.exports = {
           // Please change this to your repo.
           editUrl: `${repoUrl}/edit/${branch}/home/`,
           editLocalizedFiles: true,
-          blogSidebarCount: 'ALL',
+          blogSidebarCount: 0,
           onUntruncatedBlogPosts: 'ignore',
-          onInlineAuthors: 'ignore'
+          onInlineAuthors: 'ignore',
+          // Categories are predefined in blog/tags.yml. Existing topic tags
+          // remain inline because they are intentionally more granular.
+          onInlineTags: 'ignore'
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
@@ -361,6 +364,7 @@ module.exports = {
     ],
   ],
   plugins: [
+    require.resolve('./plugins/blogFeaturedPosts'),
     [
       '@docusaurus/plugin-client-redirects',
       {

--- a/home/i18n/en/code.json
+++ b/home/i18n/en/code.json
@@ -500,5 +500,29 @@
   },
   "team.thanks": {
     "message": "Thanks to these wonderful people, who already contributed to HertzBeat!"
+  },
+  "blog.page.title": {
+    "message": "Blog",
+    "description": "Heading shown at the top of the blog list page"
+  },
+  "blog.category.all": {
+    "message": "All",
+    "description": "Label of the category filter showing every blog post"
+  },
+  "blog.category.navigation": {
+    "message": "Blog categories",
+    "description": "Accessible label for the blog category navigation"
+  },
+  "blog.category.releases": {
+    "message": "Releases"
+  },
+  "blog.category.engineering": {
+    "message": "Engineering"
+  },
+  "blog.category.tutorials": {
+    "message": "Tutorials"
+  },
+  "blog.category.community": {
+    "message": "Community"
   }
 }

--- a/home/i18n/zh-cn/code.json
+++ b/home/i18n/zh-cn/code.json
@@ -503,5 +503,29 @@
   },
   "team.thanks": {
     "message": "感谢这些已经为 HertzBeat 做出贡献的非常棒的人们！"
+  },
+  "blog.page.title": {
+    "message": "博客",
+    "description": "Heading shown at the top of the blog list page"
+  },
+  "blog.category.all": {
+    "message": "全部",
+    "description": "Label of the category filter showing every blog post"
+  },
+  "blog.category.navigation": {
+    "message": "博客分类",
+    "description": "Accessible label for the blog category navigation"
+  },
+  "blog.category.releases": {
+    "message": "版本发布"
+  },
+  "blog.category.engineering": {
+    "message": "技术解析"
+  },
+  "blog.category.tutorials": {
+    "message": "教程实践"
+  },
+  "blog.category.community": {
+    "message": "社区动态"
   }
 }

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-06-01-hertzbeat-v1.0.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-06-01-hertzbeat-v1.0.md
@@ -3,7 +3,8 @@ title: 云监控系统 HertzBeat v1.0 正式发布啦
 author: tom
 author_title: tom
 author_url: https://github.com/tomsun28
-tags: [opensource]
+tags: [releases]
+cover_headline: HertzBeat 1.0
 ---
 
 [HertzBeat 赫兹跳动](https://github.com/apache/hertzbeat) 是由 [Dromara](https://dromara.org) 孵化，[TanCloud](https://tancloud.cn) 开源的一个支持网站，API，PING，端口，数据库，全站，操作系统，中间件等监控类型，支持阈值告警，告警通知 (邮箱，webhook，钉钉，企业微信，飞书机器人)，拥有易用友好的可视化操作界面的开源监控告警项目。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-06-19-hertzbeat-v1.1.0.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-06-19-hertzbeat-v1.1.0.md
@@ -3,7 +3,8 @@ title: 云监控系统 HertzBeat v1.1.0 发布！一条命令即可开启监控�
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+cover_headline: HertzBeat 1.1.0
 ---
 
 [HertzBeat 赫兹跳动](https://github.com/apache/hertzbeat) 是由 [Dromara](https://dromara.org) 孵化，[TanCloud](https://tancloud.cn) 开源的一个支持网站，API，PING，端口，数据库，全站，操作系统，中间件等监控类型，支持阈值告警，告警通知 (邮箱，webhook，钉钉，企业微信，飞书机器人)，拥有易用友好的可视化操作界面的开源监控告警项目。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-06-22-one-step-up.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-06-22-one-step-up.md
@@ -3,7 +3,8 @@ title: 云监控系统 HertzBeat v1.1.0 发布！一条命令即可开启监控�
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+cover_headline: HertzBeat 1.1.0
 ---
 
 [HertzBeat 赫兹跳动](https://github.com/apache/hertzbeat) 是由 [Dromara](https://dromara.org) 孵化，[TanCloud](https://tancloud.cn) 开源的一个支持网站，API，PING，端口，数据库，全站，操作系统，中间件等监控类型，支持阈值告警，告警通知 (邮箱，webhook，钉钉，企业微信，飞书机器人)，拥有易用友好的可视化操作界面的开源监控告警项目。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-07-10-hertzbeat-v1.1.1.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-07-10-hertzbeat-v1.1.1.md
@@ -3,7 +3,9 @@ title: 云监控系统 HertzBeat v1.1.1 发布！
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+description: HertzBeat 1.1.1 增强自定义监控能力，支持复用前序采集指标，改进告警渠道配置，并修复多项稳定性问题。
+cover_headline: HertzBeat 1.1.1
 ---
 
 [HertzBeat 赫兹跳动](https://github.com/apache/hertzbeat) 是由 [Dromara](https://dromara.org) 孵化，[TanCloud](https://tancloud.cn) 开源的一个支持网站，API，PING，端口，数据库，全站，操作系统，中间件等监控类型，支持阈值告警，告警通知 (邮箱，webhook，钉钉，企业微信，飞书机器人)，拥有易用友好的可视化操作界面的开源监控告警项目。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-09-04-hertzbeat-v1.1.3.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-09-04-hertzbeat-v1.1.3.md
@@ -3,7 +3,9 @@ title: 云监控系统 HertzBeat v1.1.3 发布！
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+description: HertzBeat 1.1.3 新增 Kafka 监控和 SSL 证书到期监控，扩展历史数据查询范围，并优化监控界面体验。
+cover_headline: HertzBeat 1.1.3
 ---
 
 Home: hertzbeat.com | tancloud.cn

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-09-10-ssl-practice.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-09-10-ssl-practice.md
@@ -3,7 +3,8 @@ title: SSL证书过期监控最佳实践
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [tutorials]
+cover_headline: SSL Certificate Expiry Monitoring
 ---
 
 先祝看到的同学中秋快乐，身体健康，在身体健康的基础上尽量暴富。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-10-08-hertzbeat-v1.2.0.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-10-08-hertzbeat-v1.2.0.md
@@ -3,7 +3,9 @@ title: HertzBeat v1.2.0 发布！易用友好的开源实时监控工具
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+description: HertzBeat 1.2.0 带来更强的 JSONPath 采集、指标单位转换、界面升级，并将 Spring Boot 升级至 2.7。
+cover_headline: HertzBeat 1.2.0
 ---
 
 ## V1.2.0

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-11-28-hertzbeat-v1.2.2.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-11-28-hertzbeat-v1.2.2.md
@@ -3,7 +3,9 @@ title: HertzBeat v1.2.2 发布！新增K8S监控等众多特性
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+description: HertzBeat 1.2.2 新增 Kubernetes、Docker、Spring Boot、Nacos、达梦和 openGauss 监控，并实验性支持 PromQL 采集。
+cover_headline: HertzBeat 1.2.2
 ---
 
 ## V1.2.2

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-12-19-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-12-19-new-committer.md
@@ -3,7 +3,9 @@ title: 恭喜 HertzBeat 迎来了两位新晋社区Committer
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [community]
+cover_headline: Two New Committers
+cover_kicker: New Committer
 ---
 
 > 非常高兴 HertzBeat 迎来了两位新晋社区Committer, 两位都是来自互联网公司的开发工程师，让我们来了解下他们的开源经历吧！

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-12-28-hertzbeat-v1.2.3.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2022-12-28-hertzbeat-v1.2.3.md
@@ -3,7 +3,9 @@ title: HertzBeat v1.2.3 发布！支持Prometheus,ShenYu,IotDb
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [releases]
+description: HertzBeat 1.2.3 新增 Prometheus Exporter 采集、Apache ShenYu 与 IoTDB 监控、短信通知及多项体验优化。
+cover_headline: HertzBeat 1.2.3
 ---
 
 ## V1.2.3

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-01-05-monitor-iotdb.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-01-05-monitor-iotdb.md
@@ -3,8 +3,9 @@ title: 使用 HertzBeat 对物联网数据库 IoTDB 进行监控实践
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [tutorials]
 keywords: [开源监控系统, 开源数据库监控, IotDB数据库监控]
+cover_headline: Monitoring Apache IoTDB
 ---
 
 ## 使用 HertzBeat 对物联网数据库 IoTDB 进行监控实践，5分钟搞定

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-01-08-monitor-shenyu.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-01-08-monitor-shenyu.md
@@ -3,7 +3,8 @@ title: 使用 HertzBeat 对 API 网关 Apache ShenYu 的监控实践
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [tutorials]
+cover_headline: Monitoring Apache ShenYu
 ---
 
 ## 使用 HertzBeat 对 API 网关 Apache ShenYu 进行监控实践，5分钟搞定

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-02-02-monitor-dynamic-tp.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-02-02-monitor-dynamic-tp.md
@@ -3,7 +3,8 @@ title: 使用 HertzBeat 对 线程池框架 DynamicTp 的监控实践
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [tutorials]
+cover_headline: Monitoring DynamicTp
 ---
 
 ## 使用 HertzBeat 对 线程池框架 DynamicTp 进行监控实践，5分钟搞定

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-02-10-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-02-10-new-committer.md
@@ -3,7 +3,10 @@ title: 恭喜 HertzBeat 又迎来了两位新晋社区 Committer
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource]
+tags: [community]
+description: 认识 HertzBeat 新晋 Committer 高晨和铁甲小宝，了解他们在告警通知、Redis、Docker 和数据库监控等方面的贡献经历。
+cover_headline: Two New Committers
+cover_kicker: New Committer
 ---
 
 ![hertzBeat](/img/blog/new-committer.png)

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-02-11-monitor-mysql.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-02-11-monitor-mysql.md
@@ -3,8 +3,9 @@ title: 使用开源实时监控工具 HertzBeat 对 Mysql 数据库监控告警�
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [tutorials]
 keywords: [开源监控系统, 开源数据库监控, Mysql数据库监控]
+cover_headline: Monitoring MySQL
 ---
 
 ## 使用开源实时监控工具 HertzBeat 对 Mysql 数据库监控告警实践，5分钟搞定

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-02-15-monitor-linux.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-02-15-monitor-linux.md
@@ -3,8 +3,9 @@ title: 使用开源实时监控 HertzBeat 监控 Linux 操作系统
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [tutorials]
 keywords: [开源监控系统, 操作系统监控, Linux监控]
+cover_headline: Monitoring Linux
 ---
 
 ## 使用开源实时监控工具 HertzBeat 对 Linux 操作系统的监控告警实践，5分钟搞定

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-03-15-hertzbeat-v1.3.0.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-03-15-hertzbeat-v1.3.0.md
@@ -3,8 +3,10 @@ title: 重磅更新 开源实时监控工具 HertzBeat v1.3.0 发布 在线自�
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
+description: HertzBeat 1.3.0 新增自定义监控分页、网络交换机与 Redis 集群监控，并支持 IoTDB 1.0 作为时序存储。
 keywords: [开源监控系统, 告警系统, Linux监控]
+cover_headline: HertzBeat 1.3.0
 ---
 
 官网: hertzbeat.com | tancloud.cn

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-03-22-monitor-springboot2.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-03-22-monitor-springboot2.md
@@ -3,8 +3,9 @@ title: 使用 HertzBeat 5分钟搞定 SpringBoot2 监控告警
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [tutorials]
 keywords: [开源监控系统, SpringBoot监控, 监控告警]
+cover_headline: Monitoring SpringBoot 2
 ---
 
 ## 使用开源实时监控工具 HertzBeat 对 SpringBoot2 应用的监控告警实践，5分钟搞定

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-05-09-hertzbeat-v1.3.1.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-05-09-hertzbeat-v1.3.1.md
@@ -3,8 +3,10 @@ title: 50天36位贡献者，开源实时监控工具 HertzBeat v1.3.1 发布
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
+description: HertzBeat 1.3.1 新增多种时序存储、监控配置导入导出、告警静默，以及更多操作系统和应用监控模板。
 keywords: [open source monitoring system, alerting system, Linux monitoring]
+cover_headline: HertzBeat 1.3.1
 ---
 
 官网: hertzbeat.com | tancloud.cn

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-05-11-greptimedb-store.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-05-11-greptimedb-store.md
@@ -3,8 +3,9 @@ title: GreptimeDB & HertzBeat, 使用开源时序数据库 GreptimeDB 存储开�
 author: tom
 author_title: tom
 author_url: https://github.com/tomsun28
-tags: [opensource, practice]
+tags: [tutorials, engineering]
 keywords: [开源监控系统, 开源时序数据库, HertzBeat, GreptimeDB]
+cover_headline: GreptimeDB Storage
 ---
 
 ## 使用开源时序数据库 GreptimeDB 存储开源实时监控 HertzBeat 的度量数据

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-07-05-hertzbeat-v1.3.2.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-07-05-hertzbeat-v1.3.2.md
@@ -3,8 +3,10 @@ title: 开源实时监控 HertzBeat v1.3.2 发布, 更稳定更易用
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
+description: HertzBeat 1.3.2 扩展操作系统和数据库监控，新增告警收敛、Kafka 消息队列及页面化邮件服务器配置。
 keywords: [open source monitoring system, alerting system, Linux monitoring]
+cover_headline: HertzBeat 1.3.2
 ---
 
 官网: hertzbeat.com | tancloud.cn

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-08-14-hertzbeat-v1.4.0.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-08-14-hertzbeat-v1.4.0.md
@@ -3,8 +3,10 @@ title: 重磅更新，HertzBeat 集群版发布，易用友好的开源实时监
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
+description: HertzBeat 1.4.0 引入独立部署的采集器集群，支持水平扩展、故障迁移、多隔离网络监控和云边协同。
 keywords: [open source monitoring system, alerting system, Linux monitoring]
+cover_headline: HertzBeat 1.4.0 Cluster Edition
 ---
 
 ![hertzBeat](/img/home/0.png)

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-08-28-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-08-28-new-committer.md
@@ -3,8 +3,11 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [community]
+description: 赵青然分享从运维场景使用 HertzBeat，到贡献存储集成、配置导入导出、监控模板和告警渠道的开源历程。
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome New Committer
+cover_kicker: New Committer
 ---
 
 ![hertzBeat](/img/blog/new-committer.png)

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-09-26-hertzbeat-v1.4.1.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-09-26-hertzbeat-v1.4.1.md
@@ -3,8 +3,10 @@ title: 更好的用户体验, 开源实时监控 HertzBeat v1.4.1 发布
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
+description: HertzBeat 1.4.1 带来全新的登录页与仪表盘体验、采集器管理，并进一步提升监控能力和系统稳定性。
 keywords: [open source monitoring system, alerting system, Linux monitoring]
+cover_headline: HertzBeat 1.4.1
 ---
 
 哈喽大家好，时间很快两个月又过去了，HertzBeat 经过近两个月的迭代终于发布了 v1.4.1 版本。为什么是终于，因为有点难哈哈。我们参考 rocketmq 重构了 netty 的 server client 端模块，重构了采集器集群调度。比起上一版本有了更优雅的通讯代码，更完善全面的集群。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-11-12-hertzbeat-v1.4.2.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-11-12-hertzbeat-v1.4.2.md
@@ -3,8 +3,10 @@ title: HertzBeat v1.4.2 版本发布，自定义消息通知模板
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
+description: HertzBeat 1.4.2 新增自定义通知模板、推送式指标采集、华为云 OBS 模板存储，以及 EMQX 和 UDP 监控。
 keywords: [open source monitoring system, alerting system, Linux monitoring]
+cover_headline: HertzBeat 1.4.2
 ---
 
 哈喽大家好，开源实时监控 HertzBeat 新版本 v1.4.2 发布，欢迎了解使用。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-12-11-hertzbeat-v1.4.3.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2023-12-11-hertzbeat-v1.4.3.md
@@ -3,8 +3,10 @@ title: HertzBeat v1.4.3 发布，Prometheus兼容!
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
+description: HertzBeat 1.4.3 扩展 Prometheus 生态兼容性，新增 VictoriaMetrics 存储和 Spring Gateway 监控，并改进指标国际化。
 keywords: [open source monitoring system, alerting system]
+cover_headline: HertzBeat 1.4.3
 ---
 
 ## 什么是 HertzBeat?

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-01-11-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-01-11-new-committer.md
@@ -3,8 +3,11 @@ title: 热烈欢迎 HertzBeat 三位小伙伴新晋社区 Committer!
 author: tom
 author_title: tom
 author_url: https://github.com/tomsun28
-tags: [opensource, practice]
+tags: [community]
+description: 认识新晋 Committer Leo、周书胜和张洋，了解他们在推送采集、服务监控模板、文档及社区项目中的贡献。
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome New Committer
+cover_kicker: New Committer
 ---
 
 ![hertzBeat](/img/blog/new-committer.png)

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-01-18-hertzbeat-v1.4.4.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-01-18-hertzbeat-v1.4.4.md
@@ -3,8 +3,10 @@ title: HertzBeat v1.4.4 发布!
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
+description: HertzBeat 1.4.4 新增 SNMP v3，并支持 NebulaGraph、Nginx、Hive、DNS、WebSocket、NTP、SMTP、POP3 等监控。
 keywords: [open source monitoring system, alerting system]
+cover_headline: HertzBeat 1.4.4
 ---
 
 ## 什么是 HertzBeat?

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-04-17-to-apache.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-04-17-to-apache.md
@@ -3,8 +3,10 @@ title: 开源实时监控 HertzBeat 捐赠进入 Apache 孵化器。
 author: tom
 author_title: tom
 author_url: https://github.com/tomsun28
-tags: [opensource, practice]
+tags: [community]
 keywords: [open source monitoring system, alerting system]
+cover_headline: Donated to the Apache Incubator
+cover_kicker: Milestone
 ---
 
 北京时间 2024 年 4 月 5 日，开源实时监控系统 HertzBeat 正式通过 Apache 基金会的投票决议，根据 Apache 基金会邮件列表显示，HertzBeat 以 16 个约束性投票 (binging votes) 和 1 个 无约束性投票 (non-binding votes), 无弃权和反对票通过接收 HertzBeat 加入 Apache 孵化器决议。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-05-09-hertzbeat-ospp-subject-introduction.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-05-09-hertzbeat-ospp-subject-introduction.md
@@ -1,3 +1,9 @@
+---
+tags: [community]
+description: 了解 HertzBeat 开源之夏项目，包括监控模板市场与采集器调度方向、预期成果，以及参与项目所需的技术基础。
+cover_headline: OSPP 2024 Project Topics
+---
+
 # 【开源之夏】HertzBeat 课题介绍
 
 ## 什么是 HertzBeat ？

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-06-11-hertzbeat-v1.6.0-update.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-06-11-hertzbeat-v1.6.0-update.md
@@ -1,3 +1,8 @@
+---
+tags: [tutorials]
+cover_headline: Upgrade Guide to 1.6.0
+---
+
 # HertzBeat 1.6.0 升级指南
 
 ## 注意：该指南适用于1.5.0向1.6.0版本升级

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-06-15-hertzbeat-v1.6.0.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-06-15-hertzbeat-v1.6.0.md
@@ -3,8 +3,9 @@ title: HertzBeat 的第一个 Apache 版本 v1.6.0 发布！
 author: tom  
 author_title: tom   
 author_url: https://github.com/tomsun28  
-tags: [opensource, practice]
+tags: [releases]
 keywords: [open source, monitoring, alerting]
+cover_headline: Apache HertzBeat 1.6.0
 ---
 
 **Hi 朋友们，我们很高兴地宣布，Apache HertzBeat™ 的了第一个Apache版本 v1.6.0 发布啦！🎉.**

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-07-07-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-07-07-new-committer.md
@@ -3,8 +3,11 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: crossoverJie
 author_title: crossoverJie
 author_url: https://github.com/crossoverjie
-tags: [opensource, practice]
+tags: [community]
+description: crossoverJie 分享如何将可观测性与其他 Apache 社区经验带入 HertzBeat，完善单元测试、采集代码质量和社区实践。
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome crossoverJie
+cover_kicker: New Committer
 ---
 
 ![hertzBeat](/img/blog/new-committer.png)

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-07-08-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-07-08-new-committer.md
@@ -3,8 +3,11 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: zhangshenghang
 author_title: zhangshenghang
 author_url: https://github.com/zhangshenghang
-tags: [opensource, practice]
+tags: [community]
+description: zhangshenghang 回顾从补充 HBase 和大数据监控，到参与代码审查、技术讨论并帮助社区贡献者成长的经历。
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome zhangshenghang
+cover_kicker: New Committer
 ---
 
 ![hertzBeat](/img/blog/new-committer.png)

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-07-15-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-07-15-new-committer.md
@@ -3,8 +3,11 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: LiuTianyou
 author_title: LiuTianyou
 author_url: https://github.com/LiuTianyou
-tags: [opensource, practice]
+tags: [community]
+description: 刘天佑分享从采用无代理监控，到贡献项目文档、NGQL 指标查询和 NebulaGraph 集群监控的开源历程。
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome LiuTianyou
+cover_kicker: New Committer
 ---
 
 ![hertzBeat](/img/blog/new-committer.png)

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-07-27-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-07-27-new-committer.md
@@ -3,8 +3,11 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: Calvin979
 author_title: Calvin979
 author_url: https://github.com/Calvin979
-tags: [opensource, practice]
+tags: [community]
+description: Calvin 回顾从修正文档起步，到为 HertzBeat 贡献 DNS、注册中心监控和 HTTP 服务发现功能的成长经历。
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome Calvin979
+cover_kicker: New Committer
 ---
 
 ![hertzBeat](/img/blog/new-committer.png)

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-07-28-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-07-28-new-committer.md
@@ -3,8 +3,11 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: linDong
 author_title: linDong
 author_url: https://github.com/Yanshuming1
-tags: [opensource, practice]
+tags: [community]
+description: linDong 分享自己的开源入门过程，以及在企微通知、AI 集成、PrestoDB 监控、缺陷修复和文档方面的贡献。
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome linDong
+cover_kicker: New Committer
 ---
 
 ![hertzBeat](/img/blog/new-committer.png)

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-07-29-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-07-29-new-committer.md
@@ -3,8 +3,11 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: kerwin612
 author_title: Le Zhang
 author_url: https://github.com/kerwin612
-tags: [opensource, practice]
+tags: [community]
+description: Le Zhang 介绍如何通过界面优化、公共组件重构和交互改进，持续提升 HertzBeat 的易用性与代码可维护性。
 keywords: [open source monitoring system, alerting system]
+cover_headline: Welcome kerwin612
+cover_kicker: New Committer
 ---
 
 ![hertzBeat](/img/blog/new-committer.png)

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-08-18-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-08-18-new-committer.md
@@ -3,8 +3,11 @@ title: 成为 Apache Committer, 对我参与开源的肯定
 author: yuluo-yx
 author_title: Shown Ji
 author_url: https://github.com/yuluo-yx
-tags: [opensource, practice]
+tags: [community]
+description: Shown Ji 回顾通过单元测试和代码修复成为 HertzBeat Committer 的历程，并分享帮助更多开发者参与开源的思考。
 keywords: [open source monitoring system, alerting system, Apache, Apache Committer, HertzBeat]
+cover_headline: Welcome yuluo-yx
+cover_kicker: New Committer
 ---
 
 ## 我的开源历程

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-08-31-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-08-31-new-committer.md
@@ -3,7 +3,8 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: aias00
 author_title: Hongyu Liu
 author_url: https://github.com/Aias00
-tags: [opensource, practice]
+tags: [community]
+description: Hongyu Liu 分享如何将参与 Apache ShenYu 和企业中间件监控的经验带入 HertzBeat，并逐步成长为 Committer。
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome aias00
+cover_kicker: New Committer
 ---
 
 ## 自我介绍

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-09-10-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-09-10-new-committer.md
@@ -3,7 +3,8 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: zuobiao-zhou
 author_title: Yuxuan Zhang
 author_url: https://github.com/zuobiao-zhou
-tags: [opensource, practice]
+tags: [community]
+description: 张宇轩回顾通过开源之夏加入社区，并贡献 OpenAI 账户监控、IMAP 协议、脚本系统监控和前端改进的经历。
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome zuobiao-zhou
+cover_kicker: New Committer
 ---
 
 ## 自我介绍

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-11-09-hertzbeat-v1.6.1.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-11-09-hertzbeat-v1.6.1.md
@@ -3,8 +3,10 @@ title:  Apache HertzBeat™ 1.6.1 发布公告
 author: zhangshenghang
 author_title: zhangshenghang
 author_url: https://github.com/zhangshenghang
-tags: [opensource, practice]
+tags: [releases]
+description: Apache HertzBeat 1.6.1 扩展基础设施监控，新增 Prometheus 解析与推送、NGQL 查询、短信告警和 Docker Compose 部署。
 keywords: [open source monitoring system, alerting system]
+cover_headline: Apache HertzBeat 1.6.1
 ---
 
 亲爱的社区小伙伴们，

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-11-24-custom-development.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2024-11-24-custom-development.md
@@ -3,8 +3,10 @@ title:  如何参与开发自定义Collector
 author: zhangshenghang
 author_title: zhangshenghang
 author_url: https://github.com/zhangshenghang
-tags: [opensource, practice]
+tags: [engineering, tutorials]
+description: 深入了解 HertzBeat 采集器架构，以及如何扩展协议、定义监控模板、采集指标并接入自定义采集器。
 keywords: [open source monitoring system, alerting system]
+cover_headline: Developing Custom Collectors
 ---
 
 ## Collector模块介绍

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-03-03-gsoc-2025.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-03-03-gsoc-2025.md
@@ -3,8 +3,10 @@ title:  GSOC谷歌编程之夏2025招募中｜期待您的提案
 author: zhangshenghang
 author_title: zhangshenghang
 author_url: https://github.com/zhangshenghang
-tags: [opensource, practice]
+tags: [community]
+description: 了解 Apache HertzBeat GSoC 2025 项目选题、提案流程、参与要求、导师支持与关键申请时间。
 keywords: [open source monitoring system, alerting system]
+cover_headline: GSoC 2025 Recruitment
 ---
 
 ## GSOC的起源与目的

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-03-10-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-03-10-new-committer.md
@@ -3,7 +3,8 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: yunfan24
 author_title: Lixin Diao
 author_url: https://github.com/yunfan24
-tags: [opensource, practice]
+tags: [community]
+description: Lixin Diao 分享从小型缺陷修复到成为 HertzBeat Committer 的过程，并为初次参与开源的开发者总结实用入口。
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome yunfan24
+cover_kicker: New Committer
 ---
 🎉 大家好，很高兴收到 Apache HertzBeat™ 社区的邀请，正式成为项目的 Committer！
 

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-04-06-new-pmc.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-04-06-new-pmc.md
@@ -3,8 +3,10 @@ title: 从 Committer 到 PMC：在 Apache HertzBeat™ 的持续成长与蜕变�
 author: zhangshenghang
 author_title: zhangshenghang
 author_url: https://github.com/zhangshenghang
-tags: [opensource, practice]
+tags: [community]
+description: zhangshenghang 回顾从功能开发走向技术规划、社区治理、贡献者培养和项目长期维护的 PMC 成长历程。
 keywords: [open source monitoring system, alerting system]
+cover_headline: Zhangshenghang Joins the PMC
 ---
 
 ## 从 Committer 到 PMC：角色的转变与成长

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-04-10-hertzbeat-v1.7.0.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-04-10-hertzbeat-v1.7.0.md
@@ -3,8 +3,10 @@ title: Apache HertzBeat™ 1.7.0 发布公告
 author: tomsun28
 author_title: tomsun28
 author_url: https://github.com/zhangshenghang
-tags: [opensource, release]
+tags: [releases]
+description: Apache HertzBeat 1.7.0 新增指标组独立刷新周期、HTTP 服务发现和全新告警模块，并使用 Apache Arrow 优化内存数据结构。
 keywords: [open source monitoring system, alerting system, HertzBeat, release]
+cover_headline: Apache HertzBeat 1.7.0
 ---
 
 亲爱的社区小伙伴们，

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-04-23-hertzbeat-upgrade-guide-docker-mode.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-04-23-hertzbeat-upgrade-guide-docker-mode.md
@@ -1,3 +1,9 @@
+---
+tags: [tutorials]
+description: 通过备份配置与数据、替换容器镜像和验证迁移结果，安全升级基于 Docker 部署的 HertzBeat 服务。
+cover_headline: Upgrade Guide Docker Mode
+---
+
 # HertzBeat 升级指导-(Docker Mode)
 
 ## Docker 方式升级 - Mysql 数据库

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-04-23-hertzbeat-upgrade-guide-from-v1.6.1-to-v1.7.0-helm-mode.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-04-23-hertzbeat-upgrade-guide-from-v1.6.1-to-v1.7.0-helm-mode.md
@@ -1,3 +1,9 @@
+---
+tags: [tutorials]
+description: 使用 Helm 将 HertzBeat 从 1.6.1 升级至 1.7.0，涵盖环境检查、数据库备份、Chart 配置、部署验证与回滚注意事项。
+cover_headline: Upgrade Guide Helm Mode
+---
+
 # HertzBeat 从 1.6.1 版本升级到 1.7.0 版本指引-(Helm Mode)
 
 ## 1. 前置准备

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-04-23-hertzbeat-v1.7.0-docker-and-helm-upgrade-guide.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-04-23-hertzbeat-v1.7.0-docker-and-helm-upgrade-guide.md
@@ -1,3 +1,9 @@
+---
+tags: [tutorials]
+description: 按照数据备份、配置检查、镜像更新和服务验证步骤，完成 HertzBeat 1.7.0 的 Docker 部署升级。
+cover_headline: Upgrade Guide to 1.7.0
+---
+
 # hertzbeat 升级指导-docker模式
 
 ## Docker 方式升级 - Mysql数据库

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-05-22-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-05-22-new-committer.md
@@ -3,7 +3,8 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: pwallk
 author_title: Kang Li
 author_url: https://github.com/pwallk
-tags: [opensource, practice]
+tags: [community]
+description: Kang Li 分享从在企业内部采用 HertzBeat，到修复数据库问题并贡献存储模板、SSH 隧道和文档改进的经历。
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome pwallk
+cover_kicker: New Committer
 ---
 
 > 大家好，非常荣幸受到社区的邀请，成为 Apache HertzBeat™ 项目的 Committer。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-06-29-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-06-29-new-committer.md
@@ -3,7 +3,8 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: MasamiYui
 author_title: Yijun Yin
 author_url: https://github.com/MasamiYui
-tags: [opensource, practice]
+tags: [community]
+description: Yijun Yin 分享如何从使用 HertzBeat 进行轻量指标可视化，逐步走向持续代码贡献和深入社区协作。
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome MasamiYui
+cover_kicker: New Committer
 ---
 
 > 大家好，非常荣幸收到社区邀请，成为 Apache HertzBeat™ Committer。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-07-07-hertzbeat-v1.7.2.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-07-07-hertzbeat-v1.7.2.md
@@ -3,8 +3,10 @@ title: Apache HertzBeat™ 1.7.2 发布公告
 author: tomsun28
 author_title: tomsun28
 author_url: https://github.com/zhangshenghang
-tags: [opensource, release]
+tags: [releases]
+description: Apache HertzBeat 1.7.2 新增多家云平台告警源、更多服务发现方式、Ollama 与 OpenRouter 支持，以及 macOS 监控。
 keywords: [open source monitoring system, alerting system, HertzBeat, release]
+cover_headline: Apache HertzBeat 1.7.2
 ---
 
 亲爱的社区小伙伴们，

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-07-11-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-07-11-new-committer.md
@@ -3,7 +3,7 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: bigcyy
 author_title: Yang Chen
 author_url: https://github.com/bigcyy
-tags: [opensource, practice]
+tags: [community]
 keywords:
   [
     open source monitoring system,
@@ -12,6 +12,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome bigcyy
+cover_kicker: New Committer
 ---
 
 大家好，我是陈阳，目前是重庆邮电大学的一名研究生。非常荣幸能得到 Apache HertzBeat™ 社区的认可与邀请，正式成为项目的 Committer，这标志着我真正意义上的开源之旅的开启！

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-08-24-hertzbeat-graduation.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-08-24-hertzbeat-graduation.md
@@ -2,7 +2,10 @@
 title: Apache HertzBeat™ 毕业成为 Apache 顶级项目！
 author: 铁甲小宝
 author_url: https://github.com/TJxiaobao
-tags: [opensource, apache]
+tags: [community]
+description: Apache HertzBeat 经过 17 个月孵化正式成为 Apache 顶级项目，标志着社区治理、技术能力和全球协作迈入新阶段。
+cover_headline: Graduates as an Apache Top-Level Project
+cover_kicker: Milestone
 ---
 
 > **我们的开源项目的里程碑时刻**

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-09-06-hertzbeat-v1.7.3.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-09-06-hertzbeat-v1.7.3.md
@@ -3,8 +3,10 @@ title: Apache HertzBeat™ 1.7.3 发布公告
 author: LiuTianyou
 author_title: LiuTianyou
 author_url: https://github.com/LiuTianyou
-tags: [opensource, release]
+tags: [releases]
+description: Apache HertzBeat 1.7.3 扩展平台监控，新增嵌套 JSON 解析和 VictoriaMetrics 自定义标签，并提升采集与页面性能。
 keywords: [open source monitoring system, alerting system, HertzBeat, release]
+cover_headline: Apache HertzBeat 1.7.3
 ---
 
 亲爱的社区小伙伴们，

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-10-04-new-pmc.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-10-04-new-pmc.md
@@ -3,8 +3,10 @@ title: 从初识开源到成为 Apache HertzBeat™ 的 PMC 成员
 author: Calvin
 author_title: Calvin
 author_url: https://github.com/Calvin979
-tags: [opensource, practice]
+tags: [community]
+description: Calvin 回顾从第一次修正文档，到成为 Committer 和 PMC 成员，承担代码维护、贡献者指导与社区健康责任的成长过程。
 keywords: [open source monitoring system, alerting system]
+cover_headline: Calvin Joins the PMC
 ---
 
 ## 个人历程

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-10-31-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-10-31-new-committer.md
@@ -3,7 +3,8 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: Duansg
 author_title: SiGuo Duan
 author_url: https://github.com/Duansg
-tags: [opensource, practice]
+tags: [community]
+description: 段嗣国分享通过 Prometheus 解析、告警、监控集成、性能和稳定性等大量贡献成长为 Committer 的历程。
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome Duansg
+cover_kicker: New Committer
 ---
 
 > 大家好，非常荣幸收到社区邀请，成为 Apache HertzBeat™ Committer。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-12-07-new-committer.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-12-07-new-committer.md
@@ -3,7 +3,8 @@ title: 热烈欢迎 HertzBeat 小伙伴新晋社区 Committer!
 author: Delei
 author_title: ZiQiu Guo
 author_url: https://github.com/delei
-tags: [opensource, practice]
+tags: [community]
+description: ZiQiu Guo 分享在金融软件运维中采用 HertzBeat，并贡献 DolphinScheduler、macOS 和群晖 NAS 监控的经历。
 keywords:
   [
     open source monitoring system,
@@ -12,6 +13,8 @@ keywords:
     Apache Committer,
     HertzBeat,
   ]
+cover_headline: Welcome Delei
+cover_kicker: New Committer
 ---
 
 > 大家好，非常荣幸收到社区邀请，成为 Apache HertzBeat™ Committer。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-5-19-new-pmc.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2025-5-19-new-pmc.md
@@ -3,8 +3,10 @@ title: 因热爱而贡献开源：如何从用户成长为 Apache HertzBeat™ �
 author: liutianyou
 author_title: liutianyou
 author_url: https://github.com/Liutianyou
-tags: [opensource, practice]
+tags: [community]
+description: 刘天佑回顾从 HertzBeat 用户成长为贡献者、Committer 和 PMC 成员，并投入社区协作、项目健康与新人培养的历程。
 keywords: [open source monitoring system, alerting system]
+cover_headline: LiuTianyou Joins the PPMC
 ---
 
 ## 从 Contributor 到 PMC

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/2026-02-05-hertzbeat-v1.8.0.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/2026-02-05-hertzbeat-v1.8.0.md
@@ -3,8 +3,10 @@ title: Apache HertzBeat™ 1.8.0 版本发布公告
 author: Apache HertzBeat Community
 author_title: Apache HertzBeat 社区
 author_url: https://github.com/apache/hertzbeat
-tags: [开源, 发布, v1.8.0]
+tags: [releases]
+description: Apache HertzBeat 1.8.0 引入 AI 对话和 MCP 工具，新增 QuestDB、iDRAC、Jenkins 与日志监控，并显著提升性能。
 keywords: [开源监控系统, 告警系统, HertzBeat, 发布, v1.8.0, Apache]
+cover_headline: Apache HertzBeat 1.8.0
 ---
 
 亲爱的社区成员们，

--- a/home/i18n/zh-cn/docusaurus-plugin-content-blog/tags.yml
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-blog/tags.yml
@@ -1,0 +1,19 @@
+releases:
+  label: 版本发布
+  permalink: releases
+  description: Apache HertzBeat 的版本公告与产品更新。
+
+engineering:
+  label: 技术解析
+  permalink: engineering
+  description: 深入解析 Apache HertzBeat 的架构、原理与内部实现。
+
+tutorials:
+  label: 教程实践
+  permalink: tutorials
+  description: Apache HertzBeat 的部署、集成、使用教程与最佳实践。
+
+community:
+  label: 社区动态
+  permalink: community
+  description: Apache HertzBeat 社区的新闻、活动、里程碑与成员故事。

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/community/document.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/community/document.md
@@ -92,6 +92,32 @@ MD 文章的相关格式规则您可以参考：[Markdown-lint-rules](https://gi
 |-- sidebars.js // 文档侧边栏菜单配置
 ```
 
+## 写一篇博客
+
+文章放在 `blog/` 下，翻译版本放在 `i18n/<语种>/docusaurus-plugin-content-blog/`，文件名保持一致。
+
+```yaml
+---
+title: Apache HertzBeat™ 1.8.0 版本发布公告
+author: Apache HertzBeat Community
+author_url: https://github.com/apache/hertzbeat
+tags: [releases]
+description: Apache HertzBeat 1.8.0 带来 AI 对话与 MCP 工具、日志监控，以及大幅性能提升。
+cover_headline: Apache HertzBeat 1.8.0
+---
+```
+
+- **`tags`** —— 第一个必须是 `blog/tags.yml` 里定义的分类之一（`releases`、`engineering`、
+  `tutorials`、`community`），博客列表页的分类筛选依赖它。后面可以再加自由主题标签。
+- **`description`** —— 一到两句话。它同时是卡片摘要和搜索引擎摘要。不填的话
+  Docusaurus 会取正文第一段，通常是问候语或小标题。
+- **`cover_headline`** —— 可选。博客列表会为每篇文章渲染统一视觉风格的封面，这个字段
+  设置封面上的大标题（例如 `Welcome Bob`）。不填则自动从标题里的版本号或
+  被监控产品名推导。
+- **`cover_kicker`** —— 可选。生成封面上的小胶囊徽章文字（例如 `New Committer`），
+  不填默认用分类英文名。封面文字各语言统一用英文，保持视觉一致。
+- **`image`** —— 可选。真实封面图，配置后完全替代生成式封面。
+
 ## 规范
 
 ### 文件的命名规范

--- a/home/package.json
+++ b/home/package.json
@@ -25,6 +25,7 @@
     "@docusaurus/plugin-sitemap": "^3.9.2",
     "@docusaurus/preset-classic": "3.9.2",
     "@docusaurus/remark-plugin-npm2yarn": "3.9.2",
+    "@docusaurus/theme-common": "3.9.2",
     "@docusaurus/theme-live-codeblock": "3.9.2",
     "@docusaurus/theme-search-algolia": "3.9.2",
     "@douyinfe/semi-ui": "2.24.1",

--- a/home/plugins/blogFeaturedPosts/index.js
+++ b/home/plugins/blogFeaturedPosts/index.js
@@ -1,0 +1,33 @@
+const FEATURED_POST_COUNT = 4
+
+function toClientPost({metadata}) {
+  return {
+    metadata: {
+      permalink: metadata.permalink,
+      title: metadata.title,
+      description: metadata.description,
+      date: metadata.date,
+      tags: metadata.tags,
+      authors: metadata.authors,
+    },
+    frontMatter: {
+      image: metadata.frontMatter.image,
+      cover_headline: metadata.frontMatter.cover_headline,
+      cover_kicker: metadata.frontMatter.cover_kicker,
+    },
+  }
+}
+
+module.exports = function blogFeaturedPostsPlugin() {
+  return {
+    name: 'blog-featured-posts',
+    getClientModules() {
+      return [require.resolve('./scrollPosition')]
+    },
+    async allContentLoaded({allContent, actions}) {
+      const blogContent = allContent['docusaurus-plugin-content-blog']?.default
+      const posts = blogContent?.blogPosts?.slice(0, FEATURED_POST_COUNT).map(toClientPost) ?? []
+      actions.setGlobalData({posts})
+    },
+  }
+}

--- a/home/plugins/blogFeaturedPosts/scrollPosition.js
+++ b/home/plugins/blogFeaturedPosts/scrollPosition.js
@@ -1,0 +1,47 @@
+const SCROLL_KEY = 'hertzbeat.blogListScrollPosition'
+
+// Category pills and pagination links both navigate within the blog list;
+// keeping the scroll offset avoids bouncing the reader back to the top.
+export function rememberBlogListScrollPosition(event) {
+  if (
+    event.defaultPrevented ||
+    event.button !== 0 ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey
+  ) {
+    return
+  }
+
+  try {
+    sessionStorage.setItem(SCROLL_KEY, JSON.stringify({
+      pathname: event.currentTarget.pathname,
+      position: window.scrollY,
+    }))
+  } catch {
+    // Storage can be disabled without affecting navigation.
+  }
+}
+
+export function onRouteDidUpdate({location}) {
+  let storedPosition
+  try {
+    storedPosition = sessionStorage.getItem(SCROLL_KEY)
+    sessionStorage.removeItem(SCROLL_KEY)
+  } catch {
+    return
+  }
+  if (storedPosition === null) {
+    return
+  }
+
+  try {
+    const {pathname, position} = JSON.parse(storedPosition)
+    if (pathname === location.pathname && Number.isFinite(position)) {
+      window.scrollTo(0, position)
+    }
+  } catch {
+    // Ignore malformed session data left by an older build.
+  }
+}

--- a/home/pnpm-lock.yaml
+++ b/home/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@docusaurus/remark-plugin-npm2yarn':
         specifier: 3.9.2
         version: 3.9.2
+      '@docusaurus/theme-common':
+        specifier: 3.9.2
+        version: 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-live-codeblock':
         specifier: 3.9.2
         version: 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/home/src/css/custom.css
+++ b/home/src/css/custom.css
@@ -40,7 +40,7 @@
     --ifm-button-padding-vertical: 0.75rem;
     --ifm-button-border-radius: 9999px;
     --ifm-button-border-width: 0;
-    --ifm-navbar-height: 85px;
+    --ifm-navbar-height: 72px;
 
     --md-easing: cubic-bezier(0.2, 0, 0, 1);
     --md-transition-fast: 200ms var(--md-easing);
@@ -103,7 +103,7 @@ h3 {
 
 .navbar__logo {
     flex: 0 0 auto;
-    height: 2.5rem;
+    height: 2.25rem;
     margin-right: 0.5rem;
 }
 
@@ -115,6 +115,12 @@ h3 {
 @media (max-width : 1100px){
     .navbar__link {
         font-size: 12px;
+    }
+}
+
+@media (max-width: 996px) {
+    :root {
+        --ifm-navbar-height: 64px;
     }
 }
 

--- a/home/src/theme/BlogLayout/index.js
+++ b/home/src/theme/BlogLayout/index.js
@@ -1,0 +1,56 @@
+import React from 'react'
+import clsx from 'clsx'
+import Layout from '@theme/Layout'
+import BlogSidebar from '@theme/BlogSidebar'
+import {translate} from '@docusaurus/Translate'
+import {useLocation} from '@docusaurus/router'
+
+import {BLOG_LIST_ROUTE} from '../BlogPostItems/categories'
+import styles from './styles.module.css'
+
+// Main and category listings share the same page shell. Other tag and author
+// pages keep their headings from the default Docusaurus theme.
+export default function BlogLayout(props) {
+  const {sidebar, toc, children, ...layoutProps} = props
+  const {pathname} = useLocation()
+  const hasSidebar = sidebar && sidebar.items.length > 0
+  const isListPage = BLOG_LIST_ROUTE.test(pathname)
+
+  return (
+      <Layout {...layoutProps}>
+        <div className={clsx({[styles.listSurface]: isListPage})}>
+          <div
+              className={clsx('container', styles.blogContainer, {
+                'margin-vert--lg': !isListPage,
+                [styles.blogListContainer]: isListPage,
+              })}
+          >
+            {isListPage && (
+                <header className={styles.pageHeader}>
+                  <h1 className={styles.pageTitle}>
+                    {translate({
+                      id: 'blog.page.title',
+                      message: 'Blog',
+                      description: 'Heading shown at the top of the blog list page',
+                    })}
+                  </h1>
+                </header>
+            )}
+            <div className="row">
+              <BlogSidebar sidebar={sidebar} />
+              <main
+                  className={clsx('col', {
+                    'col--7': hasSidebar,
+                    'col--9 col--offset-1': !hasSidebar && !isListPage,
+                    'col--12': !hasSidebar && isListPage,
+                  })}
+              >
+                {children}
+              </main>
+              {toc && <div className="col col--2">{toc}</div>}
+            </div>
+          </div>
+        </div>
+      </Layout>
+  )
+}

--- a/home/src/theme/BlogLayout/styles.module.css
+++ b/home/src/theme/BlogLayout/styles.module.css
@@ -1,0 +1,40 @@
+/* custom.css makes every container full-width; keep blog content aligned to Doris. */
+.blogContainer.blogContainer {
+  max-width: 1288px;
+  margin-inline: auto;
+}
+
+.listSurface {
+  background: #fff;
+}
+
+.blogListContainer {
+  padding-bottom: 4.875rem;
+}
+
+.pageHeader {
+  padding: 2.5rem 0 5rem;
+  text-align: center;
+}
+
+.pageTitle {
+  margin: 0;
+  font-size: 2.75rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  line-height: normal;
+}
+
+[data-theme='dark'] .listSurface {
+  background: var(--ifm-background-color);
+}
+
+@media (max-width: 768px) {
+  .pageHeader {
+    padding: 2.5rem 0 3rem;
+  }
+
+  .pageTitle {
+    font-size: 2rem;
+  }
+}

--- a/home/src/theme/BlogListPaginator/index.js
+++ b/home/src/theme/BlogListPaginator/index.js
@@ -1,0 +1,107 @@
+import React from 'react'
+import clsx from 'clsx'
+import Link from '@docusaurus/Link'
+import {translate} from '@docusaurus/Translate'
+import {rememberBlogListScrollPosition} from '@site/plugins/blogFeaturedPosts/scrollPosition'
+
+import styles from './styles.module.css'
+
+// Page 1 lives at the blog base path, later pages at <base>/page/<n>.
+function useHrefBuilder(metadata) {
+  const {permalink, page} = metadata
+  const base = page === 1 ? permalink : permalink.replace(/\/page\/\d+$/, '')
+  return n => (n === 1 ? base : `${base}/page/${n}`)
+}
+
+// Window of pages around the current one, with ellipsis gaps: 1 … 4 [5] 6 … 12
+function pageItems(current, total) {
+  if (total <= 7) {
+    return Array.from({length: total}, (_, i) => i + 1)
+  }
+  const around = [current - 1, current, current + 1].filter(n => n > 1 && n < total)
+  const items = [1, ...around, total]
+  const result = []
+  for (let i = 0; i < items.length; i++) {
+    if (i > 0 && items[i] - items[i - 1] > 1) {
+      result.push({gap: true, key: `gap-${items[i]}`})
+    }
+    result.push(items[i])
+  }
+  return result
+}
+
+export default function BlogListPaginator({metadata}) {
+  const {page, totalPages, previousPage, nextPage} = metadata
+  const hrefFor = useHrefBuilder(metadata)
+
+  if (!totalPages || totalPages <= 1) {
+    return null
+  }
+
+  const prevLabel = translate({
+    id: 'theme.blog.paginator.newerEntries',
+    message: 'Newer entries',
+  })
+  const nextLabel = translate({
+    id: 'theme.blog.paginator.olderEntries',
+    message: 'Older entries',
+  })
+
+  return (
+      <nav
+          className={styles.paginator}
+          aria-label={translate({
+            id: 'theme.blog.paginator.navAriaLabel',
+            message: 'Blog list page navigation',
+          })}
+      >
+        {previousPage ? (
+            <Link
+                className={styles.arrow}
+                to={previousPage}
+                aria-label={prevLabel}
+                onClick={rememberBlogListScrollPosition}
+            >
+              ‹
+            </Link>
+        ) : (
+            <span className={clsx(styles.arrow, styles.disabled)} aria-hidden="true">
+              ‹
+            </span>
+        )}
+
+        {pageItems(page, totalPages).map(item =>
+            typeof item === 'object' ? (
+                <span key={item.key} className={styles.gap}>
+                  …
+                </span>
+            ) : (
+                <Link
+                    key={item}
+                    to={hrefFor(item)}
+                    className={clsx(styles.page, item === page && styles.current)}
+                    aria-current={item === page ? 'page' : undefined}
+                    onClick={rememberBlogListScrollPosition}
+                >
+                  {item}
+                </Link>
+            ),
+        )}
+
+        {nextPage ? (
+            <Link
+                className={styles.arrow}
+                to={nextPage}
+                aria-label={nextLabel}
+                onClick={rememberBlogListScrollPosition}
+            >
+              ›
+            </Link>
+        ) : (
+            <span className={clsx(styles.arrow, styles.disabled)} aria-hidden="true">
+              ›
+            </span>
+        )}
+      </nav>
+  )
+}

--- a/home/src/theme/BlogListPaginator/styles.module.css
+++ b/home/src/theme/BlogListPaginator/styles.module.css
@@ -1,0 +1,54 @@
+.paginator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 1rem 0 3rem;
+}
+
+.page,
+.arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.25rem;
+  height: 2.25rem;
+  padding: 0 0.6rem;
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: 8px;
+  color: var(--ifm-color-emphasis-800);
+  font-size: 0.9rem;
+  line-height: 1;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease;
+}
+
+.page:hover,
+.arrow:hover {
+  border-color: var(--ifm-color-primary);
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+}
+
+.current.current,
+.current.current:hover {
+  border-color: var(--ifm-color-primary);
+  background: var(--ifm-color-primary);
+  color: #fff;
+}
+
+.arrow {
+  font-size: 1.15rem;
+}
+
+.disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.gap {
+  min-width: 1.5rem;
+  text-align: center;
+  color: var(--ifm-color-emphasis-600);
+  user-select: none;
+}

--- a/home/src/theme/BlogPostItems/categories.js
+++ b/home/src/theme/BlogPostItems/categories.js
@@ -1,0 +1,39 @@
+export const BLOG_CATEGORIES = [
+  {
+    id: 'blog.category.releases',
+    message: 'Releases',
+    slug: 'releases',
+  },
+  {
+    id: 'blog.category.engineering',
+    message: 'Engineering',
+    slug: 'engineering',
+  },
+  {
+    id: 'blog.category.tutorials',
+    message: 'Tutorials',
+    slug: 'tutorials',
+  },
+  {
+    id: 'blog.category.community',
+    message: 'Community',
+    slug: 'community',
+  },
+]
+
+const CATEGORY_SLUG_PATTERN = BLOG_CATEGORIES.map(category => category.slug).join('|')
+const LOCALE_PREFIX_PATTERN = '(?:[a-z]{2}(?:-[a-z]{2})?/)?'
+
+export const CATEGORY_LIST_ROUTE = new RegExp(
+    `^/${LOCALE_PREFIX_PATTERN}blog/tags/(?:${CATEGORY_SLUG_PATTERN})(?:/page/\\d+)?/?$`,
+    'i',
+)
+
+export const BLOG_LIST_ROUTE = new RegExp(
+    `^/${LOCALE_PREFIX_PATTERN}blog(?:/page/\\d+|/tags/(?:${CATEGORY_SLUG_PATTERN})(?:/page/\\d+)?)?/?$`,
+    'i',
+)
+
+export function isCategoryPermalink(permalink) {
+  return BLOG_CATEGORIES.some(({slug}) => permalink.endsWith(`/tags/${slug}`))
+}

--- a/home/src/theme/BlogPostItems/index.js
+++ b/home/src/theme/BlogPostItems/index.js
@@ -1,0 +1,348 @@
+import React from 'react'
+import clsx from 'clsx'
+import Link from '@docusaurus/Link'
+import {translate} from '@docusaurus/Translate'
+import useBaseUrl from '@docusaurus/useBaseUrl'
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext'
+import {usePluginData} from '@docusaurus/useGlobalData'
+import {useLocation} from '@docusaurus/router'
+
+import {
+  BLOG_CATEGORIES,
+  BLOG_LIST_ROUTE,
+  CATEGORY_LIST_ROUTE,
+  isCategoryPermalink,
+} from './categories'
+import {rememberBlogListScrollPosition} from '@site/plugins/blogFeaturedPosts/scrollPosition'
+import styles from './styles.module.css'
+
+const COVER_HEADLINE_FALLBACK = 'Apache HertzBeat'
+
+// Accent pairs for the generated cover glows.
+const COVER_ACCENTS = [
+  ['#a86ee0', '#7fb5e8'],
+  ['#6fc7b4', '#8fb8ee'],
+  ['#e0a86e', '#c48fe8'],
+  ['#7f9ce8', '#b98fe0'],
+  ['#e08fb5', '#8fc4e8'],
+]
+
+// Hashed on the locale-independent part of the permalink, so a post keeps its
+// accents across rebuilds and looks the same on every locale.
+function pickAccents(permalink) {
+  const blogIndex = permalink.indexOf('/blog/')
+  const key = blogIndex === -1 ? permalink : permalink.slice(blogIndex)
+  let hash = 0
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) | 0
+  }
+  return COVER_ACCENTS[Math.abs(hash) % COVER_ACCENTS.length]
+}
+
+// Monitored targets are buried in long titles and appear nowhere else on the
+// card, so surfacing them is what makes covers differ from one another. These
+// are product names, deliberately left untranslated.
+const MONITORED_TARGETS = [
+  ['Kubernetes', /\bk8s\b|kubernetes/i],
+  ['IoTDB', /iotdb/i],
+  ['Apache ShenYu', /shenyu/i],
+  ['DynamicTp', /dynamictp/i],
+  ['GreptimeDB', /greptime/i],
+  ['SpringBoot', /spring\s*boot/i],
+  ['Linux', /\blinux\b/i],
+  ['SSL Certificate', /ssl\s*(certificate|证书)/i],
+  ['MySQL', /mysql/i],
+  ['PostgreSQL', /postgres/i],
+  ['Redis', /\bredis\b/i],
+  ['Nacos', /nacos/i],
+  ['Prometheus', /prometheus/i],
+  ['Docker', /\bdocker\b/i],
+  ['Windows', /\bwindows\b/i],
+]
+
+// The big line on the cover when the post has no cover_headline. The category
+// is not repeated here — it gets its own kicker pill below the headline.
+function deriveHeadline(title, tags) {
+  const haystack = `${title} ${tags.map(t => t.label).join(' ')}`
+
+  // Titles carry either "v1.0" or a bare "1.7.0"; only the prefixed form may
+  // omit the patch number, so a bare "1.5" stays unmatched.
+  const version =
+      haystack.match(/\bv(\d+\.\d+(?:\.\d+)?)\b/i) || haystack.match(/\b(\d+\.\d+\.\d+)\b/)
+  if (version) {
+    return `Apache HertzBeat ${version[1]}`
+  }
+  const target = MONITORED_TARGETS.find(([, pattern]) => pattern.test(haystack))
+  return target?.[0] ?? COVER_HEADLINE_FALLBACK
+}
+
+const HERO_SIDE_COUNT = 3
+
+function useDateFormatter() {
+  const {i18n} = useDocusaurusContext()
+  return dateString => {
+    const date = new Date(dateString)
+    if (Number.isNaN(date.getTime())) {
+      return dateString
+    }
+    try {
+      return new Intl.DateTimeFormat(i18n.currentLocale, {
+        day: 'numeric',
+        month: 'long',
+        year: 'numeric',
+        timeZone: 'UTC',
+      }).format(date)
+    } catch {
+      return dateString
+    }
+  }
+}
+
+function Meta({date, authorNames, formatDate}) {
+  return (
+      <div className={styles.meta}>
+        <time dateTime={date}>{formatDate(date)}</time>
+        {authorNames.length > 0 && (
+            <span className={styles.metaSeparator}>{authorNames.join(', ')}</span>
+        )}
+      </div>
+  )
+}
+
+// Cover text is deliberately English on every locale, like the original
+// hand-made covers, so the untranslated `message` is used instead of the
+// localized tag label.
+function englishCategoryLabel(category) {
+  return BLOG_CATEGORIES.find(({slug}) => category?.permalink.endsWith(`/tags/${slug}`))
+      ?.message
+}
+
+function Cover({image, headline, kicker, title, tags, category, permalink, className}) {
+  const imageUrl = useBaseUrl(image ?? '')
+  const brandUrl = useBaseUrl('/img/hertzbeat-brand.svg')
+  const brandWhiteUrl = useBaseUrl('/img/hertzbeat-brand-white.svg')
+
+  if (image) {
+    return (
+        <div className={clsx(styles.cover, className)}>
+          <img className={styles.coverImage} src={imageUrl} alt="" loading="lazy" />
+        </div>
+    )
+  }
+
+  const [accent, accent2] = pickAccents(permalink)
+  const kickerText = kicker ?? englishCategoryLabel(category)
+
+  return (
+      <div
+          className={clsx(styles.cover, styles.coverGenerated, className)}
+          style={{'--cover-accent': accent, '--cover-accent-2': accent2}}
+      >
+        <span className={clsx(styles.coverGlow, styles.coverGlowStart)} />
+        <span className={clsx(styles.coverGlow, styles.coverGlowEnd)} />
+        <img
+            className={clsx(styles.coverBrand, styles.coverBrandLight)}
+            src={brandUrl}
+            alt=""
+            loading="lazy"
+        />
+        <img
+            className={clsx(styles.coverBrand, styles.coverBrandDark)}
+            src={brandWhiteUrl}
+            alt=""
+            loading="lazy"
+        />
+        <span className={styles.coverHeadline}>
+          {headline ?? deriveHeadline(title, tags)}
+        </span>
+        {kickerText && (
+            <span className={styles.coverKicker}>
+              <span className={styles.coverKickerDot} />
+              {kickerText}
+            </span>
+        )}
+      </div>
+  )
+}
+
+function getCardData(content) {
+  const {metadata, frontMatter, assets} = content
+  const category = (metadata.tags ?? []).find(tag => isCategoryPermalink(tag.permalink))
+  return {
+    ...metadata,
+    image: assets?.image ?? frontMatter?.image,
+    coverHeadline: frontMatter?.cover_headline,
+    coverKicker: frontMatter?.cover_kicker,
+    authorNames: (metadata.authors ?? []).map(a => a.name).filter(Boolean),
+    category,
+  }
+}
+
+function BlogCard({content, formatDate}) {
+  const d = getCardData(content)
+
+  return (
+      <article className={styles.card}>
+        <Link to={d.permalink} className={styles.cardLink}>
+          <Cover
+              image={d.image}
+              headline={d.coverHeadline}
+              kicker={d.coverKicker}
+              title={d.title}
+              tags={d.tags}
+              category={d.category}
+              permalink={d.permalink}
+          />
+          <div className={styles.body}>
+            {d.tags.length > 0 && (
+                <div className={styles.tags}>
+                  {d.tags.slice(0, 3).map(tag => (
+                      <span key={tag.permalink} className={styles.tag}>
+                        {tag.label}
+                      </span>
+                  ))}
+                </div>
+            )}
+            <h2 className={styles.title}>{d.title}</h2>
+            {d.description && <p className={styles.description}>{d.description}</p>}
+            <Meta {...d} formatDate={formatDate} />
+          </div>
+        </Link>
+      </article>
+  )
+}
+
+function HeroCard({content, formatDate}) {
+  const d = getCardData(content)
+
+  return (
+      <article className={clsx(styles.card, styles.heroCard)}>
+        <Link to={d.permalink} className={styles.cardLink}>
+          <Cover
+              image={d.image}
+              headline={d.coverHeadline}
+              kicker={d.coverKicker}
+              title={d.title}
+              tags={d.tags}
+              category={d.category}
+              permalink={d.permalink}
+              className={styles.heroCover}
+          />
+          <div className={styles.body}>
+            <h2 className={clsx(styles.title, styles.heroTitle)}>{d.title}</h2>
+            {d.description && (
+                <p className={clsx(styles.description, styles.heroDescription)}>
+                  {d.description}
+                </p>
+            )}
+            <Meta {...d} formatDate={formatDate} />
+          </div>
+        </Link>
+      </article>
+  )
+}
+
+function SideCard({content, formatDate}) {
+  const d = getCardData(content)
+
+  return (
+      <article className={clsx(styles.card, styles.sideCard)}>
+        <Link to={d.permalink} className={styles.sideLink}>
+          <h3 className={styles.sideTitle}>{d.title}</h3>
+          {d.description && <p className={styles.sideDescription}>{d.description}</p>}
+          <Meta {...d} formatDate={formatDate} />
+        </Link>
+      </article>
+  )
+}
+
+function CategoryBar({compact = false}) {
+  const {pathname} = useLocation()
+  const blogBasePath = useBaseUrl('/blog/', {forcePrependBaseUrl: true})
+  const allActive = !CATEGORY_LIST_ROUTE.test(pathname)
+
+  return (
+      <nav
+          className={clsx(styles.categoryBar, {[styles.categoryBarCompact]: compact})}
+          aria-label={translate({
+            id: 'blog.category.navigation',
+            message: 'Blog categories',
+            description: 'Accessible label for the blog category navigation',
+          })}
+      >
+        <Link
+            to={blogBasePath}
+            className={clsx(styles.categoryPill, {
+              [styles.categoryPillActive]: allActive,
+            })}
+            aria-current={allActive ? 'page' : undefined}
+            onClick={rememberBlogListScrollPosition}
+        >
+          {translate({
+            id: 'blog.category.all',
+            message: 'All',
+            description: 'Label of the category filter showing every blog post',
+          })}
+        </Link>
+        {BLOG_CATEGORIES.map(category => {
+          const active = pathname.includes(`/blog/tags/${category.slug}`)
+          return (
+            <Link
+                key={category.id}
+                to={`${blogBasePath}tags/${category.slug}/`}
+                className={clsx(styles.categoryPill, {
+                  [styles.categoryPillActive]: active,
+                })}
+                aria-current={active ? 'page' : undefined}
+                onClick={rememberBlogListScrollPosition}
+            >
+              {translate({id: category.id, message: category.message})}
+            </Link>
+          )
+        })}
+      </nav>
+  )
+}
+
+export default function BlogPostItems({items}) {
+  const {pathname} = useLocation()
+  const {posts: featuredPosts = []} = usePluginData('blog-featured-posts')
+  const formatDate = useDateFormatter()
+  const isListPage = BLOG_LIST_ROUTE.test(pathname)
+  const withHero = isListPage && featuredPosts.length > HERO_SIDE_COUNT
+
+  // Featured posts stay in the grid below, so every page keeps full rows.
+  const hero = withHero ? featuredPosts[0] : null
+  const side = withHero ? featuredPosts.slice(1, 1 + HERO_SIDE_COUNT) : []
+
+  return (
+      <>
+        {hero && (
+            <div className={styles.heroSection}>
+              <HeroCard content={hero} formatDate={formatDate} />
+              <div className={styles.sideList}>
+                {side.map(content => (
+                    <SideCard
+                        key={content.metadata.permalink}
+                        content={content}
+                        formatDate={formatDate}
+                    />
+                ))}
+              </div>
+            </div>
+        )}
+
+        {isListPage && <CategoryBar compact={!withHero} />}
+
+        <div className={styles.blogGrid}>
+          {items.map(({content}) => (
+              <BlogCard
+                  key={content.metadata.permalink}
+                  content={content}
+                  formatDate={formatDate}
+              />
+          ))}
+        </div>
+      </>
+  )
+}

--- a/home/src/theme/BlogPostItems/styles.module.css
+++ b/home/src/theme/BlogPostItems/styles.module.css
@@ -1,0 +1,462 @@
+.heroSection {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1.5rem;
+  height: 602px;
+}
+
+.heroCard {
+  height: 602px;
+}
+
+.sideList {
+  display: grid;
+  grid-template-rows: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  min-height: 0;
+}
+
+.heroCover.heroCover {
+  flex-basis: 261px;
+  height: 261px;
+}
+
+.heroCard .body {
+  flex: 1;
+  height: auto;
+  padding: 0 1.5rem 1.25rem;
+}
+
+.heroTitle.heroTitle {
+  flex-shrink: 0;
+  height: 6rem;
+  margin-top: 1rem;
+  font-size: 2rem;
+  font-weight: 500;
+  line-height: 3rem;
+  -webkit-line-clamp: 2;
+}
+
+.heroDescription.heroDescription {
+  flex-shrink: 0;
+  height: auto;
+  max-height: 6.75rem;
+  margin-top: 1rem;
+  color: #666;
+  font-size: 1.125rem;
+  line-height: 1.6875rem;
+  -webkit-line-clamp: 4;
+}
+
+.heroCard .meta {
+  margin-top: auto;
+}
+
+.sideCard {
+  min-height: 0;
+}
+
+.sideLink,
+.sideLink:hover {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  padding: 1.25rem 1.5rem;
+  color: inherit;
+  text-decoration: none;
+}
+
+.sideTitle {
+  margin: 0;
+  color: var(--ifm-heading-color);
+  font-size: 1.25rem;
+  font-weight: 500;
+  line-height: 1.5rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.sideDescription {
+  height: 2.75rem;
+  margin: 0.75rem 0 0;
+  color: #4c576c;
+  font-size: 0.875rem;
+  line-height: 1.375rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.sideLink .meta {
+  margin-top: auto;
+}
+
+.sideCard:hover .sideTitle {
+  color: var(--ifm-color-primary);
+}
+
+.categoryBar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: 5.5rem;
+}
+
+.categoryBarCompact {
+  margin-top: 2rem;
+}
+
+.categoryPill {
+  display: block;
+  padding: 0.75rem 1.5rem;
+  border-radius: 2.5rem;
+  color: #4c576c;
+  font-size: 1rem;
+  line-height: 1.5rem;
+  box-shadow: 0 1px 4px rgba(114, 40, 181, 0.1);
+  text-decoration: none;
+  transition: color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.categoryPill:hover,
+.categoryPill:focus-visible {
+  color: var(--ifm-color-primary);
+  text-decoration: none;
+  box-shadow: 0 2px 8px rgba(114, 40, 181, 0.18);
+}
+
+.categoryPillActive.categoryPillActive {
+  background: var(--ifm-color-primary);
+  color: #fff;
+}
+
+.blogGrid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+  padding: 2.5rem 0 2rem;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  border: 1px solid #dfe5f0;
+  border-radius: 8px;
+  background: var(--ifm-background-surface-color);
+  transition: border-color 0.2s ease;
+}
+
+.card:hover {
+  border-color: var(--ifm-color-primary);
+}
+
+.blogGrid .card {
+  height: 416px;
+}
+
+.cardLink,
+.cardLink:hover {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  color: inherit;
+  text-decoration: none;
+}
+
+.cover {
+  position: relative;
+  display: flex;
+  align-items: flex-end;
+  flex: 0 0 165px;
+  height: 165px;
+  overflow: hidden;
+}
+
+.coverImage {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.coverGenerated {
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.75rem 1.5rem;
+  background: linear-gradient(135deg, #f7f5fd 0%, #eef3fb 55%, #f4f1fb 100%);
+  border-bottom: 1px solid #e8ecf5;
+}
+
+.coverGlow {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(34px);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.coverGlowStart {
+  top: -46%;
+  left: -14%;
+  width: 44%;
+  padding-bottom: 44%;
+  background: var(--cover-accent);
+}
+
+.coverGlowEnd {
+  right: -11%;
+  bottom: -40%;
+  width: 36%;
+  padding-bottom: 36%;
+  background: var(--cover-accent-2);
+}
+
+.heroCover .coverGlow {
+  filter: blur(52px);
+}
+
+.coverBrand {
+  position: relative;
+  width: 92px;
+}
+
+.coverBrandDark {
+  display: none;
+}
+
+.coverHeadline {
+  position: relative;
+  color: #24123a;
+  font-size: 1.0625rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.16;
+  text-align: center;
+}
+
+.coverKicker {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.16rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(114, 40, 181, 0.2);
+  color: #6b4b8f;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.coverKickerDot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--cover-accent);
+}
+
+.heroCover .coverBrand {
+  width: 148px;
+}
+
+.heroCover .coverHeadline {
+  font-size: 1.75rem;
+}
+
+.heroCover .coverKicker {
+  gap: 0.45rem;
+  padding: 0.25rem 0.9rem;
+  font-size: 0.8125rem;
+}
+
+.heroCover .coverKickerDot {
+  width: 8px;
+  height: 8px;
+}
+
+[data-theme='dark'] .coverGenerated {
+  background: linear-gradient(135deg, #241a34 0%, #1a1b2e 55%, #221a30 100%);
+  border-bottom-color: var(--ifm-color-emphasis-200);
+}
+
+[data-theme='dark'] .coverBrandLight {
+  display: none;
+}
+
+[data-theme='dark'] .coverBrandDark {
+  display: block;
+}
+
+[data-theme='dark'] .coverHeadline {
+  color: #ece5f7;
+}
+
+[data-theme='dark'] .coverKicker {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.16);
+  color: #b7a4d1;
+}
+
+.body {
+  display: flex;
+  flex: 0 0 251px;
+  flex-direction: column;
+  height: 251px;
+  padding: 1.5rem;
+}
+
+.tags {
+  display: flex;
+  flex: 0 0 28px;
+  gap: 1rem;
+  height: 28px;
+  overflow: hidden;
+}
+
+.tag {
+  padding: 0.25rem 0.5rem;
+  border: 1px solid #dadce0;
+  border-radius: 1.5rem;
+  color: var(--ifm-color-emphasis-700);
+  font-size: 0.75rem;
+  line-height: 1.125rem;
+  white-space: nowrap;
+}
+
+.title {
+  height: 3.125rem;
+  margin: 1rem 0 0;
+  color: var(--ifm-heading-color);
+  font-size: 1.25rem;
+  font-weight: 500;
+  line-height: 1.5625rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.card:hover .title {
+  color: var(--ifm-color-primary);
+}
+
+.description {
+  height: 3rem;
+  margin: 1.5rem 0 0;
+  color: #4c576c;
+  font-size: 0.875rem;
+  line-height: 1.5rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.meta {
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: nowrap;
+  gap: 1rem;
+  height: 1.375rem;
+  margin-top: 1rem;
+  color: #8592a6;
+  font-size: 0.875rem;
+  line-height: 1.375rem;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.metaSeparator {
+  min-width: 0;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+[data-theme='dark'] .card {
+  border-color: var(--ifm-color-emphasis-300);
+}
+
+[data-theme='dark'] .sideDescription,
+[data-theme='dark'] .description,
+[data-theme='dark'] .heroDescription.heroDescription,
+[data-theme='dark'] .categoryPill {
+  color: var(--ifm-color-emphasis-700);
+}
+
+@media (max-width: 996px) {
+  .heroSection {
+    grid-template-columns: 1fr;
+    height: auto;
+  }
+
+  .heroCard {
+    height: auto;
+  }
+
+  .heroCover.heroCover {
+    flex-basis: auto;
+    height: auto;
+    aspect-ratio: 900 / 383;
+  }
+
+  .heroCard .body {
+    flex: 0 0 341px;
+    height: 341px;
+  }
+
+  .sideList {
+    grid-template-rows: repeat(3, 190px);
+  }
+
+  .categoryBar {
+    flex-wrap: nowrap;
+    justify-content: flex-start;
+    gap: 0.75rem;
+    margin-top: 3rem;
+    overflow-x: auto;
+  }
+
+  .categoryPill {
+    flex: 0 0 auto;
+    padding: 0.5rem 1rem;
+    font-size: 0.875rem;
+  }
+
+  .blogGrid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .heroTitle.heroTitle {
+    height: auto;
+    font-size: 1.5rem;
+    line-height: 2rem;
+  }
+
+  .heroDescription.heroDescription {
+    height: auto;
+    font-size: 0.875rem;
+    line-height: 1.375rem;
+  }
+
+  .heroCard .body {
+    flex-basis: auto;
+    height: auto;
+    padding: 0 1.5rem 1.5rem;
+  }
+
+  .blogGrid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/home/src/theme/BlogTagsPostsPage/index.js
+++ b/home/src/theme/BlogTagsPostsPage/index.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import clsx from 'clsx'
+import {translate} from '@docusaurus/Translate'
+import {
+  HtmlClassNameProvider,
+  PageMetadata,
+  ThemeClassNames,
+} from '@docusaurus/theme-common'
+import OriginalBlogTagsPostsPage from '@theme-original/BlogTagsPostsPage'
+import BlogLayout from '@theme/BlogLayout'
+import BlogListPaginator from '@theme/BlogListPaginator'
+import BlogPostItems from '@theme/BlogPostItems'
+import SearchMetadata from '@theme/SearchMetadata'
+import Unlisted from '@theme/ContentVisibility/Unlisted'
+
+import {isCategoryPermalink} from '../BlogPostItems/categories'
+
+function CategoryPostsPage({tag, items, sidebar, listMetadata}) {
+  const blogTitle = translate({
+    id: 'blog.page.title',
+    message: 'Blog',
+    description: 'Heading shown at the top of the blog list page',
+  })
+
+  return (
+      <HtmlClassNameProvider
+          className={clsx(
+              ThemeClassNames.wrapper.blogPages,
+              ThemeClassNames.page.blogTagPostListPage,
+          )}
+      >
+        <PageMetadata title={`${tag.label} | ${blogTitle}`} description={tag.description} />
+        <SearchMetadata tag="blog_tags_posts" />
+        <BlogLayout sidebar={sidebar}>
+          {tag.unlisted && <Unlisted />}
+          <BlogPostItems items={items} />
+          <BlogListPaginator metadata={listMetadata} />
+        </BlogLayout>
+      </HtmlClassNameProvider>
+  )
+}
+
+export default function BlogTagsPostsPage(props) {
+  if (!isCategoryPermalink(props.tag.permalink)) {
+    return <OriginalBlogTagsPostsPage {...props} />
+  }
+  return <CategoryPostsPage {...props} />
+}


### PR DESCRIPTION
## What's changed?

Refactors the blog list page from the default Docusaurus list into a card-based
layout, as requested in #2075.

Closes #2075

The design follows [Apache Doris](https://doris.apache.org/blog?currentPage=1&currentCategory=All#blog):
a featured hero block above a three-column card grid, with category filtering and
numbered pagination. Missing `description` front matter was backfilled so cards
and search snippets no longer fall back to a greeting line.

## How covers work

No image files are shipped. Every cover is rendered at runtime with CSS
(gradient + logo + text), so the repository size does not grow with each post.

**Cover text is always English, on every locale.** Localized content (title,
description, tags) sits below the cover. Two optional front matter fields:

- **`cover_headline`** — the big line.
  - Provided → rendered as-is (write it in English, e.g. `Welcome Bob`).
  - Not provided → derived from the title: a version number
    (`Apache HertzBeat 1.7.2`), else a known product name (`MySQL`), else
    `Apache HertzBeat`. Derived text is English by nature, since it only
    extracts versions and product names.
- **`cover_kicker`** — the pill badge.
  - Provided → rendered as-is (e.g. `New Committer`).
  - Not provided → the post category's English name (`Releases`, `Community`,
    …). The localized label is deliberately not used here.
  - No category tag → the badge is hidden.

A real image can still be configured with `image:` and replaces the generated
cover entirely (per locale, since each translation has its own front matter).

## Before

<img width="1909" height="961" alt="Screenshot 2026-07-19 at 5 08 52 AM" src="https://github.com/user-attachments/assets/dbdbf7b9-dffd-465b-97dc-583b53de0d24" />

## After

<img width="1910" height="966" alt="Screenshot 2026-07-19 at 5 08 56 AM" src="https://github.com/user-attachments/assets/866f0507-56ee-4f4f-b024-0d86b47ac4c1" />

<img width="1905" height="962" alt="Screenshot 2026-07-19 at 5 09 03 AM" src="https://github.com/user-attachments/assets/548290ee-c28d-4488-9624-c0596cfcd93e" />

## How to review

Please review by looking at the rendered pages rather than the diff — most of the
changed files are one-line front matter additions.

```shell
gh pr checkout 4219        # or: git fetch origin pull/4219/head && git checkout FETCH_HEAD
cd home && pnpm install

pnpm start                 # English  -> http://localhost:3000/blog
pnpm run start-zh-cn       # Chinese  -> http://localhost:3000/blog
```

Worth checking:

- `/blog` — hero block, card grid, category pills, pagination
- `/blog/tags/releases` — category filtering
- `/blog/page/2` and onwards — pagination keeps scroll position
- Dark mode (generated covers follow the theme), and narrow windows (3 / 2 / 1 columns)
- The Chinese site — category labels and dates are localized, cover text stays English

## Checklist

- [x] I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x] I have written the necessary doc or comment.
- [ ] I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
