### PR TITLE
[fix] bind greptime compose data-store ports to localhost

### DIFF
--- a/script/docker-compose/hertzbeat-postgresql-greptimedb/docker-compose.yaml
+++ b/script/docker-compose/hertzbeat-postgresql-greptimedb/docker-compose.yaml
@@ -32,8 +32,11 @@ services:
       timeout: 5s
       retries: 5
       start_period: 30s
+    # Bind data-store ports to localhost only: these services carry default
+    # credentials (see POSTGRES_PASSWORD / the greptime static user provider)
+    # and are only meant for the operator on the host, not for remote access.
     ports:
-      - '15432:5432'
+      - '127.0.0.1:15432:5432'
     environment:
       POSTGRES_USER: root
       POSTGRES_PASSWORD: 123456
@@ -58,11 +61,14 @@ services:
       start_period: 30s
     environment:
         TZ: Asia/Shanghai
+    # Bind data-store ports to localhost only: these services use the default
+    # static user provider (greptime=greptime) and are only meant for the
+    # operator on the host, not for remote access.
     ports:
-      - "14000:4000"
-      - "14001:4001"
-      - "14002:4002"
-      - "14003:4003"
+      - "127.0.0.1:14000:4000"
+      - "127.0.0.1:14001:4001"
+      - "127.0.0.1:14002:4002"
+      - "127.0.0.1:14003:4003"
     volumes:
       - greptime-tsdb-data:/greptimedb_data
     command:


### PR DESCRIPTION
## Summary
Security hardening for the `hertzbeat-postgresql-greptimedb` quick-start compose bundle.

The Postgres and GreptimeDB data-store ports were mapped to `0.0.0.0` (all interfaces). Both services run with **default credentials shipped in the compose file**:
- `POSTGRES_PASSWORD: 123456`
- greptime static user provider `greptime=greptime`

Binding those ports to `0.0.0.0` lets any host that can reach the machine authenticate to the underlying data stores using only those published defaults.

## Fix
Bind the host-side port mappings to `127.0.0.1`. The `hertzbeat` container reaches both data stores over the internal compose network (`hertzbeat` network, service DNS names `postgresql` / `greptime`) and does not need these host mappings at all — they exist only for the operator to inspect the data stores from the host, so localhost binding preserves that use case.

- `127.0.0.1:15432:5432` (postgres)
- `127.0.0.1:14000-14003:4000-4003` (greptime)

The hertzbeat web/collector ports (`1157`/`1158`) are intentionally left unchanged.

## Out of scope (noted, not addressed here)
The default credentials themselves remain in the bundle for quick-start ergonomics. Operators should still override `POSTGRES_PASSWORD` / the greptime user provider in production. Binding to localhost is the robust mitigation against remote use of those defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)