### PR TITLE
[fix] keep monitor instance identity stable across edits

### DIFF
--- a/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/MonitorServiceImpl.java
+++ b/hertzbeat-manager/src/main/java/org/apache/hertzbeat/manager/service/impl/MonitorServiceImpl.java
@@ -138,6 +138,34 @@ public class MonitorServiceImpl implements MonitorService {
     @Autowired
     private MetricsFavoriteService metricsFavoriteService;
 
+    /**
+     * Idempotent: an instance already carrying a port is left untouched, so repeated
+     * edits cannot grow it (host:443:443...). A missing instance falls back to the
+     * host param - never concatenated onto null, which produced "null:443" identities.
+     */
+    private void resolveMonitorInstance(Monitor monitor, List<Param> params) {
+        String instance = monitor.getInstance();
+        if (!StringUtils.hasText(instance)) {
+            instance = params.stream()
+                    .filter(param -> "host".equals(param.getField()))
+                    .map(Param::getParamValue)
+                    .filter(StringUtils::hasText)
+                    .findFirst()
+                    .orElse(StringUtils.hasText(monitor.getName()) ? monitor.getName() : "unknown");
+        }
+        Param portParam = params.stream()
+                .filter(param -> PARAM_FIELD_PORT.equals(param.getField()))
+                .findFirst()
+                .orElse(null);
+        String portWithMark = (Objects.isNull(portParam) || !StringUtils.hasText(portParam.getParamValue()))
+                ? ""
+                : SignConstants.DOUBLE_MARK + portParam.getParamValue();
+        if (!IpDomainUtil.isHasPortWithMark(instance)) {
+            instance = instance + portWithMark;
+        }
+        monitor.setInstance(instance);
+    }
+
     @Override
     @Transactional(readOnly = true)
     public void detectMonitor(Monitor monitor, List<Param> params, String collector) throws MonitorDetectException {
@@ -184,19 +212,8 @@ public class MonitorServiceImpl implements MonitorService {
         appDefine.setScheduleType(monitor.getScheduleType());
         appDefine.setCronExpression(monitor.getCronExpression());
 
+        resolveMonitorInstance(monitor, params);
         String instance = monitor.getInstance();
-        // The port field may be null
-        Param portParam = params.stream()
-                .filter(param -> PARAM_FIELD_PORT.equals(param.getField()))
-                .findFirst()
-                .orElse(null);
-        String portWithMark = (Objects.isNull(portParam) || !StringUtils.hasText(portParam.getParamValue()))
-                ? ""
-                : SignConstants.DOUBLE_MARK + portParam.getParamValue();
-        if (!IpDomainUtil.isHasPortWithMark(instance)) {
-            instance = instance + portWithMark;
-        }
-        monitor.setInstance(instance);
 
         Map<String, String> metadata = Map.of(CommonConstants.LABEL_INSTANCE_NAME, monitor.getName(),
                 CommonConstants.LABEL_INSTANCE, instance);
@@ -384,19 +401,8 @@ public class MonitorServiceImpl implements MonitorService {
             labelDao.saveAll(addLabels);
         }
 
+        resolveMonitorInstance(monitor, params);
         String instance = monitor.getInstance();
-        // The port field may be null
-        Param portParam = params.stream()
-                .filter(param -> PARAM_FIELD_PORT.equals(param.getField()))
-                .findFirst()
-                .orElse(null);
-        String portWithMark = (Objects.isNull(portParam) || !StringUtils.hasText(portParam.getParamValue()))
-                ? ""
-                : SignConstants.DOUBLE_MARK + portParam.getParamValue();
-        if (Objects.nonNull(instance)) {
-            instance = instance + portWithMark;
-        }
-        monitor.setInstance(instance);
 
         boolean isStatic = CommonConstants.SCRAPE_STATIC.equals(monitor.getScrape())
                 || !StringUtils.hasText(monitor.getScrape());

--- a/hertzbeat-manager/src/test/java/org/apache/hertzbeat/manager/service/MonitorServiceTest.java
+++ b/hertzbeat-manager/src/test/java/org/apache/hertzbeat/manager/service/MonitorServiceTest.java
@@ -226,6 +226,59 @@ class MonitorServiceTest {
     }
 
     @Test
+    void addMonitorWithoutInstanceFallsBackToHostParam() {
+        Monitor monitor = Monitor.builder()
+                .intervals(1)
+                .name("memory")
+                .app("demoApp")
+                .build();
+        Job job = new Job();
+        when(appService.getAppDefine(monitor.getApp())).thenReturn(job);
+        when(collectJobScheduling.addAsyncCollectJob(job, null)).thenReturn(1L);
+        when(monitorDao.save(monitor)).thenReturn(monitor);
+        List<Param> params = List.of(
+                Param.builder().field("host").paramValue("www.example.com").build(),
+                Param.builder().field("port").paramValue("443").build());
+        when(paramDao.saveAll(params)).thenReturn(params);
+        assertDoesNotThrow(() -> monitorService.addMonitor(monitor, params, null, null));
+        assertEquals("www.example.com:443", monitor.getInstance());
+    }
+
+    @Test
+    void addMonitorInstanceStaysStableAcrossRepeatedResolution() {
+        Monitor monitor = Monitor.builder()
+                .intervals(1)
+                .name("memory")
+                .app("demoApp")
+                .instance("www.example.com:443")
+                .build();
+        Job job = new Job();
+        when(appService.getAppDefine(monitor.getApp())).thenReturn(job);
+        when(collectJobScheduling.addAsyncCollectJob(job, null)).thenReturn(1L);
+        when(monitorDao.save(monitor)).thenReturn(monitor);
+        List<Param> params = List.of(Param.builder().field("port").paramValue("443").build());
+        when(paramDao.saveAll(params)).thenReturn(params);
+        assertDoesNotThrow(() -> monitorService.addMonitor(monitor, params, null, null));
+        assertEquals("www.example.com:443", monitor.getInstance());
+    }
+
+    @Test
+    void modifyMonitorKeepsInstanceStableAcrossEdits() {
+        long monitorId = 7L;
+        Monitor stored = Monitor.builder().jobId(1L).intervals(1).app("demoApp").name("ssl")
+                .instance("www.example.com:443").id(monitorId).build();
+        when(monitorDao.findById(monitorId)).thenReturn(Optional.of(stored));
+        List<Param> params = List.of(Param.builder().field("port").paramValue("443").build());
+
+        for (int edit = 0; edit < 2; edit++) {
+            Monitor dto = Monitor.builder().jobId(1L).intervals(1).app("demoApp").name("ssl")
+                    .instance("www.example.com:443").id(monitorId).build();
+            assertDoesNotThrow(() -> monitorService.modifyMonitor(dto, params, null, null));
+            assertEquals("www.example.com:443", dto.getInstance());
+        }
+    }
+
+    @Test
     void addMonitorException() {
         Monitor monitor = Monitor.builder()
                 .intervals(1)


### PR DESCRIPTION
Fixes #3613

SSL certificate monitors return duplicated metric series, and on current master editing any monitor that has a port fails outright with `Could not commit JPA transaction`.

Root cause: metric history is keyed by the monitor's `instance` string (`host:port`), and the modify path appended the port on **every** edit without the `isHasPortWithMark` guard the add path has. Each edit changed the identity (`github.com:443` → `github.com:443:443` → ...), so storage opened a fresh series each time — and once `Monitor.instance` gained format validation, the grown value fails validation and rolls the whole edit back. A separate hole on the add path concatenated onto a null instance, producing literal `"null:443"` identities shared by every API-created monitor.

The fix extracts the duplicated add/modify assembly into one idempotent `resolveMonitorInstance`: an instance already carrying a port is left untouched, and a missing instance falls back to the host param (then name) instead of null. `MonitorServiceTest` pins the stable-across-edits, host-fallback, and repeated-resolution behaviors.

Reproduced end-to-end — real backend, one `ssl_cert` monitor against github.com:443, edited twice via the API:

```
before:
  create (no instance)  -> instance = null:443
  edit #1               -> github.com:443
  edit #2               -> appends to github.com:443:443 -> entity validation rejects
                           {"code":4,"msg":"Could not commit JPA transaction"}
  stored series for this one monitor:
    null:443            63 rows
    github.com:443      84 rows
    github.com:443:443  609 rows      <- the duplicated series from the issue

after:
  create                -> instance = github.com:443
  edit #1               -> "Modify success" | instance: github.com:443
  edit #2               -> "Modify success" | instance: github.com:443
  stored series:
    github.com:443      231 rows      <- single identity throughout
```

Boundary: already-split historical series are not merged retroactively — this stops new splits; stale identities age out with retention.