### PR TITLE
[fix] skip SQL Server integration test on arm64

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-collector/src/test/java/org/apache/hertzbeat/collector/collect/database/sqlserver/SqlServerJdbcTemplateIntegrationTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-collector/src/test/java/org/apache/hertzbeat/collector/collect/database/sqlserver/SqlServerJdbcTemplateIntegrationTest.java
@@ -85,6 +85,15 @@ class SqlServerJdbcTemplateIntegrationTest {
 
     @BeforeAll
     void setUp() throws Exception {
+        // Checked before the Docker probe so the skip costs nothing: Microsoft ships
+        // no arm64 image for SQL Server on Linux -- 2017, 2019 and 2022 are all
+        // amd64-only.  Under emulation on Apple Silicon sqlservr crashes during
+        // startup (core dump, never logs "ready for client connections"), and
+        // Rosetta does not help.  This is not a timeout to be tuned: the full
+        // version matrix runs on the amd64 CI runners instead.
+        Assumptions.assumeFalse(
+                "aarch64".equals(System.getProperty("os.arch")),
+                "SQL Server has no arm64 image; matrix runs on amd64 CI");
         Assumptions.assumeTrue(
                 DockerClientFactory.instance().isDockerAvailable(),
                 "Docker is required for integration tests");


### PR DESCRIPTION
## What's changed?

`SqlServerJdbcTemplateIntegrationTest` cannot run on arm64 hosts. Microsoft ships no arm64 image for SQL Server on Linux (`2017-latest`, `2019-latest` and `2022-latest` are all amd64-only), so under emulation `sqlservr` crashes on startup and never logs "SQL Server is now ready for client connections". The wait strategy then times out after ~68 minutes. Rosetta does not help.

This skips the class on arm64 via `Assumptions.assumeFalse`, checked before the Docker probe so no container is started. The full matrix still runs on the amd64 CI runners, so no coverage is lost.

On an Apple Silicon host: 4053 s error → 0.03 s skip.

## Checklist

- [x] I have read the Contributing Guide
- [ ] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.
