### PR TITLE
[fix] ssl_cert monitor: skip hostname check when verify is off

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/http/SslCertificateCollectImpl.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/http/SslCertificateCollectImpl.java
@@ -92,6 +92,7 @@ public class SslCertificateCollectImpl extends AbstractCollect {
             if (!verifySsl){
                 SSLContext ignoreSslContext = createIgnoreVerifySslContext();
                 urlConnection.setSSLSocketFactory(ignoreSslContext.getSocketFactory());
+                urlConnection.setHostnameVerifier((hostname, session) -> true);
             }
 
             urlConnection.connect();

--- a/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/http/SslCertificateCollectImplTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/http/SslCertificateCollectImplTest.java
@@ -17,23 +17,101 @@
 
 package org.apache.hertzbeat.collector.collect.http;
 
-import org.junit.jupiter.api.BeforeEach;
+import com.sun.net.httpserver.HttpsConfigurator;
+import com.sun.net.httpserver.HttpsServer;
+import java.io.FileInputStream;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStore;
+import java.util.List;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import org.apache.hertzbeat.common.entity.job.Metrics;
+import org.apache.hertzbeat.common.entity.job.protocol.HttpProtocol;
+import org.apache.hertzbeat.common.entity.message.CollectRep;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for {@link SslCertificateCollectImpl}
+ * Test case for {@link SslCertificateCollectImpl}: real TLS handshake against a local
+ * HTTPS server using a self-signed cert whose CN/SAN does not match the target address.
  */
 class SslCertificateCollectImplTest {
 
-    @BeforeEach
-    void setUp() {
+    private static HttpsServer server;
+    private static Path keystore;
+
+    @BeforeAll
+    static void startServer() throws Exception {
+        keystore = genSelfSignedKeystore();
+        KeyStore ks = KeyStore.getInstance("PKCS12");
+        try (FileInputStream in = new FileInputStream(keystore.toFile())) {
+            ks.load(in, "changeit".toCharArray());
+        }
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+        kmf.init(ks, "changeit".toCharArray());
+        SSLContext ctx = SSLContext.getInstance("TLS");
+        ctx.init(kmf.getKeyManagers(), null, null);
+        server = HttpsServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.setHttpsConfigurator(new HttpsConfigurator(ctx));
+        server.createContext("/", exchange -> {
+            exchange.sendResponseHeaders(200, -1);
+            exchange.close();
+        });
+        server.start();
+    }
+
+    @AfterAll
+    static void stopServer() throws Exception {
+        if (server != null) {
+            server.stop(0);
+        }
+        if (keystore != null) {
+            Files.deleteIfExists(keystore);
+        }
+    }
+
+    private static Path genSelfSignedKeystore() throws Exception {
+        Path ks = Files.createTempFile("ssl-collect-test", ".p12");
+        Files.delete(ks);
+        String keytool = Path.of(System.getProperty("java.home"), "bin", "keytool").toString();
+        int exit = new ProcessBuilder(keytool, "-genkeypair", "-alias", "test",
+                "-keyalg", "RSA", "-keysize", "2048", "-storetype", "PKCS12",
+                "-keystore", ks.toString(), "-storepass", "changeit",
+                "-dname", "CN=test", "-ext", "SAN=dns:not-this-host", "-validity", "1")
+                .inheritIO().start().waitFor();
+        Assertions.assertEquals(0, exit, "keytool failed to generate test keystore");
+        return ks;
+    }
+
+    private CollectRep.MetricsData.Builder collect(boolean verify) {
+        HttpProtocol http = new HttpProtocol();
+        http.setHost("127.0.0.1");
+        http.setPort(String.valueOf(server.getAddress().getPort()));
+        http.setSsl(String.valueOf(verify));
+        Metrics metrics = Metrics.builder()
+                .http(http)
+                .aliasFields(List.of("subject", "expired", "end_timestamp"))
+                .build();
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
+        new SslCertificateCollectImpl().collect(builder, metrics);
+        return builder;
     }
 
     @Test
-    void getInstance() {
+    void verifyOnFailsForUntrustedCert() {
+        CollectRep.MetricsData.Builder builder = collect(true);
+        Assertions.assertEquals(CollectRep.Code.UN_CONNECTABLE, builder.getCode(), builder.getMsg());
+        Assertions.assertEquals(0, builder.getValuesCount());
     }
 
     @Test
-    void collect() {
+    void verifyOffCollectsUntrustedMismatchedCert() {
+        CollectRep.MetricsData.Builder builder = collect(false);
+        Assertions.assertTrue(builder.getValuesCount() > 0, "expected cert rows, got: " + builder.getMsg());
+        Assertions.assertEquals("CN=test", builder.getValues(0).getColumns(0));
     }
 }


### PR DESCRIPTION
Fixes #1132

Users monitoring a self-signed HTTPS site (typically an internal service reached by IP) get no certificate data at all — even after switching "verify certificate" off, the monitor still fails with:

```
No subject alternative names matching IP address 192.168.x.x found
```

Root cause: when Java opens a TLS connection it runs **two independent checks** on the server certificate — (1) *is the cert signed by a trusted CA?* (chain validation, done by the `TrustManager`) and (2) *does the name on the cert match the address I dialed?* (hostname verification, done by `HttpsURLConnection`'s `HostnameVerifier`). The verify-off switch only disabled check 1 (via a trust-all `SSLContext`); check 2 kept running. Self-signed certs on IP-addressed hosts fail both checks, so for exactly the users who need the switch, it didn't work.

The fix adds the missing half: with verify off, also install a permissive `HostnameVerifier`, so both checks are skipped and the certificate can always be read — which is the whole point of a cert-expiry monitor. Verify **on** is untouched: the `PKIX path building failed` error quoted in the issue happens with verify on, and that is correct behavior when the user asks for validation, not part of this fix.

The test replaces the empty `SslCertificateCollectImplTest` stub with a real handshake: a local `HttpsServer` serving a keytool-generated self-signed cert whose name deliberately mismatches the target, hitting both checks at once.

Before / after (same test, fix reverted vs applied):

| scenario | before | after |
|---|---|---|
| verify **off** | ❌ `No subject alternative names matching IP address 127.0.0.1 found` | ✅ cert collected: `rows=1 [CN=test, false, <end_timestamp>]` |
| verify **on** | `UN_CONNECTABLE` — `PKIX path building failed` | unchanged (correct for untrusted cert) |


Note on the issue timeline: the `PKIX path building failed` error reported in #1132 (and again in 2025) happens with verify **on**, which had no escape hatch until #2221 added the verify toggle (2024-07). Since then the answer to PKIX is "switch verify off" — this PR makes that switch actually cover all certs, closing the remaining gap for name-mismatched/IP-addressed ones.
