### PR TITLE
fix(alerter): keep webhook query params intact

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/notice/impl/WebHookAlertNotifyHandlerImpl.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/notice/impl/WebHookAlertNotifyHandlerImpl.java
@@ -17,6 +17,7 @@
 
 package org.apache.hertzbeat.alert.notice.impl;
 
+import java.net.URI;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hertzbeat.alert.notice.AlertNoticeException;
@@ -47,6 +48,15 @@ final class WebHookAlertNotifyHandlerImpl extends AbstractAlertNotifyHandlerImpl
                 throw new AlertNoticeException("Webhook URL is null or empty");
             }
 
+            // Send the URL verbatim via the URI overload: the String overload treats it
+            // as a URI template and re-encodes it, corrupting pre-encoded query params
+            URI hookUri;
+            try {
+                hookUri = URI.create(hookUrl);
+            } catch (IllegalArgumentException e) {
+                throw new AlertNoticeException("Invalid webhook URL: " + e.getMessage());
+            }
+
             HttpHeaders headers = new HttpHeaders();
             if ("Basic".equalsIgnoreCase(receiver.getHookAuthType())) {
                 headers.setBasicAuth(receiver.getHookAuthToken());
@@ -59,7 +69,7 @@ final class WebHookAlertNotifyHandlerImpl extends AbstractAlertNotifyHandlerImpl
             webhookJson = webhookJson.replace(",\n  }", "\n }");
 
             HttpEntity<String> alertHttpEntity = new HttpEntity<>(webhookJson, headers);
-            ResponseEntity<String> entity = restTemplate.postForEntity(hookUrl, alertHttpEntity, String.class);
+            ResponseEntity<String> entity = restTemplate.postForEntity(hookUri, alertHttpEntity, String.class);
             if (entity.getStatusCode().value() < HttpStatus.BAD_REQUEST.value()) {
                 log.debug("Send WebHook: {} Success", hookUrl);
             } else {

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/notice/impl/WebHookAlertNotifyHandlerImplTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/notice/impl/WebHookAlertNotifyHandlerImplTest.java
@@ -37,11 +37,17 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestTemplate;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.net.URI;
 import java.util.ResourceBundle;
 
 /**
@@ -93,7 +99,7 @@ class WebHookAlertNotifyHandlerImplTest {
         ResponseEntity<String> responseEntity = 
             new ResponseEntity<>("null", HttpStatus.OK);
         
-        when(restTemplate.postForEntity(any(String.class), any(), eq(String.class))).thenReturn(responseEntity);
+        when(restTemplate.postForEntity(any(URI.class), any(), eq(String.class))).thenReturn(responseEntity);
         
         webHookAlertNotifyHandler.send(receiver, template, groupAlert);
     }
@@ -103,7 +109,7 @@ class WebHookAlertNotifyHandlerImplTest {
         ResponseEntity<String> responseEntity =
                 new ResponseEntity<>("null", HttpStatus.INTERNAL_SERVER_ERROR);
 
-        when(restTemplate.postForEntity(any(String.class), any(), eq(String.class))).thenReturn(responseEntity);
+        when(restTemplate.postForEntity(any(URI.class), any(), eq(String.class))).thenReturn(responseEntity);
 
 
         assertThrows(AlertNoticeException.class,
@@ -117,9 +123,25 @@ class WebHookAlertNotifyHandlerImplTest {
         ResponseEntity<String> responseEntity =
             new ResponseEntity<>("null", HttpStatus.OK);
 
-        when(restTemplate.postForEntity(eq(receiver.getHookUrl()), any(), eq(String.class))).thenReturn(responseEntity);
+        when(restTemplate.postForEntity(eq(URI.create(receiver.getHookUrl())), any(), eq(String.class))).thenReturn(responseEntity);
 
         webHookAlertNotifyHandler.send(receiver, template, groupAlert);
+    }
+
+    @Test
+    public void testHookUrlWithPercentEncodedQuerySentVerbatim() {
+        String hookUrl = "https://example.environment.api.powerplatform.com/workflows/wf1/triggers/manual/paths/invoke"
+                + "?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=UejZsrJyaZwwAm_jArn7Ze0PIf";
+        receiver.setHookUrl(hookUrl);
+
+        RestTemplate realRestTemplate = new RestTemplate();
+        MockRestServiceServer mockServer = MockRestServiceServer.createServer(realRestTemplate);
+        mockServer.expect(requestTo(hookUrl)).andRespond(withSuccess());
+        ReflectionTestUtils.setField(webHookAlertNotifyHandler, "restTemplate", realRestTemplate);
+
+        webHookAlertNotifyHandler.send(receiver, template, groupAlert);
+
+        mockServer.verify();
     }
 
     @Test
@@ -145,7 +167,7 @@ class WebHookAlertNotifyHandlerImplTest {
         ResponseEntity<String> responseEntity =
             new ResponseEntity<>("null", HttpStatus.OK);
 
-        when(restTemplate.postForEntity(any(String.class), any(), eq(String.class))).thenReturn(responseEntity);
+        when(restTemplate.postForEntity(any(URI.class), any(), eq(String.class))).thenReturn(responseEntity);
 
         // Test various valid URLs that should work
         receiver.setHookUrl("https://hooks.slack.com/services/T123/B456/complete-token");
@@ -170,7 +192,7 @@ class WebHookAlertNotifyHandlerImplTest {
         ResponseEntity<String> responseEntity =
             new ResponseEntity<>("null", HttpStatus.OK);
 
-        when(restTemplate.postForEntity(eq(receiver.getHookUrl()), any(), eq(String.class))).thenReturn(responseEntity);
+        when(restTemplate.postForEntity(eq(URI.create(receiver.getHookUrl())), any(), eq(String.class))).thenReturn(responseEntity);
 
         webHookAlertNotifyHandler.send(receiver, template, groupAlert);
 


### PR DESCRIPTION
## What's changed?

Fixes #3778

The webhook URL was percent-encoded a second time before being sent:
`postForEntity(String, ...)` treats the URL as a URI template and re-encodes
it (`%` → `%25`), corrupting the pre-encoded query params of signed webhook
URLs like Power Automate's:

```text
configured:  sp=%2Ftriggers%2Fmanual%2Frun
sent:        sp=%252Ftriggers%252Fmanual%252Frun
```

The server decodes once, gets a wrong value, and returns
`401 AuthorizationFailed`. Hard to spot: Spring redacts the query in error
messages (looks like the query was dropped), and queries without `%` are
unaffected (simple tests pass).

Fix: pass a `java.net.URI` so the URL is sent verbatim.

## Before

<img width="1456" height="735" alt="Screenshot 2026-07-26 at 12 37 06 AM" src="https://github.com/user-attachments/assets/9f1c497d-23b2-45bf-8474-7719c56b2769" />


## After


<img width="1548" height="654" alt="Screenshot 2026-07-26 at 12 44 56 AM" src="https://github.com/user-attachments/assets/7b70de00-44fd-42f1-8b08-05bff950657b" />

## How this was verified

- New regression test uses a real `RestTemplate` with `MockRestServiceServer`,
  asserting the request URI matches the configured URL byte-for-byte. It fails
  on the old code (`%252F` corruption) and passes with the fix.
- Reproduced end-to-end against a real Power Automate endpoint: the same URL
  returns `202 Accepted` when sent verbatim (curl/Postman) and
  `401 AuthorizationFailed` through the old code path; with this fix the
  send-test succeeds from the HertzBeat UI.
- `hertzbeat-alerter` module: 428 tests pass.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

