### PR TITLE
ci(doc-deploy): fix pnpm cache setup and upgrade Node to 22

### DIFF
--- a/.github/workflows/doc-build-test.yml
+++ b/.github/workflows/doc-build-test.yml
@@ -43,7 +43,7 @@ jobs:
           version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: pnpm
           cache-dependency-path: home/pnpm-lock.yaml
       - uses: actions/setup-python@v4

--- a/.github/workflows/doc-deploy.yml
+++ b/.github/workflows/doc-deploy.yml
@@ -47,19 +47,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Setup pnpm (must run before setup-node so the pnpm cache can be configured)
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       # Setup Node.js environment
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: pnpm
           cache-dependency-path: home/pnpm-lock.yaml
-
-      # Setup pnpm
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: latest
 
       # Install dependencies in home directory
       - name: Install Dependencies


### PR DESCRIPTION
## What's changed?

The `DOC Deploy` workflow failed with `Unable to locate executable file: pnpm` (see [run 30157860900](https://github.com/apache/hertzbeat/actions/runs/30157860900/job/89678510369)).

Root cause: `actions/setup-node@v4` with `cache: pnpm` ran **before** `pnpm/action-setup`, so setup-node could not find the `pnpm` executable to compute the cache key.

Fix:
- Reorder steps in `.github/workflows/doc-deploy.yml` so `pnpm/action-setup` runs before `actions/setup-node`, matching the order already used in `doc-build-test.yml`.
- Pin pnpm to `10` (instead of `latest`) for reproducibility, consistent with `doc-build-test.yml`.
- Upgrade Node.js from `20` to `22` (LTS) in both `doc-deploy.yml` and `doc-build-test.yml` to clear the GitHub Actions Node 20 deprecation warning.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

> N/A — CI-only change, no production code or tests affected.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

> N/A — no API changes.

#### Test plan

- [ ] Trigger `DOC Deploy` workflow (workflow_dispatch) and confirm the `Setup Node.js` step succeeds with pnpm cache enabled.
- [ ] Trigger `DOC CI` workflow on a PR touching `home/**` and confirm Node 22 setup + build succeeds.

Generated with [Devin](https://devin.ai)
