### PR TITLE
[improve] reject masked receiver edit when the stored receiver does not exist

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/impl/NoticeConfigServiceImpl.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/service/impl/NoticeConfigServiceImpl.java
@@ -185,13 +185,18 @@ public class NoticeConfigServiceImpl implements NoticeConfigService, CommandLine
      * The rest api returns receivers with masked secret fields, so a receiver submitted
      * from the ui may carry the mask placeholder instead of the real secret.
      * Restore such fields from the stored entity before using the receiver.
+     * @throws IllegalArgumentException if the receiver carries an id but no stored receiver
+     *                                  exists for it: without the stored entity the mask cannot
+     *                                  be resolved, and saving would persist the placeholder
      */
     private void resolveMaskedSecrets(NoticeReceiver noticeReceiver) {
         if (noticeReceiver == null || noticeReceiver.getId() == null) {
             return;
         }
-        noticeReceiverDao.findById(noticeReceiver.getId())
-                .ifPresent(existing -> NoticeReceiverMaskUtil.resolveMask(noticeReceiver, existing));
+        NoticeReceiver existing = noticeReceiverDao.findById(noticeReceiver.getId())
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "The receiver with id " + noticeReceiver.getId() + " does not exist."));
+        NoticeReceiverMaskUtil.resolveMask(noticeReceiver, existing);
     }
 
     @Override

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/service/NoticeConfigServiceTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/service/NoticeConfigServiceTest.java
@@ -52,10 +52,12 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -213,7 +215,9 @@ class NoticeConfigServiceTest {
 
     @Test
     void editReceiver() {
-        final NoticeReceiver noticeReceiver = mock(NoticeReceiver.class);
+        final NoticeReceiver noticeReceiver = new NoticeReceiver();
+        noticeReceiver.setId(5L);
+        when(noticeReceiverDao.findById(5L)).thenReturn(Optional.of(noticeReceiver));
         noticeConfigService.editReceiver(noticeReceiver);
         verify(noticeReceiverDao, times(1)).save(noticeReceiver);
     }
@@ -236,6 +240,18 @@ class NoticeConfigServiceTest {
     }
 
     @Test
+    void editReceiverRejectsUnknownId() {
+        when(noticeReceiverDao.findById(5L)).thenReturn(Optional.empty());
+
+        final NoticeReceiver incoming = new NoticeReceiver();
+        incoming.setId(5L);
+        incoming.setTgBotToken(NoticeReceiverMaskUtil.SECRET_MASK + "voJM");
+
+        assertThrows(IllegalArgumentException.class, () -> noticeConfigService.editReceiver(incoming));
+        verify(noticeReceiverDao, never()).save(any());
+    }
+
+    @Test
     void sendTestMsgResolvesMaskedSecret() {
         final NoticeReceiver stored = new NoticeReceiver();
         stored.setId(5L);
@@ -249,6 +265,18 @@ class NoticeConfigServiceTest {
         noticeConfigService.sendTestMsg(incoming);
 
         assertEquals("1499012345:AAEOB_wEYS-DZyPM3h5NzI8voJM", incoming.getTgBotToken());
+    }
+
+    @Test
+    void sendTestMsgRejectsUnknownId() {
+        when(noticeReceiverDao.findById(5L)).thenReturn(Optional.empty());
+
+        final NoticeReceiver incoming = new NoticeReceiver();
+        incoming.setId(5L);
+        incoming.setTgBotToken(NoticeReceiverMaskUtil.SECRET_MASK + "voJM");
+
+        assertThrows(IllegalArgumentException.class, () -> noticeConfigService.sendTestMsg(incoming));
+        verify(dispatcherAlarm, never()).sendNoticeMsg(any(), any(), any());
     }
 
     @Test
@@ -323,7 +351,7 @@ class NoticeConfigServiceTest {
 
     @Test
     void sendTestMsg() {
-        final NoticeReceiver noticeReceiver = mock(NoticeReceiver.class);
+        final NoticeReceiver noticeReceiver = new NoticeReceiver();
         final NoticeTemplate noticeTemplate = null;
         noticeConfigService.sendTestMsg(noticeReceiver);
         verify(dispatcherAlarm, times(1)).sendNoticeMsg(eq(noticeReceiver), eq(noticeTemplate), any(GroupAlert.class));


### PR DESCRIPTION
## What's changed?

Follow-up to #4220.

- `resolveMaskedSecrets` silently did nothing when the submitted receiver had an id but no stored receiver existed (e.g. deleted concurrently). The subsequent `save()` then persisted the mask placeholder (like `******voJM`) as a real credential — and with the IDENTITY id strategy the PUT even inserted a new row.

- Added regression tests for both `editReceiver` and `sendTestMsg`.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [ ]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
