### PR TITLE
[feat] paginate the monitoring metrics data table

### DIFF
--- a/web-app/src/app/routes/monitor/monitor-data-table/monitor-data-table.component.html
+++ b/web-app/src/app/routes/monitor/monitor-data-table/monitor-data-table.component.html
@@ -92,10 +92,16 @@
       *ngIf="!monitor && isTable"
       nzSize="small"
       [nzNoResult]="'monitor.detail.chart.no-data' | i18n"
-      [nzFrontPagination]="false"
-      [nzShowPagination]="false"
+      [nzFrontPagination]="true"
+      [nzShowPagination]="valueRows.length > 10"
+      [nzPageSize]="pageSize"
+      [nzShowSizeChanger]="true"
+      [nzPageSizeOptions]="[10, 20, 50, 100]"
+      [nzPageIndex]="pageIndex"
+      (nzPageIndexChange)="pageIndex = $event"
+      (nzPageSizeChange)="pageSize = $event; pageIndex = 1"
       [nzData]="valueRows"
-      [nzScroll]="height ? { y: scrollY } : { x: '100%' }"
+      [nzScroll]="height ? { y: valueRows.length > 10 ? pagedScrollY : scrollY } : { x: '100%' }"
       #smallTable
     >
       <thead>

--- a/web-app/src/app/routes/monitor/monitor-data-table/monitor-data-table.component.ts
+++ b/web-app/src/app/routes/monitor/monitor-data-table/monitor-data-table.component.ts
@@ -60,16 +60,20 @@ export class MonitorDataTableComponent implements OnInit {
   showModal!: boolean;
   time!: any;
   fields!: any[];
-  valueRows!: any[];
+  valueRows: any[] = [];
   rowValues!: any[];
   isTable: boolean = true;
   scrollY: string = '100%';
+  pagedScrollY: string = '100%';
   loading: boolean = false;
+  pageSize: number = 10;
+  pageIndex: number = 1;
 
   constructor(private monitorSvc: MonitorService, private notifySvc: NzNotificationService) {}
 
   ngOnInit(): void {
     this.scrollY = `calc(${this.height} - 130px)`;
+    this.pagedScrollY = `calc(${this.height} - 170px)`;
   }
 
   loadData() {
@@ -85,6 +89,7 @@ export class MonitorDataTableComponent implements OnInit {
             this.time = message.data.time;
             this.fields = message.data.fields;
             this.valueRows = message.data.valueRows;
+            this.pageIndex = 1;
             if (this.valueRows.length == 1) {
               this.isTable = false;
               this.rowValues = this.valueRows[0].values;


### PR DESCRIPTION
## What's changed?

Fixes #1594: a metric group with hundreds of rows renders as one unbounded scroll blob in the monitor detail card. The maintainer asked to "support pageable in monitoring metrics data table ui".

- add front pagination to the row table: pager above 10 rows, size changer 10/20/50/100
- page index resets on data reload and page size change; the scroll area shrinks while the pager is shown so the fixed-height card does not clip it
- `valueRows` initialized to `[]` (the new template expression evaluates before the async load); single-row table and fullscreen modal reuse the same template and keep working

**Before** (200 rows, scroll only):
<img width="1530" height="784" alt="1594-before-no-pager" src="https://github.com/user-attachments/assets/98d15a9d-1e7c-4dae-b365-da354ec382a8" />
**After** (paged):
<img width="1568" height="669" alt="1594-after-pager" src="https://github.com/user-attachments/assets/05071c38-5b40-4dd2-b9fc-592e9d135eba" />
**50/page** (page index resets):
<img width="1530" height="784" alt="1594-pagesize50" src="https://github.com/user-attachments/assets/17e48c0e-2e27-4a14-bdf1-154098eb2cf3" />

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
