### PR TITLE
[fix] allow long threshold expr when binding many monitors

### DIFF
--- a/hertzbeat-common-spring/src/main/java/org/apache/hertzbeat/common/entity/alerter/AlertDefine.java
+++ b/hertzbeat-common-spring/src/main/java/org/apache/hertzbeat/common/entity/alerter/AlertDefine.java
@@ -69,8 +69,8 @@ public class AlertDefine {
     private String type;
 
     @Schema(title = "Alarm Threshold Expr", example = "usage>90", accessMode = READ_WRITE)
-    @Size(max = 2048)
-    @Column(length = 2048)
+    @Size(max = 65535)
+    @Column(columnDefinition = "TEXT")
     private String expr;
 
     @Schema(title = "Execution Period/ Window Size (seconds) - For periodic rules/ For log realtime", example = "300")

--- a/hertzbeat-common-spring/src/test/java/org/apache/hertzbeat/common/entity/alerter/AlertDefineTest.java
+++ b/hertzbeat-common-spring/src/test/java/org/apache/hertzbeat/common/entity/alerter/AlertDefineTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.common.entity.alerter;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Test case for {@link AlertDefine}
+ */
+class AlertDefineTest {
+
+    private final ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+    private final Validator validator = factory.getValidator();
+
+    @Test
+    void exprShouldAllowBindingManyMonitors() {
+        String boundMonitors = LongStream.range(0, 76)
+                .mapToObj(id -> "equals(__instance__, \"" + (653868108767488L + id) + "\")")
+                .collect(Collectors.joining(" or "));
+        String expr = "equals(__app__,\"ping\") && equals(__available__,\"down\") && (" + boundMonitors + ")";
+        assertTrue(expr.length() > 2048);
+
+        AlertDefine define = AlertDefine.builder()
+                .name("ping-offline")
+                .type("realtime_metric")
+                .expr(expr)
+                .template("instance {{ $labels.instance }} is offline")
+                .build();
+
+        Set<ConstraintViolation<AlertDefine>> violations = validator.validate(define);
+        assertTrue(violations.isEmpty(), "binding many monitors should not fail validation: " + violations);
+    }
+
+    @Test
+    void oversizedExprShouldReportCharacterLength() {
+        AlertDefine define = AlertDefine.builder()
+                .name("ping-offline")
+                .type("realtime_metric")
+                .expr("x".repeat(65536))
+                .template("template")
+                .build();
+
+        Set<ConstraintViolation<AlertDefine>> violations = validator.validate(define);
+        assertEquals(1, violations.size());
+        assertEquals("expr", violations.iterator().next().getPropertyPath().toString());
+    }
+}

--- a/hertzbeat-startup/src/main/resources/db/migration/h2/V183__update_column.sql
+++ b/hertzbeat-startup/src/main/resources/db/migration/h2/V183__update_column.sql
@@ -1,0 +1,19 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Enlarge alert define expr to fit rules binding many monitors (#4171)
+ALTER TABLE HZB_ALERT_DEFINE ALTER COLUMN expr CLOB;

--- a/hertzbeat-startup/src/main/resources/db/migration/mysql/V183__update_column.sql
+++ b/hertzbeat-startup/src/main/resources/db/migration/mysql/V183__update_column.sql
@@ -1,0 +1,50 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Enlarge alert define expr to fit rules binding many monitors (#4171)
+DELIMITER //
+
+CREATE PROCEDURE ModifyAlertDefineExprColumn()
+BEGIN
+    DECLARE table_exists INT;
+    DECLARE col_exists INT;
+
+    SELECT COUNT(*) INTO table_exists
+    FROM INFORMATION_SCHEMA.TABLES
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'hzb_alert_define';
+
+    IF table_exists = 1 THEN
+        SELECT COUNT(*) INTO col_exists
+        FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'hzb_alert_define'
+        AND COLUMN_NAME = 'expr'
+        AND DATA_TYPE != 'longtext';
+
+        IF col_exists = 1 THEN
+            ALTER TABLE hzb_alert_define MODIFY COLUMN expr LONGTEXT;
+        END IF;
+    END IF;
+END //
+
+DELIMITER ;
+
+CALL ModifyAlertDefineExprColumn();
+
+DROP PROCEDURE IF EXISTS ModifyAlertDefineExprColumn;
+
+COMMIT;

--- a/hertzbeat-startup/src/main/resources/db/migration/postgresql/V183__update_column.sql
+++ b/hertzbeat-startup/src/main/resources/db/migration/postgresql/V183__update_column.sql
@@ -1,0 +1,20 @@
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+
+-- Enlarge alert define expr to fit rules binding many monitors (#4171)
+ALTER TABLE HZB_ALERT_DEFINE ALTER COLUMN expr TYPE TEXT;
+commit;


### PR DESCRIPTION
Fixes #4171

Binding more than ~30 monitors to one alert rule fails with a validation error, because each bound monitor appends an `equals(__instance__, "...")` clause (~65 chars) to the threshold `expr`, and the field was capped at 2048 characters — 2048 / 65 ≈ 30 bindings.

The fix widens `AlertDefine.expr` from `@Size(2048)/@Column(2048)` to `@Lob` with a `@Size(65535)` validation cap — the same pattern the codebase already uses for `NoticeTemplate.content`. Migration `V182` alters the column on all three vendors (mysql `longtext` with an INFORMATION_SCHEMA idempotency guard matching V172/V180, postgresql `TEXT`, h2 `CLOB`); widening is lossless for existing rows. The custom validation message was deliberately dropped so the default hibernate-validator message stays localized.

Backward compatible: previously valid input remains valid, the new 65535 cap still rejects runaway payloads, and `expr` is admin-authored config so no new trust boundary.

Verified end-to-end against a real backend (fresh H2, `Successfully applied 7 migrations ... now at version v182`):

```
before (2048 cap):
  POST expr=1501 chars (35 bindings)  -> {"code":0,"msg":"Add success"}
  POST expr=2296 chars (50 bindings)  -> {"code":1,"msg":"Size.alertDefine.expr:size must be between 0 and 2048"}
                                          (verbatim the error reported in the issue)

after (lob + 65535 cap):
  POST the same 2296-char expr        -> {"code":0,"msg":"Add success"}
  read back                           -> expr length 2296, stored intact
  POST 65536 chars                    -> {"code":1,"msg":"Size.alertDefine.expr:size must be between 0 and 65535"}
```