### PR TITLE
[fix] Make email notifier optional when spring.mail is not configured

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/notice/impl/EmailAlertNotifyHandlerImpl.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/notice/impl/EmailAlertNotifyHandlerImpl.java
@@ -32,29 +32,37 @@ import org.apache.hertzbeat.common.support.event.SystemConfigChangeEvent;
 import org.apache.hertzbeat.common.util.JsonUtil;
 import org.apache.hertzbeat.common.util.ResourceBundleUtil;
 import org.apache.hertzbeat.base.dao.GeneralConfigDao;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 /**
- * Send alarm information through email
+ * Send alarm information through email.
+ * <p>
+ * {@code spring.mail} is optional. Spring Boot only auto-configures {@link JavaMailSender}
+ * when mail host properties are set; without them this handler still starts and uses a
+ * local {@link JavaMailSenderImpl}, which can be configured via yml defaults or the UI
+ * (database) mail server settings.
+ * </p>
  */
 @Component
 @Slf4j
 public class EmailAlertNotifyHandlerImpl extends AbstractAlertNotifyHandlerImpl {
 
-    private final JavaMailSender javaMailSender;
+    private final JavaMailSenderImpl javaMailSender;
 
-    @Value("${spring.mail.host:smtp.demo.com}")
+    @Value("${spring.mail.host:}")
     private String host;
 
-    @Value("${spring.mail.username:demo}")
+    @Value("${spring.mail.username:}")
     private String username;
 
-    @Value("${spring.mail.password:demo}")
+    @Value("${spring.mail.password:}")
     private String password;
 
     @Value("${spring.mail.port:465}")
@@ -72,19 +80,27 @@ public class EmailAlertNotifyHandlerImpl extends AbstractAlertNotifyHandlerImpl 
 
     private ResourceBundle bundle = ResourceBundleUtil.getBundle("alerter");
 
-    public EmailAlertNotifyHandlerImpl(JavaMailSender javaMailSender, GeneralConfigDao generalConfigDao) {
-        this.javaMailSender = javaMailSender;
+    public EmailAlertNotifyHandlerImpl(ObjectProvider<JavaMailSender> javaMailSenderProvider,
+                                       GeneralConfigDao generalConfigDao) {
+        // Prefer the Boot-auto-configured sender when spring.mail is present; otherwise keep a
+        // local sender so the app can start and email can still be configured via the UI/DB.
+        JavaMailSender available = javaMailSenderProvider.getIfAvailable();
+        if (available instanceof JavaMailSenderImpl mailSender) {
+            this.javaMailSender = mailSender;
+        } else {
+            this.javaMailSender = new JavaMailSenderImpl();
+            log.info("spring.mail is not configured; email notify will require UI/DB mail server settings");
+        }
         this.generalConfigDao = generalConfigDao;
     }
 
     @Override
     public void send(NoticeReceiver receiver, NoticeTemplate noticeTemplate, GroupAlert alert) throws AlertNoticeException {
         try {
-            // get sender
-            JavaMailSenderImpl sender = (JavaMailSenderImpl) javaMailSender;
+            JavaMailSenderImpl sender = javaMailSender;
             String fromUsername = username;
+            boolean useDatabase = false;
             try {
-                boolean useDatabase = false;
                 GeneralConfig emailConfig = generalConfigDao.findByType(TYPE);
                 if (emailConfig != null && emailConfig.getContent() != null) {
                     // enable database configuration
@@ -103,6 +119,9 @@ public class EmailAlertNotifyHandlerImpl extends AbstractAlertNotifyHandlerImpl 
                     }
                 }
                 if (!useDatabase) {
+                    if (!StringUtils.hasText(host) || !StringUtils.hasText(username)) {
+                        throw new AlertNoticeException(mailNotConfiguredMessage());
+                    }
                     // if the database is not configured, use the yml configuration
                     sender.setHost(host);
                     sender.setPort(port);
@@ -112,6 +131,8 @@ public class EmailAlertNotifyHandlerImpl extends AbstractAlertNotifyHandlerImpl 
                     props.put("mail.smtp.ssl.enable", sslEnable);
                     props.put("mail.smtp.starttls.enable", starttlsEnable);
                 }
+            } catch (AlertNoticeException e) {
+                throw e;
             } catch (Exception e) {
                 log.error("Type not found {}", e.getMessage());
             }
@@ -128,9 +149,16 @@ public class EmailAlertNotifyHandlerImpl extends AbstractAlertNotifyHandlerImpl 
             // Set Email Content Template
             messageHelper.setText(process, true);
             javaMailSender.send(mimeMessage);
+        } catch (AlertNoticeException e) {
+            throw e;
         } catch (Exception e) {
             throw new AlertNoticeException("[Email Notify Error] " + e.getMessage());
         }
+    }
+
+    private static String mailNotConfiguredMessage() {
+        return "[Email Notify Error] Mail server is not configured. "
+                + "Set spring.mail in application.yml or enable email settings in the UI.";
     }
 
     @Override

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/notice/impl/EmailAlertNotifyHandlerImplTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/notice/impl/EmailAlertNotifyHandlerImplTest.java
@@ -17,35 +17,38 @@
 
 package org.apache.hertzbeat.alert.notice.impl;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import jakarta.mail.internet.MimeMessage;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Properties;
-import org.apache.hertzbeat.common.entity.dto.MailServerConfig;
+import java.util.ResourceBundle;
+import org.apache.hertzbeat.alert.notice.AlertNoticeException;
 import org.apache.hertzbeat.base.dao.GeneralConfigDao;
 import org.apache.hertzbeat.common.entity.alerter.GroupAlert;
 import org.apache.hertzbeat.common.entity.alerter.NoticeReceiver;
 import org.apache.hertzbeat.common.entity.alerter.NoticeTemplate;
 import org.apache.hertzbeat.common.entity.alerter.SingleAlert;
-import org.apache.hertzbeat.alert.notice.AlertNoticeException;
+import org.apache.hertzbeat.common.entity.dto.MailServerConfig;
 import org.apache.hertzbeat.common.entity.manager.GeneralConfig;
 import org.apache.hertzbeat.common.util.JsonUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
-import jakarta.mail.internet.MimeMessage;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.ResourceBundle;
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * Test case for Email Alert Notify
@@ -57,6 +60,9 @@ class EmailAlertNotifyHandlerImplTest {
     private JavaMailSenderImpl mailSender;
 
     @Mock
+    private ObjectProvider<JavaMailSender> javaMailSenderProvider;
+
+    @Mock
     private ResourceBundle bundle;
 
     @Mock
@@ -65,7 +71,6 @@ class EmailAlertNotifyHandlerImplTest {
     @Mock
     private MimeMessage mimeMessage;
 
-    @InjectMocks
     private EmailAlertNotifyHandlerImpl emailAlertNotifyHandler;
 
     private NoticeReceiver receiver;
@@ -74,6 +79,14 @@ class EmailAlertNotifyHandlerImplTest {
 
     @BeforeEach
     public void setUp() {
+        when(javaMailSenderProvider.getIfAvailable()).thenReturn(mailSender);
+        emailAlertNotifyHandler = new EmailAlertNotifyHandlerImpl(javaMailSenderProvider, generalConfigDao);
+        ReflectionTestUtils.setField(emailAlertNotifyHandler, "bundle", bundle);
+        ReflectionTestUtils.setField(emailAlertNotifyHandler, "host", "smtp.example.com");
+        ReflectionTestUtils.setField(emailAlertNotifyHandler, "username", "sender@example.com");
+        ReflectionTestUtils.setField(emailAlertNotifyHandler, "password", "password");
+        ReflectionTestUtils.setField(emailAlertNotifyHandler, "port", 587);
+
         receiver = new NoticeReceiver();
         receiver.setId(1L);
         receiver.setName("test-receiver");
@@ -129,5 +142,24 @@ class EmailAlertNotifyHandlerImplTest {
         when(mailSender.createMimeMessage()).thenThrow(new RuntimeException("Test Error"));
         assertThrows(AlertNoticeException.class,
                 () -> emailAlertNotifyHandler.send(receiver, template, groupAlert));
+    }
+
+    @Test
+    public void testStartsWithoutJavaMailSenderBean() {
+        when(javaMailSenderProvider.getIfAvailable()).thenReturn(null);
+        assertDoesNotThrow(() -> new EmailAlertNotifyHandlerImpl(javaMailSenderProvider, generalConfigDao));
+    }
+
+    @Test
+    public void testNotifyAlertFailsWhenMailNotConfigured() {
+        when(javaMailSenderProvider.getIfAvailable()).thenReturn(null);
+        EmailAlertNotifyHandlerImpl handler =
+                new EmailAlertNotifyHandlerImpl(javaMailSenderProvider, generalConfigDao);
+        ReflectionTestUtils.setField(handler, "bundle", bundle);
+        when(generalConfigDao.findByType(any())).thenReturn(null);
+
+        AlertNoticeException exception = assertThrows(AlertNoticeException.class,
+                () -> handler.send(receiver, template, groupAlert));
+        assertTrue(exception.getMessage().contains("Mail server is not configured"));
     }
 }

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/notice/impl/EmailAlertNotifyHandlerImplTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/notice/impl/EmailAlertNotifyHandlerImplTest.java
@@ -118,8 +118,8 @@ class EmailAlertNotifyHandlerImplTest {
         GeneralConfig generalConfig = GeneralConfig.builder()
                 .content(JsonUtil.toJson(mailServerConfig))
                 .build();
-        when(generalConfigDao.findByType(any())).thenReturn(generalConfig);
-        when(mailSender.getJavaMailProperties()).thenReturn(new Properties());
+        lenient().when(generalConfigDao.findByType(any())).thenReturn(generalConfig);
+        lenient().when(mailSender.getJavaMailProperties()).thenReturn(new Properties());
     }
 
     @Test

--- a/hertzbeat-startup/src/main/resources/application.yml
+++ b/hertzbeat-startup/src/main/resources/application.yml
@@ -125,6 +125,8 @@ spring:
     locations:
       - classpath:db/migration/{vendor}
 
+  # Not required if you don't use email notify. The whole spring.mail block can be omitted.
+  # Email can also be configured later in the UI (system email settings).
   mail:
     # Mail server address, eg: qq-mailbox is smtp.qq.com, qq-exmail is smtp.exmail.qq.com
     host: smtp.qq.com

--- a/home/docs/help/alert_email.md
+++ b/home/docs/help/alert_email.md
@@ -28,6 +28,6 @@ keywords: [open source monitoring tool, open source alerter, open source email n
 
 1. HertzBeat deployed on its own intranet cannot receive email notifications
 
-   > HertzBeat needs to configure its own mail server. Please confirm whether you have configured its own mail server in application.yml
+   > HertzBeat needs to configure its own mail server. Configure `spring.mail` in `application.yml`, or enable the system email settings in the UI. `spring.mail` is not required to start HertzBeat if you do not use email notify.
 
 Other issues can be fed back through the communication group ISSUE!

--- a/home/docs/start/docker-deploy.md
+++ b/home/docs/start/docker-deploy.md
@@ -149,7 +149,7 @@ By deploying multiple HertzBeat Collectors, high availability, load balancing, a
    > Download source [github/script/application.yml](https://github.com/apache/hertzbeat/raw/master/script/application.yml)
    > You can modify the configuration yml file according to your needs.
    >
-   > - If you need to use email to send alarms, you need to replace the email server parameters `spring.mail` in `application.yml`
+   > - `spring.mail` is optional. Omit it if you do not use email notify. If you need email alarms, configure `spring.mail` in `application.yml` (or set the mail server in the UI)
    > - **Recommended** If you need to use an external Mysql database to replace the built-in H2 database, you need to replace the `spring.datasource` parameter in `application.yml` For specific steps, see [Using Mysql to replace H2 database](mysql-change)
    > - **Recommended** If you need to use the time series database victoria-metrics to store metric data, you need to replace the `warehouse.store.victoria-metrics` parameter in `application.yml` for specific steps, see [Using victoria-metrics to store metrics data](victoria-metrics-init)
 

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/alert_email.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/alert_email.md
@@ -28,7 +28,7 @@ keywords: [告警邮件通知, 开源告警系统, 开源监控告警系统]
 
 1. 自己内网部署的HertzBeat无法接收到邮件通知
 
-   > HertzBeat需要自己配置邮件服务器，TanCloud无需，请确认是否在application.yml配置了自己的邮件服务器
+   > HertzBeat需要配置邮件服务器。可在 `application.yml` 中配置 `spring.mail`，或在 UI 系统邮件设置中配置。若不使用邮件通知，可省略 `spring.mail`，不影响 HertzBeat 启动。
 
 2. 云环境TanCloud无法接收到邮件通知
 

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/docker-deploy.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/start/docker-deploy.md
@@ -141,7 +141,7 @@ HertzBeat Collector 是一个轻量级的数据采集器，用于采集并将数
    下载 `application.yml` 文件到主机目录下，例如: $(pwd)/application.yml  
    下载源 [github/script/application.yml](https://github.com/apache/hertzbeat/raw/master/script/application.yml)
 
-   - 若需使用邮件发送告警，需替换 `application.yml` 里面的邮件服务器参数
+   - `spring.mail` 可选：若不使用邮件通知可省略；若需邮件告警，请在 `application.yml` 配置 `spring.mail`（也可在 UI 系统邮件设置中配置）
    - 若需使用外置Mysql数据库替换内置H2数据库，需替换`application.yml`里面的`spring.datasource`参数 具体步骤参见 [H2数据库切换为MYSQL](mysql-change)）
    - 若需使用时序数据库TDengine来存储指标数据，需替换`application.yml`里面的`warehouse.store.victoria-metrics`参数 具体步骤参见 [使用victoria-metrics存储指标数据](victoria-metrics-init)
 

--- a/home/versioned_docs/version-1.8.0/start/docker-deploy.md
+++ b/home/versioned_docs/version-1.8.0/start/docker-deploy.md
@@ -143,7 +143,7 @@ By deploying multiple HertzBeat Collectors, high availability, load balancing, a
    > Download source [github/script/application.yml](https://github.com/apache/hertzbeat/raw/master/script/application.yml)
    > You can modify the configuration yml file according to your needs.
    >
-   > - If you need to use email to send alarms, you need to replace the email server parameters `spring.mail` in `application.yml`
+   > - `spring.mail` is optional. Omit it if you do not use email notify. If you need email alarms, configure `spring.mail` in `application.yml` (or set the mail server in the UI)
    > - **Recommended** If you need to use an external Mysql database to replace the built-in H2 database, you need to replace the `spring.datasource` parameter in `application.yml` For specific steps, see [Using Mysql to replace H2 database](mysql-change)
    > - **Recommended** If you need to use the time series database victoria-metrics to store metric data, you need to replace the `warehouse.store.victoria-metrics` parameter in `application.yml` for specific steps, see [Using victoria-metrics to store metrics data](victoria-metrics-init)
 

--- a/script/application.yml
+++ b/script/application.yml
@@ -125,6 +125,8 @@ spring:
     locations:
       - classpath:db/migration/{vendor}
 
+  # Not required if you don't use email notify. The whole spring.mail block can be omitted.
+  # Email can also be configured later in the UI (system email settings).
   mail:
     # Mail server address, eg: qq-mailbox is smtp.qq.com, qq-exmail is smtp.exmail.qq.com
     host: smtp.qq.com

--- a/script/docker-compose/hertzbeat-mysql-iotdb/conf/application.yml
+++ b/script/docker-compose/hertzbeat-mysql-iotdb/conf/application.yml
@@ -128,7 +128,8 @@ spring:
     locations:
       - classpath:db/migration/mysql
 
-  # Not Require, Please config if you need email notify
+  # Not required if you don't use email notify. The whole spring.mail block can be omitted.
+  # Email can also be configured later in the UI (system email settings).
   mail:
     # Attention: this is mail server address.
     host: smtp.qq.com

--- a/script/docker-compose/hertzbeat-mysql-tdengine/conf/application.yml
+++ b/script/docker-compose/hertzbeat-mysql-tdengine/conf/application.yml
@@ -128,7 +128,8 @@ spring:
     locations:
       - classpath:db/migration/mysql
 
-  # Not Require, Please config if you need email notify
+  # Not required if you don't use email notify. The whole spring.mail block can be omitted.
+  # Email can also be configured later in the UI (system email settings).
   mail:
     # Attention: this is mail server address.
     host: smtp.qq.com

--- a/script/docker-compose/hertzbeat-mysql-victoria-metrics/conf/application.yml
+++ b/script/docker-compose/hertzbeat-mysql-victoria-metrics/conf/application.yml
@@ -128,7 +128,8 @@ spring:
     locations:
       - classpath:db/migration/mysql
 
-  # Not Require, Please config if you need email notify
+  # Not required if you don't use email notify. The whole spring.mail block can be omitted.
+  # Email can also be configured later in the UI (system email settings).
   mail:
     # Attention: this is mail server address.
     host: smtp.qq.com

--- a/script/docker-compose/hertzbeat-postgresql-greptimedb/conf/application.yml
+++ b/script/docker-compose/hertzbeat-postgresql-greptimedb/conf/application.yml
@@ -127,7 +127,8 @@ spring:
     locations:
       - classpath:db/migration/postgresql
 
-  # Not Require, Please config if you need email notify
+  # Not required if you don't use email notify. The whole spring.mail block can be omitted.
+  # Email can also be configured later in the UI (system email settings).
   mail:
     # Attention: this is mail server address.
     host: smtp.qq.com

--- a/script/docker-compose/hertzbeat-postgresql-victoria-metrics/conf/application.yml
+++ b/script/docker-compose/hertzbeat-postgresql-victoria-metrics/conf/application.yml
@@ -127,7 +127,8 @@ spring:
     locations:
       - classpath:db/migration/postgresql
 
-  # Not Require, Please config if you need email notify
+  # Not required if you don't use email notify. The whole spring.mail block can be omitted.
+  # Email can also be configured later in the UI (system email settings).
   mail:
     # Attention: this is mail server address.
     host: smtp.qq.com


### PR DESCRIPTION
## What's changed?

Fixes #4344

HertzBeat fails to start when `spring.mail` is omitted because `EmailAlertNotifyHandlerImpl` constructor-injects `JavaMailSender`, which Spring Boot only auto-configures when mail host properties are set. Docs and sample configs already describe mail as optional (“Not required if you don’t use email notify”), but missing mail config becomes a fatal startup failure / Docker restart crash loop.

This change:
- Injects `ObjectProvider<JavaMailSender>` and falls back to a local `JavaMailSenderImpl` when no mail bean exists, so startup succeeds without `spring.mail`
- Still supports email via `spring.mail` or UI/DB mail server settings
- Returns a clear `AlertNoticeException` when email notify is used without any mail configuration
- Aligns `application.yml` comments and deploy/email docs with the optional-mail behavior
- Adds unit coverage for startup without a mail bean and the not-configured send path

## DietPi smoke test (SHA `03956af9a87e9a2c214e9808e28f253edaf6bd8a`)

Tested by overlaying this fix onto `apache/hertzbeat:1.8.0` (local smoke image built from the SHA above).

| Check | Result |
| --- | --- |
| Config | **`spring.mail` fully omitted** |
| Startup | Container **healthy**, **Restarts=0** for several minutes |
| Missing-bean crash | **None** — no `JavaMailSender` required-bean startup failure |
| Startup log | `spring.mail is not configured; email notify will require UI/DB mail server settings` |
| Email negative | `/api/notice/receiver/send-test-msg` → `[Email Notify Error] Mail server is not configured. Set spring.mail in application.yml or enable email settings in the UI.` |
| Webhook / Discord | HertzBeat reached Discord janitor; stock `send-test-msg` got Discord `50006` (empty message — test payload/template limitation), **not** a crash; direct janitor embed POST returned **200** |
| Unit tests | `EmailAlertNotifyHandlerImplTest` **5/5 passed** |

Note: Discord `send-test-msg` was **not** claimed as a fully rendered Discord message; empty-body `50006` is a template/payload limitation of the stock test path, not a regression from this fix.

## Checklist

- [x] I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.