### PR TITLE
fix(collector): keep partial telnet metrics, surface raw reply

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/telnet/TelnetCollectImpl.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/telnet/TelnetCollectImpl.java
@@ -67,14 +67,20 @@ public class TelnetCollectImpl extends AbstractCollect {
                 long responseTime = System.currentTimeMillis() - startTime;
                 List<String> aliasFields = metrics.getAliasFields();
                 String app = builder.getApp();
-                Map<String, String> resultMap = execCmdAndParseResult(telnetClient, telnet.getCmd(), app);
-                resultMap.put(CollectorConstants.RESPONSE_TIME, Long.toString(responseTime));
-                if (resultMap.size() < aliasFields.size()) {
-                    log.error("telnet response data not enough: {}", resultMap);
+                CmdResult cmdResult = execCmdAndParseResult(telnetClient, telnet.getCmd(), app);
+                Map<String, String> resultMap = cmdResult.values();
+                boolean expectsCmdMetrics = StringUtils.isNotBlank(telnet.getCmd())
+                        && aliasFields.stream().anyMatch(field -> !CollectorConstants.RESPONSE_TIME.equalsIgnoreCase(field));
+                boolean hasExpectedMetric = aliasFields.stream().anyMatch(resultMap::containsKey);
+                if (expectsCmdMetrics && !hasExpectedMetric) {
+                    // e.g. zookeeper refusing a 4lw command not in its 4lw.commands.whitelist
+                    String reply = sanitizeReply(cmdResult.rawResponse());
+                    log.warn("telnet cmd [{}] returned no expected metrics: {}", telnet.getCmd(), reply);
                     builder.setCode(CollectRep.Code.FAIL);
-                    builder.setMsg("The cmd execution results do not match the expected number of metrics.");
+                    builder.setMsg("Cmd [" + telnet.getCmd() + "] returned no expected metrics. Response: " + reply);
                     return;
                 }
+                resultMap.put(CollectorConstants.RESPONSE_TIME, Long.toString(responseTime));
                 CollectRep.ValueRow.Builder valueRowBuilder = CollectRep.ValueRow.newBuilder();
                 for (String field : aliasFields) {
                     String fieldValue = resultMap.get(field);
@@ -118,30 +124,36 @@ public class TelnetCollectImpl extends AbstractCollect {
         return DispatchConstants.PROTOCOL_TELNET;
     }
 
-    private static Map<String, String> execCmdAndParseResult(TelnetClient telnetClient, String cmd, String app) throws IOException {
+    record CmdResult(Map<String, String> values, String rawResponse) {
+    }
+
+    private static String sanitizeReply(String raw) {
+        return StringUtils.abbreviate(raw.trim().replaceAll("[\\p{Cntrl}]+", " "), 300);
+    }
+
+    private static CmdResult execCmdAndParseResult(TelnetClient telnetClient, String cmd, String app) throws IOException {
         if (cmd == null || StringUtils.isEmpty(cmd.trim())) {
-            return new HashMap<>(16);
+            return new CmdResult(new HashMap<>(16), "");
         }
         OutputStream outputStream = telnetClient.getOutputStream();
         outputStream.write(cmd.getBytes(StandardCharsets.UTF_8));
         outputStream.flush();
         String result = new String(telnetClient.getInputStream().readAllBytes());
         String[] lines = result.split("\n");
-        if (CollectorConstants.ZOOKEEPER_APP.equals(app) && CollectorConstants.ZOOKEEPER_ENVI_HEAD.equals(lines[0])) {
+        if (lines.length > 0 && CollectorConstants.ZOOKEEPER_APP.equals(app)
+                && CollectorConstants.ZOOKEEPER_ENVI_HEAD.equals(lines[0])) {
             lines = Arrays.stream(lines)
                     .skip(1)
                     .toArray(String[]::new);
         }
-        boolean contains = lines[0].contains("=");
-        return Arrays.stream(lines)
-                .map(item -> {
-                    if (contains) {
-                        return item.split("=");
-                    } else {
-                        return item.split("\t");
-                    }
-                })
+        if (lines.length == 0) {
+            return new CmdResult(new HashMap<>(16), result);
+        }
+        String separator = lines[0].contains("=") ? "=" : "\t";
+        Map<String, String> values = Arrays.stream(lines)
+                .map(item -> item.split(separator, 2))
                 .filter(item -> item.length == 2)
-                .collect(Collectors.toMap(x -> x[0], x -> x[1]));
+                .collect(Collectors.toMap(x -> x[0], x -> x[1], (first, second) -> first, HashMap::new));
+        return new CmdResult(values, result);
     }
 }

--- a/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/telnet/TelnetCollectImplTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/telnet/TelnetCollectImplTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
@@ -30,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.net.telnet.TelnetClient;
 import org.apache.hertzbeat.collector.dispatch.DispatchConstants;
+import org.apache.hertzbeat.common.constants.CommonConstants;
 import org.apache.hertzbeat.common.entity.job.Metrics;
 import org.apache.hertzbeat.common.entity.job.protocol.TelnetProtocol;
 import org.apache.hertzbeat.common.entity.message.CollectRep;
@@ -153,6 +155,114 @@ class TelnetCollectImplTest {
             assertEquals(valueRow.getColumns(3), "YetAnotherValue");
         }
         mocked.close();
+    }
+
+    @Test
+    void testCollectPadsMissingMetrics() {
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
+        Metrics metrics = telnetMetrics("mntr", List.of("responseTime", "a", "b", "c"));
+        try (MockedConstruction<TelnetClient> mocked = mockTelnetReply("a=1")) {
+            telnetCollect.collect(builder, metrics);
+        }
+        assertEquals(1, builder.getValuesCount());
+        assertEquals("1", builder.getValues(0).getColumns(1));
+        assertEquals(CommonConstants.NULL_VALUE, builder.getValues(0).getColumns(2));
+        assertEquals(CommonConstants.NULL_VALUE, builder.getValues(0).getColumns(3));
+    }
+
+    @Test
+    void testCollectFailsWithRawReplyWhenNothingParsed() {
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
+        Metrics metrics = telnetMetrics("conf", List.of("responseTime", "a"));
+        try (MockedConstruction<TelnetClient> mocked =
+                mockTelnetReply("conf is not executed because it is not in the whitelist.")) {
+            telnetCollect.collect(builder, metrics);
+        }
+        assertEquals(CollectRep.Code.FAIL, builder.getCode());
+        assertTrue(builder.getMsg().contains("not in the whitelist"));
+    }
+
+    @Test
+    void testCollectKeepsFirstOnDuplicateKeys() {
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
+        Metrics metrics = telnetMetrics("mntr", List.of("a", "b"));
+        try (MockedConstruction<TelnetClient> mocked = mockTelnetReply("a=1\na=2\nb=3")) {
+            telnetCollect.collect(builder, metrics);
+        }
+        assertEquals(1, builder.getValuesCount());
+        assertEquals("1", builder.getValues(0).getColumns(0));
+        assertEquals("3", builder.getValues(0).getColumns(1));
+    }
+
+    @Test
+    void testCollectFailsWhenReplyHasOnlyUnrelatedPairs() {
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
+        Metrics metrics = telnetMetrics("mntr", List.of("responseTime", "a"));
+        try (MockedConstruction<TelnetClient> mocked = mockTelnetReply("error=conf disabled")) {
+            telnetCollect.collect(builder, metrics);
+        }
+        assertEquals(CollectRep.Code.FAIL, builder.getCode());
+    }
+
+    @Test
+    void testCollectSurvivesHeaderOnlyEnviReply() {
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder().setApp("zookeeper");
+        Metrics metrics = telnetMetrics("envi", List.of("responseTime", "a"));
+        try (MockedConstruction<TelnetClient> mocked = mockTelnetReply("Environment:")) {
+            telnetCollect.collect(builder, metrics);
+        }
+        assertEquals(CollectRep.Code.FAIL, builder.getCode());
+    }
+
+    @Test
+    void testCollectFailsCleanlyOnNewlineOnlyReply() {
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder().setApp("zookeeper");
+        Metrics metrics = telnetMetrics("conf", List.of("responseTime", "a"));
+        try (MockedConstruction<TelnetClient> mocked = mockTelnetReply("\n")) {
+            telnetCollect.collect(builder, metrics);
+        }
+        assertEquals(CollectRep.Code.FAIL, builder.getCode());
+        assertTrue(builder.getMsg().contains("returned no expected metrics"));
+    }
+
+    @Test
+    void testCollectKeepsValueContainingSeparator() {
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
+        Metrics metrics = telnetMetrics("conf", List.of("dataDir", "secureClientPort"));
+        try (MockedConstruction<TelnetClient> mocked = mockTelnetReply("dataDir=/data/zk=a\nsecureClientPort=")) {
+            telnetCollect.collect(builder, metrics);
+        }
+        assertEquals(1, builder.getValuesCount());
+        assertEquals("/data/zk=a", builder.getValues(0).getColumns(0));
+        assertEquals("", builder.getValues(0).getColumns(1));
+    }
+
+    @Test
+    void testCollectBlankCmdKeepsResponseTimeRow() {
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
+        Metrics metrics = telnetMetrics("", List.of("responseTime"));
+        try (MockedConstruction<TelnetClient> mocked =
+                Mockito.mockConstruction(TelnetClient.class, (telnetClient, context) ->
+                        Mockito.when(telnetClient.isConnected()).thenReturn(true))) {
+            telnetCollect.collect(builder, metrics);
+        }
+        assertEquals(1, builder.getValuesCount());
+    }
+
+    private static Metrics telnetMetrics(String cmd, List<String> aliasFields) {
+        Metrics metrics = new Metrics();
+        metrics.setTelnet(TelnetProtocol.builder().timeout("10").port("2181").cmd(cmd).build());
+        metrics.setAliasFields(aliasFields);
+        return metrics;
+    }
+
+    private static MockedConstruction<TelnetClient> mockTelnetReply(String reply) {
+        InputStream inputStream = new ByteArrayInputStream(reply.getBytes(StandardCharsets.UTF_8));
+        return Mockito.mockConstruction(TelnetClient.class, (telnetClient, context) -> {
+            Mockito.when(telnetClient.isConnected()).thenReturn(true);
+            Mockito.when(telnetClient.getOutputStream()).thenReturn(Mockito.mock(OutputStream.class));
+            Mockito.when(telnetClient.getInputStream()).thenReturn(inputStream);
+        });
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

Fixes #1693: zookeeper monitors fail with "The cmd execution results do not match the expected number of metrics". One blunt check caused two different failures reported in the issue:

```java
if (resultMap.size() < aliasFields.size()) {
    builder.setMsg("The cmd execution results do not match the expected number of metrics.");
    return;
}
```

### Case 1: valid partial reply thrown away (reporter ZachariahHu)

`conf` on standalone zookeeper 3.4.14 returns 8 keys; the template defines 10 (`dataDirSize`/`dataLogSize` only exist in newer versions). Nothing is misconfigured, yet the whole group is discarded every cycle.

Fix: fail only when the reply contains none of the expected fields. A partial reply keeps its parsed values; missing fields fall through to the pre-existing null-padding path.

**Before** — 9 parsed entries thrown away, `conf` shows no data:

```
ERROR TelnetCollectImpl - telnet response data not enough: {maxSessionTimeout=40000, dataDir=/data/version-2, responseTime=7, clientPort=2181, tickTime=2000, minSessionTimeout=4000, dataLogDir=/datalog/version-2, serverId=0, maxClientCnxns=60}
```

**After** — same server, collected without errors:

```json
{"clientPort": "2181", "dataDir": "/data/version-2", "dataDirSize": null,
 "dataLogDir": "/datalog/version-2", "dataLogSize": null, "tickTime": "2000",
 "maxClientCnxns": "60", "minSessionTimeout": "4000",
 "maxSessionTimeout": "40000", "serverId": "0"}
```

### Case 2: whitelist refusal reason swallowed (reporter leim)

When the 4lw whitelist blocks `conf` (bitnami image default), zookeeper replies with an explanation instead of data — but parsing dropped the raw reply, so the user only saw the generic message above.

Fix: parsing returns the raw reply alongside the parsed map (`CmdResult` record); the failure message now carries it, in logs and in the UI popup.

**Before** — the refusal reason is nowhere:

```
ERROR TelnetCollectImpl - telnet response data not enough: {responseTime=18}
```

**After** — zookeeper's own explanation reaches the user:

```
WARN TelnetCollectImpl - telnet cmd [conf] returned no expected metrics: conf is not executed because it is not in the whitelist.
```

Failure is judged by "no expected field present", not "map is empty", so refusal text that parses as key/value (`error=conf disabled`) still fails.

### Parsing hardening

Values split at the first separator only (`split(sep, 2)`) so `dataDir=/data/zk=a` survives; duplicate keys keep the first value; header-only/newline-only replies no longer throw on `lines[0]`. Tradeoff: a truncated reply with some expected fields present now yields visible null cells instead of a hard failure. zookeeper 3.9 with an open whitelist still collects all 10 columns.

UI popup before/after (case 2):
<img width="1568" height="669" alt="ui-before" src="https://github.com/user-attachments/assets/f5c688b8-b4ee-4ff4-8c94-0ae8f3a7bb9a" />
<img width="1568" height="669" alt="ui-after" src="https://github.com/user-attachments/assets/93ec7db9-5ba3-4ccf-90fe-a3c5ebc28b23" />


## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

