### PR TITLE
docs: fix malformed links and images

### DIFF
--- a/hip/TEMPLATE.md
+++ b/hip/TEMPLATE.md
@@ -7,7 +7,7 @@ PROPOSAL HEALTH CHECK
 I can read the design document and understand the problem statement and what you plan to change *without* resorting to a couple of hours of code reading just to start having a high level understanding of the change.
 
 IMAGES
-If you need diagrams, avoid attaching large files. You can use [MermaidJS]([url](https://mermaid.js.org/)) as a simple language to describe many types of diagrams.
+If you need diagrams, avoid attaching large files. You can use [MermaidJS](https://mermaid.js.org/) as a simple language to describe many types of diagrams.
 
 THIS COMMENTS
 Please remove them when done.

--- a/home/blog/2023-05-11-greptimedb-store.md
+++ b/home/blog/2023-05-11-greptimedb-store.md
@@ -76,7 +76,7 @@ See the [official documentation](https://hertzbeat.apache.org/zh-cn/docs/start/d
 
    - `-v /opt/application.yml:/opt/hertzbeat/config/application.yml` : Mount customized local configuration files to the container, i.e. use local configuration files to overwrite the container configuration files.
 
-    Note that the ⚠️ local mount configuration file `application.yml` needs to exist in advance, and the full contents of the file can be found in the project repository [/script/application.yml]([https://github.com/apache/hertzbeat/raw/master/script/](https://github.com/apache/hertzbeat/raw/master/script/) application.yml)
+    Note that the ⚠️ local mount configuration file `application.yml` needs to exist in advance, and the full contents of the file can be found in the project repository [/script/application.yml](https://github.com/apache/hertzbeat/raw/master/script/application.yml)
 
 2. Go to [http://ip:1157/](http://ip:1157/) with the default account and password admin/hertzbeat to see if HertzBeat starts successfully.
 
@@ -84,7 +84,7 @@ See the [official documentation](https://hertzbeat.apache.org/zh-cn/docs/start/d
 
 1. Modify the HertzBeat configuration file.
 
-    Modify the locally mounted HertzBeat configuration file [application.yml](https://github.com/apache/hertzbeat/raw/master/script/application.yml), in package mode modify `hertzbeat/ config/application.yml
+    Modify the locally mounted HertzBeat configuration file [application.yml](https://github.com/apache/hertzbeat/raw/master/script/application.yml), in package mode modify `hertzbeat/config/application.yml`
 
     **Modify the `warehouse.store.jpa.enabled` parameter in there to `false`, configure the `warehouse.store.greptime` datasource parameter in there, the URL account password, and enable `enabled` to `true`**.
 

--- a/home/blog/2023-08-28-new-committer.md
+++ b/home/blog/2023-08-28-new-committer.md
@@ -10,7 +10,7 @@ cover_headline: Welcome New Committer
 cover_kicker: New Committer
 ---
 
-! [hertzBeat](/img/blog/new-committer.png)
+![hertzBeat](/img/blog/new-committer.png)
 
 It's great to welcome a new community `Committer`, unlike other contributors `logicz` comes from an Ops implementation position at Cyberoam rather than a development position, but the quality of the contributions, both in terms of code and documentation etc. is very high 👍.  
 This is also our `HertzBeat` and other open source projects are not the same place, because the user group is more oriented to the operation and maintenance of the development, in our 139 contributors in the operation and maintenance engineers accounted for more than 30%, which breaks the open source project collaboration and contribution to the object are the inherent cognition of the development position, which shows that whether it is the operation and maintenance engineers and test engineers to contribute to the open source project participation is very enthusiastic!  

--- a/home/blog/2024-01-11-new-committer.md
+++ b/home/blog/2024-01-11-new-committer.md
@@ -10,7 +10,7 @@ cover_headline: Welcome New Committer
 cover_kicker: New Committer
 ---
 
-! [hertzBeat](/img/blog/new-committer.png)
+![hertzBeat](/img/blog/new-committer.png)
 
 > Welcome to HertzBeat's three new community committeers, let's learn more about their open source experience!
 

--- a/home/blog/2024-08-18-new-committer.md
+++ b/home/blog/2024-08-18-new-committer.md
@@ -66,15 +66,15 @@ Open source is often pure, and the Apache Foundation exists to protect projects 
 
 #### Apache Community Identity
 
-Before contributing to the community, it is important to understand the community's definition of identity, where a project's Committers are located, and how to become a Committer. The Apache community has a clear definition of [Contributor Identity]([https://community.apache.org/contributor-ladder](https://community.apache.org/contributor-ladder). html): [Contributor Identity]([https://community.apache.org/contributor-ladder](https://community.apache.org/contributor-ladder). html). The Apache community has a very clear definition of [contributor status](. html):
+Before contributing to the community, it is important to understand the community's definition of identity, where a project's Committers are located, and how to become a Committer. The Apache community has a clear definition of [Contributor Identity](https://community.apache.org/contributor-ladder.html):
 
-! [Apache contributor label](/img/blog/committer/yuluo-yx/6.jpg)
+![Apache contributor label](/img/blog/committer/yuluo-yx/6.jpg)
 
 #### Project Committer Nomination Criteria
 
 The conditions for a Project PPMC Team to nominate a Committer are different. Take Apache HertzBeat™ for example:
 
-! [Apache HertzBeat™ becoming committer](/img/blog/committer/yuluo-yx/7.jpg)
+![Apache HertzBeat™ becoming committer](/img/blog/committer/yuluo-yx/7.jpg)
 
 Each project has its own standards, and these standards are not set in stone and will be adjusted at each stage of the project.
 


### PR DESCRIPTION
Malformed Markdown in the HIP template and older blog posts leaves links unclickable, images rendered as text, and one configuration path with an unterminated code span.

Spaces between image markers and labels, nested link syntax, and a missing closing backtick prevent Markdown parsers from recognizing the intended elements.

Correct the affected links, image markers, and code span. The corrupted contributor-ladder sentence is reduced to its single intended link.

### User-visible difference

Without this change, readers see an exclamation mark and linked alt text where the banner should appear; malformed external links either point to corrupted destinations or are not recognized as links; and the configuration path has a broken inline-code boundary.

With this change, the intended images render, the Mermaid and Apache contributor links open their real documentation pages, and only the configuration path is formatted as inline code.

### Before

The banner is reduced to the visible text `! hertzBeat`.

![Before: the New Committer banner appears as an exclamation mark and text link](https://raw.githubusercontent.com/orangeCatDeveloper/hertzbeat/3e7fdf9afbf80970119f177d370cac7f4e180b94/.pr-assets/broken-markdown-before.png)

### After

The New Committer banner renders as an image.

![After: the New Committer banner renders correctly](https://raw.githubusercontent.com/orangeCatDeveloper/hertzbeat/3e7fdf9afbf80970119f177d370cac7f4e180b94/.pr-assets/broken-markdown-after.png)