### PR TITLE
[alerter]feature: add Microsoft Teams as an alert notification channel

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/notice/impl/TeamsAlertNotifyHandlerImpl.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/notice/impl/TeamsAlertNotifyHandlerImpl.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.alert.notice.impl;
+
+import freemarker.template.TemplateException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hertzbeat.alert.notice.AlertNoticeException;
+import org.apache.hertzbeat.common.entity.alerter.GroupAlert;
+import org.apache.hertzbeat.common.entity.alerter.NoticeReceiver;
+import org.apache.hertzbeat.common.entity.alerter.NoticeTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+/**
+ * Send alert notification to Microsoft Teams via Workflows (Power Automate) webhook.
+ * Office 365 Incoming Webhooks have been retired; this handler posts an Adaptive Card
+ * to a Teams Workflows webhook URL and must send the URL through {@link URI} so that
+ * pre-encoded query parameters are not corrupted.
+ *
+ * @see <a href="https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook">
+ * Teams webhook documentation</a>
+ */
+@Component
+@Slf4j
+final class TeamsAlertNotifyHandlerImpl extends AbstractAlertNotifyHandlerImpl {
+
+    private static final String STATUS_FIRING = "firing";
+    private static final String SEVERITY_CRITICAL = "critical";
+    private static final String SEVERITY_WARNING = "warning";
+    private static final String COLOR_ATTENTION = "Attention";
+    private static final String COLOR_WARNING = "Warning";
+    private static final String COLOR_GOOD = "Good";
+    private static final String COLOR_DEFAULT = "Default";
+    private static final String HTTPS = "https";
+
+    @Override
+    public void send(NoticeReceiver receiver, NoticeTemplate noticeTemplate, GroupAlert alert)
+            throws AlertNoticeException {
+        try {
+            String webhookUrl = receiver.getTeamsWebHookUrl();
+            if (StringUtils.isBlank(webhookUrl)) {
+                throw new AlertNoticeException("Teams webhook URL is null or empty");
+            }
+            URI webhookUri = toHttpsUri(webhookUrl);
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<Map<String, Object>> httpEntity =
+                    new HttpEntity<>(buildPayload(noticeTemplate, alert), headers);
+            ResponseEntity<String> entity = restTemplate.postForEntity(webhookUri, httpEntity, String.class);
+            if (entity.getStatusCode().value() < HttpStatus.BAD_REQUEST.value()) {
+                log.debug("Send Microsoft Teams: {} Success", webhookUrl);
+            } else {
+                log.warn("Send Microsoft Teams: {} Failed: {}", webhookUrl, entity.getBody());
+                throw new AlertNoticeException("Http StatusCode " + entity.getStatusCode());
+            }
+        } catch (AlertNoticeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AlertNoticeException("[Teams Notify Error] " + e.getMessage());
+        }
+    }
+
+    @Override
+    public byte type() {
+        return 16;
+    }
+
+    /**
+     * Build the Teams Workflows Adaptive Card envelope.
+     */
+    Map<String, Object> buildPayload(NoticeTemplate noticeTemplate, GroupAlert alert)
+            throws TemplateException, IOException {
+        String content = renderContent(noticeTemplate, alert);
+        String title = bundle.getString("alerter.notify.title");
+        String color = resolveAccentColor(alert);
+
+        Map<String, Object> titleBlock = new LinkedHashMap<>();
+        titleBlock.put("type", "TextBlock");
+        titleBlock.put("text", title);
+        titleBlock.put("weight", "Bolder");
+        titleBlock.put("size", "Large");
+        titleBlock.put("wrap", true);
+        titleBlock.put("color", color);
+
+        Map<String, Object> bodyBlock = new LinkedHashMap<>();
+        bodyBlock.put("type", "TextBlock");
+        bodyBlock.put("text", content);
+        bodyBlock.put("wrap", true);
+
+        List<Map<String, Object>> cardBody = new ArrayList<>();
+        cardBody.add(titleBlock);
+        Map<String, Object> facts = buildFactSet(alert);
+        if (facts != null) {
+            cardBody.add(facts);
+        }
+        cardBody.add(bodyBlock);
+
+        Map<String, Object> card = new LinkedHashMap<>();
+        card.put("$schema", "http://adaptivecards.io/schemas/adaptive-card.json");
+        card.put("type", "AdaptiveCard");
+        card.put("version", "1.4");
+        card.put("body", cardBody);
+
+        Map<String, Object> attachment = new LinkedHashMap<>();
+        attachment.put("contentType", "application/vnd.microsoft.card.adaptive");
+        attachment.put("contentUrl", null);
+        attachment.put("content", card);
+
+        List<Map<String, Object>> attachments = new ArrayList<>();
+        attachments.add(attachment);
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("type", "message");
+        payload.put("attachments", attachments);
+        return payload;
+    }
+
+    /**
+     * Map alert status and severity to Adaptive Card accent color.
+     */
+    String resolveAccentColor(GroupAlert alert) {
+        if (alert == null || !STATUS_FIRING.equalsIgnoreCase(alert.getStatus())) {
+            return COLOR_GOOD;
+        }
+        String severity = extractSeverity(alert);
+        if (SEVERITY_CRITICAL.equalsIgnoreCase(severity)) {
+            return COLOR_ATTENTION;
+        }
+        if (SEVERITY_WARNING.equalsIgnoreCase(severity)) {
+            return COLOR_WARNING;
+        }
+        return COLOR_DEFAULT;
+    }
+
+    private Map<String, Object> buildFactSet(GroupAlert alert) {
+        if (alert == null) {
+            return null;
+        }
+        List<Map<String, String>> facts = new ArrayList<>();
+        if (StringUtils.isNotBlank(alert.getStatus())) {
+            facts.add(fact("Status", alert.getStatus()));
+        }
+        String severity = extractSeverity(alert);
+        if (StringUtils.isNotBlank(severity)) {
+            facts.add(fact("Severity", severity));
+        }
+        Map<String, String> commonLabels = alert.getCommonLabels();
+        if (commonLabels != null && StringUtils.isNotBlank(commonLabels.get("alertname"))) {
+            facts.add(fact("Alert Name", commonLabels.get("alertname")));
+        }
+        if (facts.isEmpty()) {
+            return null;
+        }
+        Map<String, Object> factSet = new LinkedHashMap<>();
+        factSet.put("type", "FactSet");
+        factSet.put("facts", facts);
+        return factSet;
+    }
+
+    private Map<String, String> fact(String name, String value) {
+        Map<String, String> fact = new LinkedHashMap<>();
+        fact.put("title", name);
+        fact.put("value", value);
+        return fact;
+    }
+
+    private String extractSeverity(GroupAlert alert) {
+        Map<String, String> commonLabels = alert.getCommonLabels();
+        if (commonLabels == null) {
+            return null;
+        }
+        String severity = commonLabels.get("severity");
+        if (severity == null) {
+            severity = commonLabels.get("priority");
+        }
+        return severity;
+    }
+
+    private URI toHttpsUri(String webhookUrl) {
+        URI uri;
+        try {
+            uri = URI.create(webhookUrl.trim());
+        } catch (IllegalArgumentException e) {
+            throw new AlertNoticeException("Invalid Teams webhook URL: " + e.getMessage());
+        }
+        if (!HTTPS.equalsIgnoreCase(uri.getScheme()) || StringUtils.isBlank(uri.getHost())) {
+            throw new AlertNoticeException("Invalid Teams webhook URL");
+        }
+        return uri;
+    }
+}

--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/util/NoticeReceiverMaskUtil.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/util/NoticeReceiverMaskUtil.java
@@ -65,7 +65,8 @@ public final class NoticeReceiverMaskUtil {
             new SecretField(NoticeReceiver::getSmnSk, NoticeReceiver::setSmnSk),
             new SecretField(NoticeReceiver::getServerChanToken, NoticeReceiver::setServerChanToken),
             new SecretField(NoticeReceiver::getGotifyToken, NoticeReceiver::setGotifyToken),
-            new SecretField(NoticeReceiver::getNtfyToken, NoticeReceiver::setNtfyToken));
+            new SecretField(NoticeReceiver::getNtfyToken, NoticeReceiver::setNtfyToken),
+            new SecretField(NoticeReceiver::getTeamsWebHookUrl, NoticeReceiver::setTeamsWebHookUrl));
 
     private NoticeReceiverMaskUtil() {
     }

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/notice/impl/TeamsAlertNotifyHandlerImplTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/notice/impl/TeamsAlertNotifyHandlerImplTest.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.alert.notice.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ResourceBundle;
+import org.apache.hertzbeat.alert.AlerterProperties;
+import org.apache.hertzbeat.alert.notice.AlertNoticeException;
+import org.apache.hertzbeat.common.entity.alerter.GroupAlert;
+import org.apache.hertzbeat.common.entity.alerter.NoticeReceiver;
+import org.apache.hertzbeat.common.entity.alerter.NoticeTemplate;
+import org.apache.hertzbeat.common.entity.alerter.SingleAlert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Test case for {@link TeamsAlertNotifyHandlerImpl}
+ */
+@ExtendWith(MockitoExtension.class)
+class TeamsAlertNotifyHandlerImplTest {
+
+    private static final String WORKFLOW_URL = "https://prod-12.westus.logic.azure.com:443/workflows/wf1"
+            + "/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=abc_def";
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Mock
+    private AlerterProperties alerterProperties;
+
+    @Mock
+    private ResourceBundle bundle;
+
+    @InjectMocks
+    private TeamsAlertNotifyHandlerImpl teamsHandler;
+
+    private NoticeReceiver receiver;
+    private NoticeTemplate template;
+
+    @BeforeEach
+    void setUp() {
+        receiver = new NoticeReceiver();
+        receiver.setId(1L);
+        receiver.setName("teams-test");
+        receiver.setTeamsWebHookUrl(WORKFLOW_URL);
+
+        template = new NoticeTemplate();
+        template.setId(1L);
+        template.setName("test-template");
+        template.setContent("test alert content");
+
+        ReflectionTestUtils.setField(teamsHandler, "bundle", bundle);
+        lenient().when(bundle.getString(anyString())).thenReturn("HertzBeat Alert Notify");
+        lenient().when(alerterProperties.getConsoleUrl()).thenReturn("https://console.hertzbeat.com");
+    }
+
+    @Test
+    void testType() {
+        assertEquals(16, teamsHandler.type());
+    }
+
+    @Test
+    void testSendSuccessAccepted() {
+        GroupAlert alert = buildGroupAlert("firing", "critical");
+        when(restTemplate.postForEntity(any(URI.class), any(), eq(String.class)))
+                .thenReturn(new ResponseEntity<>("{}", HttpStatus.ACCEPTED));
+
+        teamsHandler.send(receiver, template, alert);
+
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        verify(restTemplate).postForEntity(uriCaptor.capture(), any(), eq(String.class));
+        assertEquals(URI.create(WORKFLOW_URL), uriCaptor.getValue());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void testSendAdaptiveCardPayload() {
+        GroupAlert alert = buildGroupAlert("firing", "critical");
+        when(restTemplate.postForEntity(any(URI.class), any(), eq(String.class)))
+                .thenReturn(new ResponseEntity<>("{}", HttpStatus.OK));
+
+        teamsHandler.send(receiver, template, alert);
+
+        ArgumentCaptor<HttpEntity<Map<String, Object>>> entityCaptor = ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).postForEntity(any(URI.class), entityCaptor.capture(), eq(String.class));
+        Map<String, Object> payload = entityCaptor.getValue().getBody();
+        assertEquals("message", payload.get("type"));
+        List<Map<String, Object>> attachments = (List<Map<String, Object>>) payload.get("attachments");
+        Map<String, Object> card = (Map<String, Object>) attachments.get(0).get("content");
+        assertEquals("AdaptiveCard", card.get("type"));
+        List<Map<String, Object>> body = (List<Map<String, Object>>) card.get("body");
+        assertEquals("Attention", body.get(0).get("color"));
+        assertTrue(body.stream().anyMatch(block -> "test alert content".equals(block.get("text"))));
+    }
+
+    @Test
+    void testSendFailureStatus() {
+        GroupAlert alert = buildGroupAlert("firing", "warning");
+        when(restTemplate.postForEntity(any(URI.class), any(), eq(String.class)))
+                .thenReturn(new ResponseEntity<>("error", HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertThrows(AlertNoticeException.class, () -> teamsHandler.send(receiver, template, alert));
+    }
+
+    @Test
+    void testSendBlankUrl() {
+        receiver.setTeamsWebHookUrl("  ");
+        assertThrows(AlertNoticeException.class,
+                () -> teamsHandler.send(receiver, template, buildGroupAlert("firing", "info")));
+    }
+
+    @Test
+    void testSendHttpUrlRejected() {
+        receiver.setTeamsWebHookUrl("http://example.com/webhook");
+        assertThrows(AlertNoticeException.class,
+                () -> teamsHandler.send(receiver, template, buildGroupAlert("firing", "info")));
+    }
+
+    @Test
+    void testPercentEncodedQuerySentVerbatim() {
+        receiver.setTeamsWebHookUrl(WORKFLOW_URL);
+        RestTemplate realRestTemplate = new RestTemplate();
+        MockRestServiceServer mockServer = MockRestServiceServer.createServer(realRestTemplate);
+        mockServer.expect(requestTo(WORKFLOW_URL)).andRespond(withStatus(HttpStatus.ACCEPTED));
+        ReflectionTestUtils.setField(teamsHandler, "restTemplate", realRestTemplate);
+
+        teamsHandler.send(receiver, template, buildGroupAlert("firing", "warning"));
+
+        mockServer.verify();
+    }
+
+    @Test
+    void testResolveAccentColor() {
+        assertEquals("Attention", teamsHandler.resolveAccentColor(buildGroupAlert("firing", "critical")));
+        assertEquals("Warning", teamsHandler.resolveAccentColor(buildGroupAlert("firing", "warning")));
+        assertEquals("Default", teamsHandler.resolveAccentColor(buildGroupAlert("firing", "info")));
+        assertEquals("Good", teamsHandler.resolveAccentColor(buildGroupAlert("resolved", "critical")));
+    }
+
+    private GroupAlert buildGroupAlert(String status, String severity) {
+        GroupAlert groupAlert = new GroupAlert();
+        groupAlert.setStatus(status);
+        Map<String, String> commonLabels = new HashMap<>();
+        if (severity != null) {
+            commonLabels.put("severity", severity);
+        }
+        commonLabels.put("alertname", "Test Alert");
+        groupAlert.setCommonLabels(commonLabels);
+        groupAlert.setCommonAnnotations(new HashMap<>());
+        groupAlert.setGroupLabels(new HashMap<>());
+
+        SingleAlert singleAlert = new SingleAlert();
+        singleAlert.setLabels(new HashMap<>());
+        singleAlert.setAnnotations(new HashMap<>());
+        if (severity != null) {
+            singleAlert.getLabels().put("severity", severity);
+        }
+        List<SingleAlert> alerts = new ArrayList<>();
+        alerts.add(singleAlert);
+        groupAlert.setAlerts(alerts);
+        return groupAlert;
+    }
+}

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/util/NoticeReceiverMaskUtilTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/util/NoticeReceiverMaskUtilTest.java
@@ -47,6 +47,7 @@ class NoticeReceiverMaskUtilTest {
         receiver.setServerChanToken("SCT193569TSNm6xIabdjqeZPtOGOWcvU1e");
         receiver.setGotifyToken("A845h__ZMqDxZlO");
         receiver.setNtfyToken("tk_AgQdq7mVBoFD37zQVN29RhuMzNIz2");
+        receiver.setTeamsWebHookUrl("https://prod-00.westus.logic.azure.com/workflows/xxx/triggers/manual/paths/invoke?sig=t0k3");
         return receiver;
     }
 
@@ -66,6 +67,7 @@ class NoticeReceiverMaskUtilTest {
         assertEquals(SECRET_MASK + "vU1e", masked.getServerChanToken());
         assertEquals(SECRET_MASK + "xZlO", masked.getGotifyToken());
         assertEquals(SECRET_MASK + "NIz2", masked.getNtfyToken());
+        assertEquals(SECRET_MASK + "t0k3", masked.getTeamsWebHookUrl());
 
         assertEquals(receiver.getId(), masked.getId());
         assertEquals(receiver.getName(), masked.getName());
@@ -119,6 +121,9 @@ class NoticeReceiverMaskUtilTest {
         assertEquals("NCVBODJOEYHSW3VNSMAK", incoming.getSmnAk());
         assertEquals("nmSNhUJN9MlpPl8lfCsgdA0KvHCL9JSMSK", incoming.getSmnSk());
         assertEquals("SCT193569TSNm6xIabdjqeZPtOGOWcvU1e", incoming.getServerChanToken());
+        assertEquals(
+                "https://prod-00.westus.logic.azure.com/workflows/xxx/triggers/manual/paths/invoke?sig=t0k3",
+                incoming.getTeamsWebHookUrl());
     }
 
     @Test

--- a/hertzbeat-common-spring/src/main/java/org/apache/hertzbeat/common/entity/alerter/NoticeReceiver.java
+++ b/hertzbeat-common-spring/src/main/java/org/apache/hertzbeat/common/entity/alerter/NoticeReceiver.java
@@ -69,12 +69,13 @@ public class NoticeReceiver {
 
     @Schema(title = "Notification information method: 0-SMS 1-Email 2-webhook 3-WeChat Official Account 4-Enterprise WeChat Robot "
             + "5-DingTalk Robot 6-FeiShu Robot 7-Telegram Bot 8-SlackWebHook 9-Discord Bot 10-Enterprise WeChat app message "
-            + "11-Huawei Cloud SMN 12-ServerChan 13-Gotify 14-FeiShu app message 15-Ntfy",
+            + "11-Huawei Cloud SMN 12-ServerChan 13-Gotify 14-FeiShu app message 15-Ntfy 16-Microsoft Teams",
             description = "Notification information method: "
                     + "0-SMS 1-Email 2-webhook 3-WeChat Official Account "
                     + "4-Enterprise WeChat Robot 5-DingTalk Robot 6-FeiShu Robot "
                     + "7-Telegram Bot 8-SlackWebHook 9-Discord Bot 10-Enterprise "
-                    + "WeChat app message 11-Huawei Cloud SMN 12-ServerChan 13-Gotify 14-FeiShu app message 15-Ntfy",
+                    + "WeChat app message 11-Huawei Cloud SMN 12-ServerChan 13-Gotify 14-FeiShu app message "
+                    + "15-Ntfy 16-Microsoft Teams",
             accessMode = READ_WRITE)
     @Min(0)
     @NotNull(message = "type can not null")
@@ -278,6 +279,14 @@ public class NoticeReceiver {
     @Size(max = 300)
     @Column(length = 300)
     private String ntfyToken;
+
+    @Schema(title = "URL address: The notification method is valid for Microsoft Teams Workflows webhook",
+            description = "URL address: The notification method is valid for Microsoft Teams Workflows webhook",
+            example = "https://prod-00.westus.logic.azure.com:443/workflows/xxx/triggers/manual/paths/invoke?api-version=2016-06-01&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=xxx",
+            accessMode = READ_WRITE)
+    @Size(max = 1000)
+    @Column(length = 1000)
+    private String teamsWebHookUrl;
 
     @Schema(title = "The creator of this record", example = "tom",
             accessMode = READ_ONLY)

--- a/hertzbeat-manager/src/main/resources/templates/16-MicrosoftTeamsTemplate.txt
+++ b/hertzbeat-manager/src/main/resources/templates/16-MicrosoftTeamsTemplate.txt
@@ -1,0 +1,47 @@
+## 🔔 HertzBeat Alert Notification
+
+### Alert Summary
+> - Status: ${status}
+<#if commonLabels??>
+<#if commonLabels.severity??>
+> - Severity: ${commonLabels.severity?switch("critical", "❤️ Critical", "warning", "💛 Warning", "info", "💚 Info", "Unknown")}
+</#if>
+<#if commonLabels.alertname??>
+> - Alert Name: ${commonLabels.alertname}
+</#if>
+</#if>
+
+### Alert Details
+<#list alerts as alert>
+#### Alert ${alert?index + 1}
+<#if alert.labels??>
+<#list alert.labels?keys as key>
+> - ${key}: ${alert.labels[key]}
+</#list>
+</#if>
+<#if alert.content?? && alert.content != "">
+> - Content: ${alert.content}
+</#if>
+> - Trigger Count: ${alert.triggerTimes}
+> - Start Time: ${(alert.startAt?number_to_datetime)?string('yyyy-MM-dd HH:mm:ss')}
+<#if alert.activeAt??>
+> - Active Time: ${(alert.activeAt?number_to_datetime)?string('yyyy-MM-dd HH:mm:ss')}
+</#if>
+<#if alert.endAt??>
+> - End Time: ${(alert.endAt?number_to_datetime)?string('yyyy-MM-dd HH:mm:ss')}
+</#if>
+
+<#if alert.annotations?? && alert.annotations?size gt 0>
+##### Additional Information
+<#list alert.annotations?keys as key>
+> - ${key}: ${alert.annotations[key]}
+</#list>
+</#if>
+</#list>
+
+<#if commonAnnotations?? && commonAnnotations?size gt 0>
+### Common Information
+<#list commonAnnotations?keys as key>
+> - ${key}: ${commonAnnotations[key]}
+</#list>
+</#if>

--- a/home/docs/help/alert_teams.md
+++ b/home/docs/help/alert_teams.md
@@ -1,0 +1,38 @@
+---
+id: alert_teams
+title: Alert Microsoft Teams Notifications
+sidebar_label: Alert Microsoft Teams Notification
+keywords: [open source monitoring tool, open source alerter, microsoft teams webhook notification]
+---
+
+> Send an alarm message after the threshold is triggered, and notify the recipient through Microsoft Teams Workflows webhook.
+
+## Steps
+
+### Create a Workflows webhook in Microsoft Teams
+
+Office 365 Incoming Webhooks have been retired. Use Teams Workflows instead:
+
+1. Open the target Teams channel
+2. Choose **Workflows** → **Post to a channel when a webhook request is received**
+3. Copy the generated HTTPS webhook URL
+
+Refer to Microsoft documentation: [Retirement of Office 365 connectors within Microsoft Teams](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/)
+
+### Add an alarm notifier to HertzBeat
+
+1. **【Alarm Notification】->【Add Recipient】->【Select Microsoft Teams】->【Set Teams Workflows Webhook URL】-> 【OK】**
+
+2. **Configure the associated alarm notification strategy⚠️ [Add notification strategy] -> [Associate the recipient just set] -> [OK]**
+
+   > **Note ⚠️ Adding a new recipient does not mean that it has taken effect and can receive alarm information. It is also necessary to configure the associated alarm notification strategy, that is, specify which messages are sent to which recipients**.
+
+### Microsoft Teams Notification FAQ
+
+1. Teams did not receive the alert notification
+
+   > Please check whether the alarm information has been triggered in the alarm center  
+   > Please check whether the Teams Workflows webhook URL is configured correctly, and whether the alarm policy association has been configured  
+   > Do not use the retired `webhook.office.com` Incoming Webhook URL
+
+Other questions can be fed back through the communication group ISSUE!

--- a/home/docs/help/guide.md
+++ b/home/docs/help/guide.md
@@ -134,6 +134,7 @@ More details see&emsp;&#x1F449;&emsp;[Alarm grouping](alarm_group) <br />
 &emsp;&#x1F449;&emsp;[Configure WebHook Notification](alert_webhook) <br />
 &emsp;&#x1F449;&emsp;[Configure Discord Notification](alert_discord) <br />
 &emsp;&#x1F449;&emsp;[Configure Slack Notification](alert_slack) <br />
+&emsp;&#x1F449;&emsp;[Configure Microsoft Teams Notification](alert_teams) <br />
 &emsp;&#x1F449;&emsp;[Configure Telegram Notification](alert_telegram) <br />
 &emsp;&#x1F449;&emsp;[Configure enterprise WeChat Robot Notification](alert_wework) <br />
 &emsp;&#x1F449;&emsp;[Configure enterprise WeChat App Notification](alert_enterprise_wechat_app) <br />

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/alert_teams.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/alert_teams.md
@@ -1,0 +1,38 @@
+---
+id: alert_teams
+title: 告警 Microsoft Teams 通知
+sidebar_label: 告警 Microsoft Teams 通知
+keywords: [告警 Microsoft Teams 通知, 开源告警系统, 开源监控告警系统]
+---
+
+> 阈值触发后发送告警信息，通过 Microsoft Teams Workflows Webhook 通知到接收人。
+
+## 操作步骤
+
+### 在 Microsoft Teams 创建 Workflows Webhook
+
+Office 365 Incoming Webhook 已退役，请改用 Teams Workflows：
+
+1. 打开目标 Teams 频道
+2. 选择 **Workflows** → **Post to a channel when a webhook request is received**
+3. 复制生成的 HTTPS Webhook URL
+
+参考微软文档：[Retirement of Office 365 connectors within Microsoft Teams](https://devblogs.microsoft.com/microsoft365dev/retirement-of-office-365-connectors-within-microsoft-teams/)
+
+### 在 HertzBeat 新增告警通知人
+
+1. **【告警通知】->【新增接收人】 ->【选择 Microsoft Teams】->【设置 Teams Workflows Webhook URL】-> 【确定】**
+
+2. **配置关联的告警通知策略⚠️ 【新增通知策略】-> 【将刚设置的接收人关联】-> 【确定】**
+
+   > **注意⚠️ 新增了接收人并不代表已经生效可以接收告警信息，还需配置关联的告警通知策略，即指定哪些消息发给哪些接收人**。
+
+### Microsoft Teams 通知常见问题
+
+1. Teams 未收到告警通知
+
+> 请排查在告警中心是否已有触发的告警信息  
+> 请排查是否配置正确 Teams Workflows Webhook URL，是否已配置告警策略关联  
+> 请不要使用已退役的 `webhook.office.com` Incoming Webhook URL
+
+其它问题可以通过交流群 ISSUE 反馈哦！

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/guide.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/guide.md
@@ -134,6 +134,7 @@ sidebar_label: 帮助入门
 &emsp;&#x1F449;&emsp;[配置 Telegram 通知](alert_telegram) <br />
 &emsp;&#x1F449;&emsp;[配置 Discord 通知](alert_discord) <br />
 &emsp;&#x1F449;&emsp;[配置 Slack 通知](alert_slack) <br />
+&emsp;&#x1F449;&emsp;[配置 Microsoft Teams 通知](alert_teams) <br />
 &emsp;&#x1F449;&emsp;[配置企业微信机器人通知](alert_wework) <br />
 &emsp;&#x1F449;&emsp;[配置钉钉机器人通知](alert_dingtalk) <br />
 &emsp;&#x1F449;&emsp;[配置飞书机器人通知](alert_feishu) <br />

--- a/home/sidebars.json
+++ b/home/sidebars.json
@@ -114,6 +114,7 @@
             "help/alert_webhook",
             "help/alert_discord",
             "help/alert_slack",
+            "help/alert_teams",
             "help/alert_telegram",
             "help/alert_wework",
             "help/alert_dingtalk",

--- a/web-app/src/app/pojo/NoticeReceiver.ts
+++ b/web-app/src/app/pojo/NoticeReceiver.ts
@@ -22,7 +22,7 @@ export class NoticeReceiver {
   name!: string;
   // notification mode: 0-sms 1-email 2-webhook 3-wechat public account 4-work wechat robot 5-Dingding robot 6-Feishu robot
   // 7-Telegram robot 8-SlackWebHook 9-Discord robot 10-work wechat app message 11-Huawei cloud SMN 12-ServerChan 13-Gotify
-  // 14-FeiShu app message 15-Ntfy
+  // 14-FeiShu app message 15-Ntfy 16-Microsoft Teams
   type: number = 1;
   phone!: string;
   email!: string;
@@ -53,6 +53,7 @@ export class NoticeReceiver {
   ntfyServerUrl!: string;
   ntfyTopic!: string;
   ntfyToken!: string;
+  teamsWebHookUrl!: string;
   creator!: string;
   modifier!: string;
   gmtCreate!: number;

--- a/web-app/src/app/routes/alert/alert-notice/alert-notice-receiver/alert-notice-receiver.component.html
+++ b/web-app/src/app/routes/alert/alert-notice/alert-notice-receiver/alert-notice-receiver.component.html
@@ -135,6 +135,10 @@
           <i nz-icon nzTheme="outline" nzType="notification"></i>
           <span>{{ 'alert.notice.type.ntfy' | i18n }}</span>
         </nz-tag>
+        <nz-tag *ngIf="data.type == 16" nzColor="orange">
+          <i nz-icon nzTheme="outline" nzType="notification"></i>
+          <span>{{ 'alert.notice.type.teams' | i18n }}</span>
+        </nz-tag>
       </td>
       <td nzAlign="center">
         <span *ngIf="data.type == 0">{{ data.phone }}</span>
@@ -153,6 +157,7 @@
         <span *ngIf="data.type == 13">{{ data.gotifyToken }}</span>
         <span *ngIf="data.type == 14">{{ data.appId }}</span>
         <span *ngIf="data.type == 15">{{ data.ntfyServerUrl }}/{{ data.ntfyTopic }}</span>
+        <span *ngIf="data.type == 16">{{ data.teamsWebHookUrl }}</span>
       </td>
       <td nzAlign="center">{{ (data.gmtUpdate ? data.gmtUpdate : data.gmtCreate) | date : 'YYYY-MM-dd HH:mm:ss' }}</td>
       <td nzAlign="center" nzRight>
@@ -236,6 +241,7 @@
             <nz-option [nzLabel]="'alert.notice.type.gotify' | i18n" [nzValue]="13"></nz-option>
             <nz-option [nzLabel]="'alert.notice.type.lark-app' | i18n" [nzValue]="14"></nz-option>
             <nz-option [nzLabel]="'alert.notice.type.ntfy' | i18n" [nzValue]="15"></nz-option>
+            <nz-option [nzLabel]="'alert.notice.type.teams' | i18n" [nzValue]="16"></nz-option>
           </nz-select>
         </nz-form-control>
       </nz-form-item>
@@ -552,6 +558,21 @@
         <nz-form-label [nzSpan]="7" nzFor="ntfyToken">{{ 'alert.notice.type.ntfy-token' | i18n }}</nz-form-label>
         <nz-form-control [nzSpan]="12">
           <input [(ngModel)]="receiver.ntfyToken" name="ntfyToken" nz-input type="password" placeholder="" />
+        </nz-form-control>
+      </nz-form-item>
+      <nz-form-item *ngIf="receiver.type === 16">
+        <nz-form-label [nzRequired]="receiver.type === 16" [nzSpan]="7" nzFor="teamsWebHookUrl"
+          >{{ 'alert.notice.type.teams-webHook-url' | i18n }}
+        </nz-form-label>
+        <nz-form-control [nzErrorTip]="'validation.required' | i18n" [nzSpan]="12">
+          <input
+            [(ngModel)]="receiver.teamsWebHookUrl"
+            [required]="receiver.type === 16"
+            name="teamsWebHookUrl"
+            nz-input
+            type="url"
+            placeholder="https://prod-00.westus.logic.azure.com:443/workflows/..."
+          />
         </nz-form-control>
       </nz-form-item>
       <nz-form-item *ngIf="receiver.type === 14">

--- a/web-app/src/app/routes/alert/alert-notice/alert-notice-template/alert-notice-template.component.html
+++ b/web-app/src/app/routes/alert/alert-notice/alert-notice-template/alert-notice-template.component.html
@@ -120,6 +120,12 @@
           <nz-tag *ngIf="data.type == 14" nzColor="orange">
             <span>{{ 'alert.notice.type.lark-app' | i18n }}</span>
           </nz-tag>
+          <nz-tag *ngIf="data.type == 15" nzColor="orange">
+            <span>{{ 'alert.notice.type.ntfy' | i18n }}</span>
+          </nz-tag>
+          <nz-tag *ngIf="data.type == 16" nzColor="orange">
+            <span>{{ 'alert.notice.type.teams' | i18n }}</span>
+          </nz-tag>
         </span>
       </td>
       <td nzAlign="center">
@@ -216,6 +222,8 @@
             <nz-option [nzLabel]="'alert.notice.type.serverchan' | i18n" [nzValue]="12"></nz-option>
             <nz-option [nzLabel]="'alert.notice.type.gotify' | i18n" [nzValue]="13"></nz-option>
             <nz-option [nzLabel]="'alert.notice.type.lark-app' | i18n" [nzValue]="14"></nz-option>
+            <nz-option [nzLabel]="'alert.notice.type.ntfy' | i18n" [nzValue]="15"></nz-option>
+            <nz-option [nzLabel]="'alert.notice.type.teams' | i18n" [nzValue]="16"></nz-option>
           </nz-select>
         </nz-form-control>
       </nz-form-item>

--- a/web-app/src/assets/i18n/en-US.json
+++ b/web-app/src/assets/i18n/en-US.json
@@ -224,6 +224,8 @@
   "alert.notice.type.ntfy-server-url": "Ntfy Server URL",
   "alert.notice.type.ntfy-topic": "Ntfy Topic",
   "alert.notice.type.ntfy-token": "Ntfy Access Token",
+  "alert.notice.type.teams": "Microsoft Teams",
+  "alert.notice.type.teams-webHook-url": "Teams Workflows Webhook URL",
   "alert.notice.type.phone": "Phone",
   "alert.notice.type.serverchan": "ServerChan",
   "alert.notice.type.serverchan-token": "ServerChanToken",

--- a/web-app/src/assets/i18n/ja-JP.json
+++ b/web-app/src/assets/i18n/ja-JP.json
@@ -211,6 +211,8 @@
   "alert.notice.type.ntfy-server-url": "Ntfy サーバーURL",
   "alert.notice.type.ntfy-topic": "Ntfy トピック",
   "alert.notice.type.ntfy-token": "Ntfy アクセストークン",
+  "alert.notice.type.teams": "Microsoft Teams",
+  "alert.notice.type.teams-webHook-url": "Teams Workflows Webhook URL",
   "alert.notice.type.phone": "電話",
   "alert.notice.type.serverchan": "ServerChan",
   "alert.notice.type.serverchan-token": "ServerChanトークン",

--- a/web-app/src/assets/i18n/ko-KR.json
+++ b/web-app/src/assets/i18n/ko-KR.json
@@ -224,6 +224,8 @@
   "alert.notice.type.ntfy-server-url": "Ntfy 서버 URL",
   "alert.notice.type.ntfy-topic": "Ntfy Topic",
   "alert.notice.type.ntfy-token": "Ntfy 액세스 토큰",
+  "alert.notice.type.teams": "Microsoft Teams",
+  "alert.notice.type.teams-webHook-url": "Teams Workflows Webhook URL",
   "alert.notice.type.phone": "전화",
   "alert.notice.type.serverchan": "ServerChan",
   "alert.notice.type.serverchan-token": "ServerChanToken",

--- a/web-app/src/assets/i18n/pt-BR.json
+++ b/web-app/src/assets/i18n/pt-BR.json
@@ -205,6 +205,8 @@
   "alert.notice.type.ntfy-server-url": "URL do Servidor Ntfy",
   "alert.notice.type.ntfy-topic": "Tópico Ntfy",
   "alert.notice.type.ntfy-token": "Token de Acesso Ntfy",
+  "alert.notice.type.teams": "Microsoft Teams",
+  "alert.notice.type.teams-webHook-url": "URL do Webhook Teams Workflows",
   "alert.notice.rule": "Política de Notificação",
   "alert.notice.rule.new": "Nova Política de Notificação",
   "alert.notice.rule.edit": "Editar Política de Notificação",

--- a/web-app/src/assets/i18n/zh-CN.json
+++ b/web-app/src/assets/i18n/zh-CN.json
@@ -224,6 +224,8 @@
   "alert.notice.type.ntfy-server-url": "Ntfy 服务器地址",
   "alert.notice.type.ntfy-topic": "Ntfy 主题",
   "alert.notice.type.ntfy-token": "Ntfy 访问令牌",
+  "alert.notice.type.teams": "Microsoft Teams",
+  "alert.notice.type.teams-webHook-url": "Teams Workflows Webhook 地址",
   "alert.notice.type.phone": "手机号",
   "alert.notice.type.serverchan": "Server酱(ServerChan)",
   "alert.notice.type.serverchan-token": "Server酱Token",

--- a/web-app/src/assets/i18n/zh-TW.json
+++ b/web-app/src/assets/i18n/zh-TW.json
@@ -210,6 +210,8 @@
   "alert.notice.type.ntfy-server-url": "Ntfy 伺服器地址",
   "alert.notice.type.ntfy-topic": "Ntfy 主題",
   "alert.notice.type.ntfy-token": "Ntfy 存取權杖",
+  "alert.notice.type.teams": "Microsoft Teams",
+  "alert.notice.type.teams-webHook-url": "Teams Workflows Webhook 地址",
   "alert.notice.type.phone": "手機號",
   "alert.notice.type.serverchan": "ServerChan",
   "alert.notice.type.serverchan-token": "ServerChanToken",


### PR DESCRIPTION
Support Teams Workflows webhook with Adaptive Card payload (type=16), URI-safe sending for Power Automate URLs, frontend form/i18n, default template, docs, and unit tests. Fixes #4346.

## What's changed?

Add Microsoft Teams as an independent alert notification channel.

Office 365 Incoming Webhooks have been retired. This PR integrates Teams **Workflows (Power Automate)** webhooks and sends alerts as Adaptive Cards.

- Add `TeamsAlertNotifyHandlerImpl` (`type = 16`) in alerter
- Add `teamsWebHookUrl` on `NoticeReceiver` (`@Size(max = 1000)`)
- Send HTTP requests via `java.net.URI` so pre-encoded Power Automate query params are not re-encoded (same issue as #4249)
- Render Adaptive Cards with severity-based colors (`Attention` / `Warning` / `Default` / `Good`)
- Mask the Teams webhook URL in `NoticeReceiverMaskUtil`
- Frontend: receiver form, list/template type tags, i18n (en / zh-CN / zh-TW / ja / ko / pt-BR)
- Default template: `16-MicrosoftTeamsTemplate.txt`
- Docs: `alert_teams.md` (EN/zh-CN), guide, and sidebar
- Unit tests for success / non-2xx / URL validation / URI verbatim sending / color mapping

Fixes #4346

## Checklist

- [x] I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x] I have written the necessary doc or comment.
- [x] I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.