### PR TITLE
test: fix two flaky tests

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-common/src/test/java/org/apache/hertzbeat/collector/collect/common/http/CommonHttpClientVirtualThreadTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-common/src/test/java/org/apache/hertzbeat/collector/collect/common/http/CommonHttpClientVirtualThreadTest.java
@@ -104,17 +104,23 @@ class CommonHttpClientVirtualThreadTest {
 
     @Test
     void dispatchConnectionPoolCleanupClosesExpiredAndIdleConnections() throws Exception {
-        CountDownLatch latch = new CountDownLatch(1);
+        CountDownLatch expiredConnectionsClosed = new CountDownLatch(1);
+        CountDownLatch idleConnectionsClosed = new CountDownLatch(1);
         PoolingHttpClientConnectionManager manager = mock(PoolingHttpClientConnectionManager.class);
         doAnswer(invocation -> {
-            latch.countDown();
+            expiredConnectionsClosed.countDown();
             return null;
         }).when(manager).closeExpiredConnections();
+        doAnswer(invocation -> {
+            idleConnectionsClosed.countDown();
+            return null;
+        }).when(manager).closeIdleConnections(40, TimeUnit.SECONDS);
         CommonHttpClient.setConnectionManagerForTest(manager);
 
         CommonHttpClient.dispatchConnectionPoolCleanup();
 
-        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertTrue(expiredConnectionsClosed.await(5, TimeUnit.SECONDS));
+        assertTrue(idleConnectionsClosed.await(5, TimeUnit.SECONDS));
         verify(manager, times(1)).closeExpiredConnections();
         verify(manager, times(1)).closeIdleConnections(40, TimeUnit.SECONDS);
     }

--- a/hertzbeat-common-core/src/test/java/org/apache/hertzbeat/common/util/AesUtilTest.java
+++ b/hertzbeat-common-core/src/test/java/org/apache/hertzbeat/common/util/AesUtilTest.java
@@ -106,11 +106,8 @@ class AesUtilTest {
         String invalidBase64Text = "InvalidBase64";
         assertFalse(isCiphertext(invalidBase64Text, VALID_KEY));
 
-        // Test with invalid key
-        originalText = "This is a secret message";
-        encryptedText = aesEncode(originalText, VALID_KEY);
-        String invalidKey = "6543210987654321";
-        assertFalse(isCiphertext(encryptedText, invalidKey));
+        // Valid base64 that cannot be decrypted: 3 bytes is not a block multiple
+        assertFalse(isCiphertext("AAAA", VALID_KEY));
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

Fixes two flaky tests, both seen failing on CI in an unrelated PR (#4249).

### 1. `CommonHttpClientVirtualThreadTest.dispatchConnectionPoolCleanupClosesExpiredAndIdleConnections`


The background cleanup thread calls `closeExpiredConnections()` and then
`closeIdleConnections()`. The test awaited a latch only on the **first** call
before verifying **both**, so `verify(closeIdleConnections)` could run in the
gap between the two calls and fail.

Failed run: https://github.com/apache/hertzbeat/actions/runs/30193599623/job/89771089888

```
[hertzbeat-collector-common] [ERROR] Tests run: 3, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.696 s <<< FAILURE! -- in org.apache.hertzbeat.collector.collect.common.http.CommonHttpClientVirtualThreadTest
[hertzbeat-collector-common] [ERROR] org.apache.hertzbeat.collector.collect.common.http.CommonHttpClientVirtualThreadTest.dispatchConnectionPoolCleanupClosesExpiredAndIdleConnections -- Time elapsed: 0.059 s <<< FAILURE!
Wanted but not invoked:
poolingHttpClientConnectionManager.closeIdleConnections(
    40L,
    SECONDS
);
-> at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.closeIdleConnections(PoolingHttpClientConnectionManager.java:440)

However, there was exactly 1 interaction with this mock:
poolingHttpClientConnectionManager.closeExpiredConnections();
-> at org.apache.hertzbeat.collector.collect.common.http.CommonHttpClient.runConnectionPoolCleanup(CommonHttpClient.java:219)


	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.closeIdleConnections(PoolingHttpClientConnectionManager.java:440)
	at org.apache.hertzbeat.collector.collect.common.http.CommonHttpClientVirtualThreadTest.dispatchConnectionPoolCleanupClosesExpiredAndIdleConnections(CommonHttpClientVirtualThreadTest.java:119)
```

Fix: add a second latch on `closeIdleConnections` and await both before
verifying.

### 2. `AesUtilTest.testIsCiphertext`

The test asserted `isCiphertext(ciphertext, wrongKey) == false`, but
`isCiphertext` is try-decrypt without authentication: with a random IV per
encryption, wrong-key decryption passes the PKCS5 padding check by chance for
~1/256 of runs and legitimately returns `true`.

Failed run: https://github.com/apache/hertzbeat/actions/runs/30193891096/job/89773238936

```
[hertzbeat-common-core] [ERROR]   AesUtilTest.testIsCiphertext:113 expected: <false> but was: <true>
```

Fix: drop the non-deterministic wrong-key assertion (the
wrong-key-never-recovers-plaintext property is already covered in
`testAesDecode`), and cover the decrypt-failure branch with a deterministic
input instead (valid base64 whose length is not an AES block multiple).

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

