### PR TITLE
[fix] jitter first cyclic schedule to avoid restart thundering herd

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-common/src/main/java/org/apache/hertzbeat/collector/timer/TimerDispatcher.java
+++ b/hertzbeat-collector/hertzbeat-collector-common/src/main/java/org/apache/hertzbeat/collector/timer/TimerDispatcher.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
@@ -116,7 +117,7 @@ public class TimerDispatcher implements TimerDispatch, DisposableBean {
         // Delay dispatcher lookup to avoid a startup cycle with CommonDispatcher.
         WheelTimerTask timerJob = new WheelTimerTask(addJob, metricsTaskDispatchSupplier);
         if (addJob.isCyclic()) {
-            Long nextExecutionTime = getNextExecutionInterval(addJob);
+            long nextExecutionTime = initialCyclicDelay(addJob);
             Timeout timeout = wheelTimer.newTimeout(timerJob, nextExecutionTime, TimeUnit.SECONDS);
             cancelPreviousTimeout(currentCyclicTaskMap.put(addJob.getId(), timeout));
         } else {
@@ -203,6 +204,21 @@ public class TimerDispatcher implements TimerDispatch, DisposableBean {
         if (previousTimeout != null) {
             previousTimeout.cancel();
         }
+    }
+
+    /**
+     * Interval jobs get a random first-run phase: a restart re-adds every job at once,
+     * and a shared phase makes them all collect at the same instant forever. Cron jobs
+     * keep their meaningful phase; already-executed or re-added jobs keep theirs.
+     */
+    long initialCyclicDelay(Job addJob) {
+        long nextExecutionTime = getNextExecutionInterval(addJob);
+        boolean fixedPhase = ScheduleTypeEnum.CRON.getType().equals(addJob.getScheduleType());
+        if (!fixedPhase && addJob.getDispatchTime() <= 0
+                && !currentCyclicTaskMap.containsKey(addJob.getId()) && nextExecutionTime > 1) {
+            nextExecutionTime = ThreadLocalRandom.current().nextLong(nextExecutionTime) + 1;
+        }
+        return nextExecutionTime;
     }
 
     public Long getNextExecutionInterval(Job job) {

--- a/hertzbeat-collector/hertzbeat-collector-common/src/test/java/org/apache/hertzbeat/collector/timer/TimerDispatcherTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-common/src/test/java/org/apache/hertzbeat/collector/timer/TimerDispatcherTest.java
@@ -18,8 +18,10 @@
 package org.apache.hertzbeat.collector.timer;
 
 import java.lang.reflect.Field;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.hertzbeat.collector.constants.ScheduleTypeEnum;
 import org.apache.hertzbeat.collector.dispatch.MetricsTaskDispatch;
@@ -298,5 +300,42 @@ public class TimerDispatcherTest {
         } catch (ReflectiveOperationException e) {
             throw new AssertionError(e);
         }
+    }
+
+    @Test
+    void testFirstCyclicDelayJittersWithinInterval() {
+        when(job.isCyclic()).thenReturn(true);
+        when(job.getScheduleType()).thenReturn(null);
+        when(job.getDispatchTime()).thenReturn(0L);
+        when(job.getInterval()).thenReturn(600L);
+        when(job.getId()).thenReturn(4242L);
+
+        Set<Long> delays = new HashSet<>();
+        for (int i = 0; i < 50; i++) {
+            long delay = timerDispatcher.initialCyclicDelay(job);
+            assertTrue(delay >= 1 && delay <= 600, "delay out of interval: " + delay);
+            delays.add(delay);
+        }
+        assertTrue(delays.size() > 1, "no jitter observed across 50 samples");
+    }
+
+    @Test
+    void testExecutedJobKeepsRemainingIntervalOnReAdd() {
+        when(job.getScheduleType()).thenReturn(null);
+        when(job.getDispatchTime()).thenReturn(System.currentTimeMillis() - 10_000L);
+        when(job.getInterval()).thenReturn(600L);
+
+        long expected = timerDispatcher.getNextExecutionInterval(job);
+        long actual = timerDispatcher.initialCyclicDelay(job);
+        assertTrue(Math.abs(actual - expected) <= 1, "remaining interval must not be jittered");
+    }
+
+    @Test
+    void testCronScheduleKeepsFixedPhase() {
+        when(job.getScheduleType()).thenReturn(ScheduleTypeEnum.CRON.getType());
+        when(job.getCronExpression()).thenReturn("0 0 3 * * ?");
+        long expected = timerDispatcher.getNextExecutionInterval(job);
+        long actual = timerDispatcher.initialCyclicDelay(job);
+        assertTrue(Math.abs(actual - expected) <= 1, "cron phase must not be jittered");
     }
 }


### PR DESCRIPTION
Fixes #1275

After restarting HertzBeat, website monitors report multi-second response times for a long stretch even though the monitored sites are fine.

Root cause: a restart re-adds every cyclic job in the same instant, and each one gets the same first-run delay (its full interval). From then on all monitors collect at the exact same second, every cycle, forever — the burst of concurrent requests contends for collector threads and target capacity, inflating every measured response time.

The fix gives interval-scheduled jobs a random first-run phase inside their interval, so a restart spreads them across the cycle instead of stacking them. Two deliberate exclusions: cron jobs keep their meaningful fixed phase, and already-executed / re-added jobs (config updates) keep their current phase. `TimerDispatcherTest` pins the jitter range and both exclusions.

Reproduced end-to-end — 25 website monitors, 10s interval, against a single-threaded local server (200ms/request), restarting the backend with and without the fix:

```
before restart (no fix): all 25 monitors fire in the same second every cycle
  n=1068  p50=2865ms  p95=6801ms  max=7132ms

after restart (with fix): same load, phases spread across the interval
  n=1600  p50= 617ms  p95=1497ms  max=4931ms
```

Timeline below — the dashed line is the restart with the fix; the residual sparse outliers on the right are ordinary queueing at 50% utilization of the deliberately weak test server, not re-clustering (per-second dispatch counts stay spread).