### PR TITLE
fix(collector): support legacy Redfish firmware

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/redfish/RedfishCollectImpl.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/redfish/RedfishCollectImpl.java
@@ -17,13 +17,15 @@
 
 package org.apache.hertzbeat.collector.collect.redfish;
 
-import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.hertzbeat.collector.collect.AbstractCollect;
 import org.apache.hertzbeat.collector.collect.common.cache.AbstractConnection;
@@ -36,14 +38,28 @@ import org.apache.hertzbeat.common.constants.CommonConstants;
 import org.apache.hertzbeat.common.entity.job.Metrics;
 import org.apache.hertzbeat.common.entity.job.protocol.RedfishProtocol;
 import org.apache.hertzbeat.common.entity.message.CollectRep;
+import org.apache.hertzbeat.common.util.JsonUtil;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import tools.jackson.databind.JsonNode;
 
 /**
  * redfish collect impl
  */
 @Slf4j
 public class RedfishCollectImpl extends AbstractCollect {
+
+    private static final char FRAGMENT_SEPARATOR = '#';
+
+    private static final Pattern SCHEMA_PLACEHOLDER = Pattern.compile("\\{\\w+\\}");
+
+    private static final String COLLECTION_MEMBER_PATH = "$.Members[*].['@odata.id']";
+
+    private static final String EMBEDDED_MEMBER_PATH = "$[*].['@odata.id']";
+
+    private static final String MODERN_FAN_SPEED_PATH = "$.SpeedPercent.SpeedRPM";
+
+    private static final String LEGACY_FAN_SPEED_PATH = "$.Reading";
 
     private final GlobalConnectionCache connectionCommonCache = GlobalConnectionCache.getInstance();
 
@@ -70,16 +86,17 @@ public class RedfishCollectImpl extends AbstractCollect {
             builder.setMsg(e.getMessage());
             return;
         }
-        List<String> resourcesUri = getResourcesUri(metrics, connectSession);
-        if (resourcesUri == null || resourcesUri.isEmpty()) {
+        ResourceResolver resolver = new ResourceResolver(connectSession);
+        List<String> resourcesUri = getResourcesUri(metrics, resolver);
+        if (resourcesUri.isEmpty()) {
             builder.setCode(CollectRep.Code.FAIL);
-            builder.setMsg("Get redfish resources uri error");
+            builder.setMsg(resolver.lastError != null ? resolver.lastError : "Get redfish resources uri error");
             return;
         }
         for (String uri : resourcesUri) {
-            String resp = null;
+            String resp;
             try {
-                resp = connectSession.getRedfishResource(uri);
+                resp = resolver.resolve(uri);
             } catch (Exception e) {
                 log.error("Get redfish {} detail resource error: {}", uri, e.getMessage());
                 continue;
@@ -120,53 +137,115 @@ public class RedfishCollectImpl extends AbstractCollect {
     }
 
 
-    private List<String> getResourcesUri(Metrics metrics, ConnectSession connectSession) {
-        String name = metrics.getName();
-        String collectionSchema = metrics.getRedfish().getSchema();
-        String schema = (collectionSchema != null) ? collectionSchema : RedfishCollectionSchema.getSchema(name);
-        if (!StringUtils.hasText(schema)) {
-            return null;
-        }
-        String pattern = "\\{\\w+\\}";
-        Pattern r = Pattern.compile(pattern);
-        String[] fragment = r.split(schema);
-        List<String> res = new ArrayList<>();
-        for (String value : fragment) {
-            List<String> temp = new ArrayList<>();
-            if (res.isEmpty()) {
-                res.add(value);
-            } else {
-                res = res.stream().map(s -> s + value).collect(Collectors.toList());
+    private List<String> getResourcesUri(Metrics metrics, ResourceResolver resolver) {
+        List<String> schemas = collectionSchemas(metrics);
+        Map<String, List<String>> resourcesByParent = new LinkedHashMap<>();
+        for (String schema : schemas) {
+            Map<String, List<String>> candidateResources = resolveCollectionSchema(schema, resolver);
+            if (!SCHEMA_PLACEHOLDER.matcher(schema).find()) {
+                List<String> resources = candidateResources.get(schema);
+                if (!resources.isEmpty()) {
+                    return resources;
+                }
+                continue;
             }
+            candidateResources.forEach((parent, resources) -> {
+                if (!resources.isEmpty()) {
+                    resourcesByParent.putIfAbsent(parent, resources);
+                }
+            });
+        }
+        List<String> resources = resourcesByParent.values().stream().flatMap(List::stream).toList();
+        if (!resources.isEmpty()) {
+            return resources;
+        }
+        log.warn("Redfish {} metrics unavailable, none of the collection schemas {} returned resources",
+                metrics.getName(), schemas);
+        return Collections.emptyList();
+    }
 
-            for (String s : res) {
-                List<String> t = getCollectionResource(s, connectSession);
-                temp.addAll(t);
-            }
-            res.clear();
-            res.addAll(temp);
+    /**
+     * Configured schema first, then the built-in candidates, so a user override keeps its fallbacks.
+     */
+    private List<String> collectionSchemas(Metrics metrics) {
+        String configured = metrics.getRedfish().getSchema();
+        return Stream.concat(
+                        StringUtils.hasText(configured) ? Stream.of(configured) : Stream.empty(),
+                        RedfishCollectionSchema.getSchemas(metrics.getName()).stream())
+                .distinct()
+                .toList();
+    }
+
+    private Map<String, List<String>> resolveCollectionSchema(String schema, ResourceResolver resolver) {
+        String[] segments = SCHEMA_PLACEHOLDER.split(schema, -1);
+        if (segments.length == 1) {
+            return Map.of(schema, getCollectionResource(schema, resolver));
         }
-        return res;
+
+        Map<String, List<String>> resourcesByParent = new LinkedHashMap<>();
+        for (String parent : getCollectionResource(segments[0], resolver)) {
+            List<String> uris = List.of(parent);
+            for (int index = 1; index < segments.length; index++) {
+                String segment = segments[index];
+                uris = uris.stream()
+                        .map(uri -> uri + segment)
+                        .flatMap(uri -> getCollectionResource(uri, resolver).stream())
+                        .toList();
+            }
+            resourcesByParent.put(parent, uris);
+        }
+        return resourcesByParent;
     }
 
     private List<String> parseCollectionResource(String resp) {
         if (!StringUtils.hasText(resp)) {
             return Collections.emptyList();
         }
-        String resourceIdPath = "$.Members[*].['@odata.id']";
+        String resourceIdPath = Boolean.TRUE.equals(JsonUtil.isArray(resp)) ? EMBEDDED_MEMBER_PATH : COLLECTION_MEMBER_PATH;
         List<Object> resourceIds = JsonPathParser.parseContentWithJsonPath(resp, resourceIdPath);
         return resourceIds.stream().filter(Objects::nonNull).map(String::valueOf).toList();
     }
 
-    private List<String> getCollectionResource(String uri, ConnectSession connectSession) {
-        String resp = null;
+    private List<String> getCollectionResource(String uri, ResourceResolver resolver) {
         try {
-            resp = connectSession.getRedfishResource(uri);
+            return parseCollectionResource(resolver.resolve(uri));
         } catch (Exception e) {
-            log.error("Get redfish {} collection resource error: {}", uri, e.getMessage());
+            // a candidate schema missing on this firmware is expected, so keep the reason for the failure report
+            log.debug("Redfish collection {} unavailable: {}", uri, e.getMessage());
+            resolver.lastError = "Get redfish " + uri + " error: " + e.getMessage();
             return Collections.emptyList();
         }
-        return parseCollectionResource(resp);
+    }
+
+    private static final class ResourceResolver {
+
+        private final ConnectSession connectSession;
+        private final Map<String, String> documentCache = new HashMap<>();
+
+        private String lastError;
+
+        private ResourceResolver(ConnectSession connectSession) {
+            this.connectSession = connectSession;
+        }
+
+        private String resolve(String uri) throws Exception {
+            int fragmentIndex = uri.indexOf(FRAGMENT_SEPARATOR);
+            String documentUri = fragmentIndex < 0 ? uri : uri.substring(0, fragmentIndex);
+            String document = documentCache.get(documentUri);
+            if (document == null) {
+                document = connectSession.getRedfishResource(documentUri);
+                documentCache.put(documentUri, document);
+            }
+            if (fragmentIndex < 0) {
+                return document;
+            }
+            JsonNode root = JsonUtil.fromJson(document);
+            if (root == null) {
+                return null;
+            }
+            JsonNode target = root.at(uri.substring(fragmentIndex + 1));
+            return target.isMissingNode() ? null : target.toString();
+        }
     }
 
     private void parseRedfishResource(CollectRep.MetricsData.Builder builder, String resp, Metrics metrics) {
@@ -176,8 +255,8 @@ public class RedfishCollectImpl extends AbstractCollect {
         List<String> jsonPaths = metrics.getRedfish().getJsonPath();
         CollectRep.ValueRow.Builder valueRowBuilder = CollectRep.ValueRow.newBuilder();
         for (String path : jsonPaths) {
-            List<Object> res = JsonPathParser.parseContentWithJsonPath(resp, path);
-            if (res != null && !res.isEmpty()) {
+            List<Object> res = parseMetricValues(resp, metrics.getName(), path);
+            if (!res.isEmpty()) {
                 Object value = res.get(0);
                 valueRowBuilder.addColumn(value == null ? CommonConstants.NULL_VALUE : String.valueOf(value));
             } else {
@@ -185,5 +264,15 @@ public class RedfishCollectImpl extends AbstractCollect {
             }
         }
         builder.addValueRow(valueRowBuilder.build());
+    }
+
+    private List<Object> parseMetricValues(String resp, String metricsName, String path) {
+        List<Object> values = JsonPathParser.parseContentWithOptionalJsonPath(resp, path);
+        if (!"Fan".equals(metricsName)
+                || !MODERN_FAN_SPEED_PATH.equals(path)
+                || (!values.isEmpty() && values.get(0) != null)) {
+            return values;
+        }
+        return JsonPathParser.parseContentWithOptionalJsonPath(resp, LEGACY_FAN_SPEED_PATH);
     }
 }

--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/redfish/RedfishCollectionSchema.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/redfish/RedfishCollectionSchema.java
@@ -17,6 +17,8 @@
 
 package org.apache.hertzbeat.collector.collect.redfish;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -24,14 +26,22 @@ import java.util.Map;
  */
 public class RedfishCollectionSchema {
 
-    private static final Map<String, String> schemaMap = Map.of(
-            "Chassis", "/redfish/v1/Chassis",
-            "Fan", "/redfish/v1/Chassis/{ChassisId}/ThermalSubsystem/Fans",
-            "Battery", "/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/Batteries",
-            "PowerSupply", "/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/PowerSupplies");
+    /**
+     * Candidate collection uris per resource, most recent schema first.
+     * Redfish 2020.4 moved fans and power supplies from the embedded Thermal/Power
+     * arrays into their own collections, but shipped BMC firmware still serves only
+     * the legacy layout, so both have to be probed.
+     */
+    private static final Map<String, List<String>> SCHEMA_MAP = Map.of(
+            "Chassis", List.of("/redfish/v1/Chassis"),
+            "Fan", List.of("/redfish/v1/Chassis/{ChassisId}/ThermalSubsystem/Fans",
+                    "/redfish/v1/Chassis/{ChassisId}/Thermal#/Fans"),
+            "Battery", List.of("/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/Batteries"),
+            "PowerSupply", List.of("/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/PowerSupplies",
+                    "/redfish/v1/Chassis/{ChassisId}/Power#/PowerSupplies"));
 
-    public static String getSchema(String key) {
-        return schemaMap.get(key);
+    public static List<String> getSchemas(String key) {
+        return SCHEMA_MAP.getOrDefault(key, Collections.emptyList());
     }
 
 }

--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/redfish/RedfishConnectSession.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/redfish/RedfishConnectSession.java
@@ -17,6 +17,8 @@
 
 package org.apache.hertzbeat.collector.collect.redfish;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import org.apache.hertzbeat.collector.collect.common.http.CommonHttpClient;
 import org.apache.hertzbeat.common.constants.NetworkConstants;
@@ -50,13 +52,14 @@ public class RedfishConnectSession implements ConnectSession {
     @Override
     public void close() throws Exception {
         this.active = false;
-        String url = RedfishClient.REDFISH_SESSION_SERVICE + session.location();
-        HttpDelete httpDelete = new HttpDelete(url);
+        HttpDelete httpDelete = new HttpDelete(buildUrl(session.location()));
         httpDelete.setHeader(NetworkConstants.X_AUTH_TOKEN, session.token());
         httpDelete.setHeader(NetworkConstants.LOCATION, session.location());
         try (CloseableHttpResponse response = CommonHttpClient.getHttpClient().execute(httpDelete)) {
             int statusCode = response.getStatusLine().getStatusCode();
-            if (statusCode != HttpStatus.SC_OK) {
+            if (statusCode != HttpStatus.SC_OK
+                    && statusCode != HttpStatus.SC_ACCEPTED
+                    && statusCode != HttpStatus.SC_NO_CONTENT) {
                 throw new Exception(NetworkConstants.STATUS_CODE + SignConstants.BLANK + statusCode);
             }
         } catch (Exception e) {
@@ -71,17 +74,7 @@ public class RedfishConnectSession implements ConnectSession {
         if (uri.endsWith("/")) {
             uri = uri.substring(0, uri.length() - 1);
         }
-        String url = null;
-        if (IpDomainUtil.isHasSchema(this.session.host())) {
-            url = this.session.host() + ":" + this.session.port() + uri;
-        } else {
-            String ipAddressType = IpDomainUtil.checkIpAddressType(this.session.host());
-            String baseUri = NetworkConstants.IPV6.equals(ipAddressType)
-                    ? String.format("[%s]:%s", this.session.host(), this.session.port() + uri)
-                    : String.format("%s:%s", this.session.host(), this.session.port() + uri);
-            url = NetworkConstants.HTTPS_HEADER + baseUri;
-        }
-        HttpGet httpGet = new HttpGet(url);
+        HttpGet httpGet = new HttpGet(buildUrl(uri));
         httpGet.setHeader(NetworkConstants.X_AUTH_TOKEN, session.token());
         httpGet.setHeader(NetworkConstants.LOCATION, session.location());
         try (CloseableHttpResponse response = CommonHttpClient.getHttpClient().execute(httpGet)) {
@@ -95,5 +88,50 @@ public class RedfishConnectSession implements ConnectSession {
         } finally {
             httpGet.abort();
         }
+    }
+
+    private String buildUrl(String uri) {
+        URI serviceUri = getServiceUri();
+        URI resourceUri = serviceUri.resolve(uri);
+        if (!hasSameOrigin(serviceUri, resourceUri)) {
+            throw new IllegalArgumentException("Redfish resource URI must use the monitored endpoint");
+        }
+        return resourceUri.toString();
+    }
+
+    private URI getServiceUri() {
+        String configuredHost = this.session.host();
+        if (!IpDomainUtil.isHasSchema(configuredHost)) {
+            String host = configuredHost;
+            if (NetworkConstants.IPV6.equals(IpDomainUtil.checkIpAddressType(host))) {
+                host = "[" + host + "]";
+            }
+            return URI.create(NetworkConstants.HTTPS_HEADER + host + ":" + this.session.port() + "/");
+        }
+
+        URI configuredUri = URI.create(configuredHost);
+        if (configuredUri.getHost() == null) {
+            throw new IllegalArgumentException("Invalid Redfish host: " + configuredHost);
+        }
+        int port = configuredUri.getPort() < 0 ? this.session.port() : configuredUri.getPort();
+        try {
+            return new URI(configuredUri.getScheme(), null, configuredUri.getHost(), port, "/", null, null);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid Redfish host: " + configuredHost, e);
+        }
+    }
+
+    private boolean hasSameOrigin(URI serviceUri, URI resourceUri) {
+        return resourceUri.getHost() != null
+                && serviceUri.getScheme().equalsIgnoreCase(resourceUri.getScheme())
+                && serviceUri.getHost().equalsIgnoreCase(resourceUri.getHost())
+                && effectivePort(serviceUri) == effectivePort(resourceUri);
+    }
+
+    private int effectivePort(URI uri) {
+        if (uri.getPort() >= 0) {
+            return uri.getPort();
+        }
+        return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
     }
 }

--- a/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/redfish/RedfishCollectImplTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/redfish/RedfishCollectImplTest.java
@@ -19,14 +19,19 @@ package org.apache.hertzbeat.collector.collect.redfish;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.hertzbeat.collector.dispatch.DispatchConstants;
+import org.apache.hertzbeat.common.constants.CommonConstants;
 import org.apache.hertzbeat.common.entity.job.Metrics;
 import org.apache.hertzbeat.common.entity.job.protocol.RedfishProtocol;
 import org.apache.hertzbeat.common.entity.message.CollectRep;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -41,7 +46,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
  */
 @ExtendWith(MockitoExtension.class)
 public class RedfishCollectImplTest {
-    @Mock
     private RedfishProtocol redfishProtocol;
 
     @Mock
@@ -52,6 +56,8 @@ public class RedfishCollectImplTest {
 
     @InjectMocks
     private RedfishCollectImpl redfishCollect;
+
+    private MockedStatic<RedfishClient> clientMockedStatic;
 
     @BeforeEach
     void setUp() {
@@ -64,124 +70,256 @@ public class RedfishCollectImplTest {
                 .build();
     }
 
-    @Test
-    void collect() {
-        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
-        List<String> jsonPath = new ArrayList<>();
-        jsonPath.add("$.Id");
-        Metrics metrics = new Metrics();
-        metrics.setRedfish(redfishProtocol);
-        metrics.getRedfish().setJsonPath(jsonPath);
-        metrics.setName("Chassis");
-        RedfishClient.create(redfishProtocol);
-        redfishCollect.preCheck(metrics);
-        redfishCollect.collect(builder, metrics);
+    @AfterEach
+    void closeStaticMock() {
+        if (clientMockedStatic != null) {
+            clientMockedStatic.close();
+            clientMockedStatic = null;
+        }
     }
 
-    @Test
-    void mockCollect() throws Exception {
-        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
-        List<String> jsonPath = new ArrayList<>();
-        jsonPath.add("$.['@odata.id']");
-        redfishProtocol.setSchema("/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/PowerSupplies");
-        Metrics metrics = new Metrics();
-        metrics.setRedfish(redfishProtocol);
-        metrics.getRedfish().setJsonPath(jsonPath);
-        metrics.setName("PowerSupply");
-        String chassis = """
-                {
-                    "@odata.type": "#ChassisCollection.ChassisCollection",
-                    "Name": "Chassis Collection",
-                    "Members@odata.count": 2,
-                    "Members": [
-                        {
-                            "@odata.id": "/redfish/v1/Chassis/1U"
-                        },
-                        {
-                            "@odata.id": "/redfish/v1/Chassis/2U"
-                        }
-                    ]
-                }""";
-        String powerSupplies1U = """
-                {
-                    "@odata.type": "#PowerSupplyCollection.PowerSupplyCollection",
-                    "Name": "Power Supply Collection",
-                    "Members@odata.count": 2,
-                    "Members": [
-                        {
-                            "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1"
-                        },
-                        {
-                            "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay2"
-                        }
-                    ]
-                }""";
-        String powerSupplies2U = """
-                {
-                    "@odata.type": "#PowerSupplyCollection.PowerSupplyCollection",
-                    "Name": "Power Supply Collection",
-                    "Members@odata.count": 2,
-                    "Members": [
-                        {
-                            "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/Bay1"
-                        },
-                        {
-                            "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/Bay2"
-                        }
-                    ]
-                }""";
-        String bay1U1 = """
-                {
-                    "@odata.type": "#PowerSupply.v1_5_3.PowerSupply",
-                    "Id": "Bay1",
-                    "Name": "Power Supply Bay 1",
-                    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1"
-                }""";
-        String bay2U1 = """
-                {
-                    "@odata.type": "#PowerSupply.v1_5_3.PowerSupply",
-                    "Id": "Bay2",
-                    "Name": "Power Supply Bay 2",
-                    "@odata.id": "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay2"
-                }""";
-        String bay1U2 = """
-                {
-                    "@odata.type": "#PowerSupply.v1_5_3.PowerSupply",
-                    "Id": "Bay1",
-                    "Name": "Power Supply Bay 1",
-                    "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/Bay1"
-                }""";
-        String bay2U2 = """
-                {
-                    "@odata.type": "#PowerSupply.v1_5_3.PowerSupply",
-                    "Id": "Bay2",
-                    "Name": "Power Supply Bay 2",
-                    "@odata.id": "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/Bay2"
-                }""";
-        Mockito.when(redfishConnectSession.getRedfishResource("/redfish/v1/Chassis/")).thenReturn(chassis);
-        Mockito.when(redfishConnectSession.getRedfishResource("/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies")).thenReturn(powerSupplies1U);
-        Mockito.when(redfishConnectSession.getRedfishResource("/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies")).thenReturn(powerSupplies2U);
-        Mockito.when(redfishConnectSession.getRedfishResource("/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1")).thenReturn(bay1U1);
-        Mockito.when(redfishConnectSession.getRedfishResource("/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay2")).thenReturn(bay2U1);
-        Mockito.when(redfishConnectSession.getRedfishResource("/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/Bay1")).thenReturn(bay1U2);
-        Mockito.when(redfishConnectSession.getRedfishResource("/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/Bay2")).thenReturn(bay2U2);
-        MockedStatic<RedfishClient> clientMockedStatic = Mockito.mockStatic(RedfishClient.class);
+    private void givenConnectedSession() throws Exception {
+        clientMockedStatic = Mockito.mockStatic(RedfishClient.class);
         clientMockedStatic.when(() -> RedfishClient.create(redfishProtocol)).thenReturn(redfishClient);
         Mockito.when(redfishClient.connect()).thenReturn(redfishConnectSession);
+    }
+
+    private Metrics metrics(String name, String... jsonPaths) {
+        redfishProtocol.setJsonPath(List.of(jsonPaths));
+        Metrics metrics = new Metrics();
+        metrics.setName(name);
+        metrics.setRedfish(redfishProtocol);
+        return metrics;
+    }
+
+    private CollectRep.MetricsData.Builder collectMetrics(Metrics metrics) throws Exception {
+        givenConnectedSession();
+        CollectRep.MetricsData.Builder builder = CollectRep.MetricsData.newBuilder();
         redfishCollect.preCheck(metrics);
         redfishCollect.collect(builder, metrics);
-        assertEquals("/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1", builder.getValues(0).getColumns(0));
-        assertEquals("/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay2", builder.getValues(1).getColumns(0));
-        assertEquals("/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/Bay1", builder.getValues(2).getColumns(0));
-        assertEquals("/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/Bay2", builder.getValues(3).getColumns(0));
+        return builder;
+    }
+
+    private void givenResource(String uri, String response) throws Exception {
+        Mockito.when(redfishConnectSession.getRedfishResource(uri)).thenReturn(response);
+    }
+
+    private void givenUnavailable(String uri) throws Exception {
+        Mockito.when(redfishConnectSession.getRedfishResource(uri))
+                .thenThrow(new Exception("Redfish session get resource error:StatusCode 404"));
+    }
+
+    private static String collection(String... resourceUris) {
+        String members = Arrays.stream(resourceUris)
+                .map(uri -> "{\"@odata.id\":\"" + uri + "\"}")
+                .collect(Collectors.joining(","));
+        return "{\"Members\":[" + members + "]}";
+    }
+
+    private static String resource(String uri, String name) {
+        return "{\"@odata.id\":\"" + uri + "\",\"Name\":\"" + name + "\"}";
     }
 
     @Test
-    void preCheck() throws Exception {
-        // metrics is null
+    void collectChassis() throws Exception {
+        Metrics metrics = metrics("Chassis", "$.Name");
+        String chassisUri = "/redfish/v1/Chassis/1";
+        givenResource("/redfish/v1/Chassis", collection(chassisUri));
+        givenResource(chassisUri, resource(chassisUri, "Main Chassis"));
+
+        CollectRep.MetricsData.Builder builder = collectMetrics(metrics);
+
+        assertEquals("Main Chassis", builder.getValues(0).getColumns(0));
+    }
+
+    @Test
+    void collectsConfiguredSchema() throws Exception {
+        redfishProtocol.setSchema("/redfish/v1/Chassis/{ChassisId}/PowerSubsystem/PowerSupplies");
+        Metrics metrics = metrics("PowerSupply", "$.['@odata.id']");
+        String bay1U1 = "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay1";
+        String bay2U1 = "/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies/Bay2";
+        String bay1U2 = "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/Bay1";
+        String bay2U2 = "/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies/Bay2";
+        givenResource("/redfish/v1/Chassis/", collection("/redfish/v1/Chassis/1U", "/redfish/v1/Chassis/2U"));
+        givenResource("/redfish/v1/Chassis/1U/PowerSubsystem/PowerSupplies", collection(bay1U1, bay2U1));
+        givenResource("/redfish/v1/Chassis/2U/PowerSubsystem/PowerSupplies", collection(bay1U2, bay2U2));
+        givenResource(bay1U1, resource(bay1U1, "Power Supply Bay 1"));
+        givenResource(bay2U1, resource(bay2U1, "Power Supply Bay 2"));
+        givenResource(bay1U2, resource(bay1U2, "Power Supply Bay 1"));
+        givenResource(bay2U2, resource(bay2U2, "Power Supply Bay 2"));
+
+        CollectRep.MetricsData.Builder builder = collectMetrics(metrics);
+        assertEquals(bay1U1, builder.getValues(0).getColumns(0));
+        assertEquals(bay2U1, builder.getValues(1).getColumns(0));
+        assertEquals(bay1U2, builder.getValues(2).getColumns(0));
+        assertEquals(bay2U2, builder.getValues(3).getColumns(0));
+    }
+
+    @Test
+    void collectFansFromLegacyThermalDocument() throws Exception {
+        Metrics metrics = metrics("Fan", "$.Name", "$.Reading", "$.Status.Health");
+        String thermal = """
+                {
+                    "@odata.context": "/redfish/v1/$metadata#Thermal.Thermal",
+                    "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal",
+                    "@odata.type": "#Thermal.v1_7_1.Thermal",
+                    "Fans": [
+                        {
+                            "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/0",
+                            "@odata.type": "#Thermal.v1_7_1.Fan",
+                            "FanName": "System Board Fan1A",
+                            "MemberId": "0",
+                            "Name": "System Board Fan1A",
+                            "Reading": 3480,
+                            "ReadingUnits": "RPM",
+                            "Status": {
+                                "Health": "OK",
+                                "State": "Enabled"
+                            }
+                        },
+                        {
+                            "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/1",
+                            "@odata.type": "#Thermal.v1_7_1.Fan",
+                            "FanName": "System Board Fan1B",
+                            "MemberId": "1",
+                            "Name": "System Board Fan1B",
+                            "Reading": 3240,
+                            "ReadingUnits": "RPM",
+                            "Status": {
+                                "Health": "OK",
+                                "State": "Enabled"
+                            }
+                        }
+                    ]
+                }""";
+        givenResource("/redfish/v1/Chassis/", collection("/redfish/v1/Chassis/System.Embedded.1"));
+        givenUnavailable("/redfish/v1/Chassis/System.Embedded.1/ThermalSubsystem/Fans");
+        givenResource("/redfish/v1/Chassis/System.Embedded.1/Thermal", thermal);
+
+        CollectRep.MetricsData.Builder builder = collectMetrics(metrics);
+
+        assertEquals(2, builder.getValuesCount());
+        assertEquals("System Board Fan1A", builder.getValues(0).getColumns(0));
+        assertEquals("3480", builder.getValues(0).getColumns(1));
+        assertEquals("OK", builder.getValues(0).getColumns(2));
+        assertEquals("System Board Fan1B", builder.getValues(1).getColumns(0));
+        assertEquals("3240", builder.getValues(1).getColumns(1));
+        Mockito.verify(redfishConnectSession, Mockito.times(1))
+                .getRedfishResource("/redfish/v1/Chassis/System.Embedded.1/Thermal");
+    }
+
+    @Test
+    void collectPowerSuppliesFromLegacyPowerDocument() throws Exception {
+        Metrics metrics = metrics("PowerSupply", "$.['@odata.id']", "$.Name");
+        String power = """
+                {
+                    "PowerSupplies": [
+                        {
+                            "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Power#/PowerSupplies/0",
+                            "Name": "Power Supply 1"
+                        }
+                    ]
+                }""";
+        givenResource("/redfish/v1/Chassis/", collection("/redfish/v1/Chassis/System.Embedded.1"));
+        givenUnavailable("/redfish/v1/Chassis/System.Embedded.1/PowerSubsystem/PowerSupplies");
+        givenResource("/redfish/v1/Chassis/System.Embedded.1/Power", power);
+
+        CollectRep.MetricsData.Builder builder = collectMetrics(metrics);
+
+        assertEquals(1, builder.getValuesCount());
+        assertEquals("/redfish/v1/Chassis/System.Embedded.1/Power#/PowerSupplies/0",
+                builder.getValues(0).getColumns(0));
+        assertEquals("Power Supply 1", builder.getValues(0).getColumns(1));
+    }
+
+    @Test
+    void collectFailsWhenNoSchemaCandidateResolves() throws Exception {
+        Metrics metrics = metrics("Fan", "$.Name");
+        Mockito.when(redfishConnectSession.getRedfishResource(anyString()))
+                .thenThrow(new Exception("Redfish session get resource error:StatusCode 404"));
+
+        CollectRep.MetricsData.Builder builder = collectMetrics(metrics);
+
+        assertEquals(CollectRep.Code.FAIL, builder.getCode());
+    }
+
+    @Test
+    void legacyFanFieldsUseAvailableFallbacks() throws Exception {
+        Metrics metrics = metrics("Fan", "$.['@odata.id']", "$.Name", "$.Status.State",
+                "$.Status.Health", "$.SpeedPercent.Reading", "$.SpeedPercent.SpeedRPM");
+        String thermal = """
+                {
+                    "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal",
+                    "Fans": [
+                        {
+                            "@odata.id": "/redfish/v1/Chassis/System.Embedded.1/Thermal#/Fans/0",
+                            "Name": "System Board Fan1A",
+                            "Reading": 3480,
+                            "ReadingUnits": "RPM",
+                            "Status": {
+                                "Health": "OK",
+                                "State": "Enabled"
+                            }
+                        }
+                    ]
+                }""";
+        givenResource("/redfish/v1/Chassis/", collection("/redfish/v1/Chassis/System.Embedded.1"));
+        givenUnavailable("/redfish/v1/Chassis/System.Embedded.1/ThermalSubsystem/Fans");
+        givenResource("/redfish/v1/Chassis/System.Embedded.1/Thermal", thermal);
+
+        CollectRep.MetricsData.Builder builder = collectMetrics(metrics);
+
+        assertEquals(1, builder.getValuesCount());
+        assertEquals("System Board Fan1A", builder.getValues(0).getColumns(1));
+        assertEquals("Enabled", builder.getValues(0).getColumns(2));
+        assertEquals(CommonConstants.NULL_VALUE, builder.getValues(0).getColumns(4));
+        assertEquals("3480", builder.getValues(0).getColumns(5));
+    }
+
+    @Test
+    void collectFallsBackPerChassis() throws Exception {
+        Metrics metrics = metrics("Fan", "$.['@odata.id']", "$.Name");
+        String modernFanUri = "/redfish/v1/Chassis/Modern/ThermalSubsystem/Fans/1";
+        String legacyThermal = """
+                {
+                    "Fans": [
+                        {
+                            "@odata.id": "/redfish/v1/Chassis/Legacy/Thermal#/Fans/0",
+                            "Name": "Legacy Fan"
+                        }
+                    ]
+                }""";
+        givenResource("/redfish/v1/Chassis/",
+                collection("/redfish/v1/Chassis/Modern", "/redfish/v1/Chassis/Legacy"));
+        givenResource("/redfish/v1/Chassis/Modern/ThermalSubsystem/Fans", collection(modernFanUri));
+        givenUnavailable("/redfish/v1/Chassis/Legacy/ThermalSubsystem/Fans");
+        givenUnavailable("/redfish/v1/Chassis/Modern/Thermal");
+        givenResource("/redfish/v1/Chassis/Legacy/Thermal", legacyThermal);
+        givenResource(modernFanUri, resource(modernFanUri, "Modern Fan"));
+
+        CollectRep.MetricsData.Builder builder = collectMetrics(metrics);
+
+        assertEquals(2, builder.getValuesCount());
+        assertEquals("Modern Fan", builder.getValues(0).getColumns(1));
+        assertEquals("Legacy Fan", builder.getValues(1).getColumns(1));
+    }
+
+    @Test
+    void authFailureIsReportedInsteadOfMissingSchema() throws Exception {
+        Metrics metrics = metrics("Fan", "$.Name");
+        Mockito.when(redfishConnectSession.getRedfishResource(anyString()))
+                .thenThrow(new Exception("Redfish session get resource error:StatusCode 401"));
+
+        CollectRep.MetricsData.Builder builder = collectMetrics(metrics);
+
+        assertEquals(CollectRep.Code.FAIL, builder.getCode());
+        assertTrue(builder.getMsg().contains("401"));
+    }
+
+    @Test
+    void preCheck() {
         assertThrows(IllegalArgumentException.class, () -> redfishCollect.preCheck(null));
 
-        // protocol is null
         assertThrows(IllegalArgumentException.class, () -> {
             Metrics metrics = Metrics.builder().build();
             redfishCollect.preCheck(metrics);

--- a/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/redfish/RedfishConnectSessionTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/redfish/RedfishConnectSessionTest.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.collector.collect.redfish;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link RedfishConnectSession}
+ */
+public class RedfishConnectSessionTest {
+
+    private static final String SESSION_LOCATION = "/redfish/v1/SessionService/Sessions/1";
+
+    private HttpServer server;
+
+    private int responseStatus = HttpStatus.SC_OK;
+
+    private final List<String> receivedRequests = new CopyOnWriteArrayList<>();
+
+    @BeforeEach
+    void startServer() throws Exception {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            receivedRequests.add(exchange.getRequestMethod() + " " + exchange.getRequestURI().getPath());
+            if (responseStatus == HttpStatus.SC_NO_CONTENT) {
+                exchange.sendResponseHeaders(HttpStatus.SC_NO_CONTENT, -1);
+                exchange.close();
+                return;
+            }
+            byte[] body = "{\"Id\":\"1\"}".getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(responseStatus, body.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(body);
+            }
+        });
+        server.start();
+    }
+
+    @AfterEach
+    void stopServer() {
+        server.stop(0);
+    }
+
+    private RedfishConnectSession session() {
+        return session(SESSION_LOCATION);
+    }
+
+    private RedfishConnectSession session(String location) {
+        return new RedfishConnectSession(
+                new Session("token", location, "http://127.0.0.1", server.getAddress().getPort()));
+    }
+
+    @Test
+    void closeDeletesSessionAtItsLocation() throws Exception {
+        RedfishConnectSession connectSession = session();
+
+        connectSession.close();
+
+        assertEquals(List.of("DELETE " + SESSION_LOCATION), receivedRequests);
+        assertFalse(connectSession.isOpen());
+    }
+
+    @Test
+    void closeAcceptsNoContentResponse() throws Exception {
+        responseStatus = HttpStatus.SC_NO_CONTENT;
+
+        session().close();
+
+        assertEquals(List.of("DELETE " + SESSION_LOCATION), receivedRequests);
+    }
+
+    @Test
+    void closeAcceptsAcceptedResponse() throws Exception {
+        responseStatus = HttpStatus.SC_ACCEPTED;
+
+        session().close();
+
+        assertEquals(List.of("DELETE " + SESSION_LOCATION), receivedRequests);
+    }
+
+    @Test
+    void closeAcceptsSameOriginAbsoluteLocation() throws Exception {
+        String location = "http://127.0.0.1:" + server.getAddress().getPort() + SESSION_LOCATION;
+
+        session(location).close();
+
+        assertEquals(List.of("DELETE " + SESSION_LOCATION), receivedRequests);
+    }
+
+    @Test
+    void closeRejectsCrossOriginLocation() {
+        RedfishConnectSession connectSession = session("https://example.com" + SESSION_LOCATION);
+
+        IllegalArgumentException error = assertThrows(IllegalArgumentException.class, connectSession::close);
+
+        assertTrue(error.getMessage().contains("monitored endpoint"));
+        assertTrue(receivedRequests.isEmpty());
+    }
+
+    @Test
+    void getRedfishResourceRequestsGivenUri() throws Exception {
+        String resource = session().getRedfishResource("/redfish/v1/Chassis/1U/");
+
+        assertEquals("{\"Id\":\"1\"}", resource);
+        assertEquals(List.of("GET /redfish/v1/Chassis/1U"), receivedRequests);
+    }
+
+    @Test
+    void getRedfishResourceRejectsSchemeDowngrade() {
+        String uri = "https://127.0.0.1:" + server.getAddress().getPort() + "/redfish/v1/Chassis/1U";
+
+        IllegalArgumentException error = assertThrows(
+                IllegalArgumentException.class, () -> session().getRedfishResource(uri));
+
+        assertTrue(error.getMessage().contains("monitored endpoint"));
+        assertTrue(receivedRequests.isEmpty());
+    }
+}

--- a/hertzbeat-collector/hertzbeat-collector-common/src/main/java/org/apache/hertzbeat/collector/util/JsonPathParser.java
+++ b/hertzbeat-collector/hertzbeat-collector-common/src/main/java/org/apache/hertzbeat/collector/util/JsonPathParser.java
@@ -78,6 +78,20 @@ public final class JsonPathParser {
     }
 
     /**
+     * use json path to parse content, missing paths yield an empty list instead of throwing
+     * @param content json content
+     * @param jsonPath jsonPath
+     * @return matched values, empty list when the path does not exist in the content
+     */
+    public static List<Object> parseContentWithOptionalJsonPath(String content, String jsonPath) {
+        if (StringUtils.isAnyEmpty(content, jsonPath)) {
+            return Collections.emptyList();
+        }
+        List<Object> values = ROW_PARSER.parse(content).read(jsonPath);
+        return values == null ? Collections.emptyList() : values;
+    }
+
+    /**
      * use json path to parse one already-parsed row object, missing paths yield an empty list
      * @param document parsed json object of a single row
      * @param jsonPath jsonPath relative to the row root


### PR DESCRIPTION
Part of #3210

Fan and PowerSupply collection fails on older Dell iDRAC firmware with `StatusCode 404`, and cached Redfish sessions are not released.

Newer Redfish schemas expose fans and power supplies as standalone collections, while older iDRAC firmware embeds them in `Thermal` and `Power`; the collector only probes the newer paths. Session cleanup also resolves the server-provided `Location` against the session service path, producing an invalid DELETE target.

Probe modern and legacy layouts per chassis, resolve embedded `#` JSON Pointer members from their containing document, reuse fetched documents, and map legacy fan `Reading` to RPM. Session requests now resolve relative and same-origin absolute resource URIs, reject cross-origin or downgraded targets before attaching `X-Auth-Token`, and accept every Redfish DELETE success status.

Boundary: the session-creation `405` still needs HTTP Basic Auth fallback, and no verified pre-2020.4 Battery resource is available.

Validation uses a temporary Docker HTTP service seeded with the user-reported legacy iDRAC payload; hardware validation is still pending.

```text
Before
ERROR ... ThermalSubsystem/Fans ... StatusCode 404
fan rows = 0
session release: FAILED - Redfish session close error:null

After
FAN_ROWS=[[/redfish/v1/Chassis/Modern/ThermalSubsystem/Fans/1, Modern Fan, Enabled, OK, &nbsp;, 7200], [/redfish/v1/Chassis/Legacy/Thermal#/Fans/0, Legacy Fan, Enabled, OK, &nbsp;, 3480]]
POWER_ROWS=[[/redfish/v1/Chassis/Modern/PowerSubsystem/PowerSupplies/1, Modern Power Supply, Enabled, OK], [/redfish/v1/Chassis/Legacy/Power#/PowerSupplies/0, Legacy Power Supply, Enabled, OK]]
sessionActive=false
DELETE /redfish/v1/SessionService/Sessions/1 HTTP/1.1 202
```
