### PR TITLE
fix(collector): use Redis username for ACL authentication instead of client name

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/redis/RedisCommonCollectImpl.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/main/java/org/apache/hertzbeat/collector/collect/redis/RedisCommonCollectImpl.java
@@ -305,12 +305,13 @@ public class RedisCommonCollectImpl extends AbstractCollect {
         return RedisClient.create(defaultClientResources, redisUri(redisProtocol, host, port));
     }
 
-    private RedisURI redisUri(RedisProtocol redisProtocol, String host, String port) {
+    RedisURI redisUri(RedisProtocol redisProtocol, String host, String port) {
         RedisURI.Builder redisUriBuilder = RedisURI.builder().withHost(host).withPort(Integer.parseInt(port));
         if (StringUtils.hasText(redisProtocol.getUsername())) {
-            redisUriBuilder.withClientName(redisProtocol.getUsername());
-        }
-        if (StringUtils.hasText(redisProtocol.getPassword())) {
+            // An ACL user without a password still authenticates with AUTH <username> "".
+            char[] password = redisProtocol.getPassword() == null ? new char[0] : redisProtocol.getPassword().toCharArray();
+            redisUriBuilder.withAuthentication(redisProtocol.getUsername(), password);
+        } else if (StringUtils.hasText(redisProtocol.getPassword())) {
             redisUriBuilder.withPassword(redisProtocol.getPassword().toCharArray());
         }
         Duration timeout = Duration.ofMillis(CollectUtil.getTimeout(redisProtocol.getTimeout()));

--- a/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/redis/RedisCommonCollectImplTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/redis/RedisCommonCollectImplTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.collector.collect.redis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import io.lettuce.core.RedisURI;
+import org.apache.hertzbeat.common.entity.job.protocol.RedisProtocol;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link RedisCommonCollectImpl}
+ */
+class RedisCommonCollectImplTest {
+
+    @Test
+    void redisUriShouldUseUsernameForAuthentication() {
+        RedisProtocol protocol = new RedisProtocol();
+        protocol.setUsername("monitor");
+        protocol.setPassword("secret");
+
+        RedisCommonCollectImpl collect = new RedisCommonCollectImpl();
+        RedisURI uri = collect.redisUri(protocol, "127.0.0.1", "6379");
+
+        assertEquals("monitor", uri.getUsername());
+        assertEquals("secret", new String(uri.getPassword()));
+        assertNull(uri.getClientName());
+    }
+
+    @Test
+    void redisUriShouldUsePasswordOnlyWithoutUsername() {
+        RedisProtocol protocol = new RedisProtocol();
+        protocol.setPassword("secret");
+
+        RedisCommonCollectImpl collect = new RedisCommonCollectImpl();
+        RedisURI uri = collect.redisUri(protocol, "127.0.0.1", "6379");
+
+        assertNull(uri.getUsername());
+        assertEquals("secret", new String(uri.getPassword()));
+        assertNull(uri.getClientName());
+    }
+}


### PR DESCRIPTION
## What's changed

The Redis collector passed the configured `username` to `RedisURI.Builder.withClientName`, which only sets the informational `CLIENT SETNAME` sent after connecting and plays no role in authentication (lettuce 6.8.2 resolves the username exclusively from `RedisURI` credentials).

As a result, with a Redis 6+ ACL user (e.g. `ACL SETUSER monitor on >secretpass ~* +@read`) and a monitor configured with `username=monitor`, `password=secretpass` (both exposed by `app-redis.yml`), lettuce authenticated as the `default` user and the collection failed with `WRONGPASS`/`NOAUTH` — the username setting never worked.

Fix: use `withAuthentication(username, password)` so the username and password are applied as credentials. An ACL user without a password authenticates with an empty one (`AUTH <username> ""`); password-only configuration keeps the previous `withPassword` behavior.

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] I have added unit tests for the change (`RedisCommonCollectImplTest` — the module previously had no Redis collector tests).
- [x] All tests pass locally (`mvn -pl hertzbeat-collector/hertzbeat-collector-basic -am test`: 273 tests, 0 failures).

---

**Verification**

- fail-before: `redisUriShouldUseUsernameForAuthentication` fails on master — `expected: <monitor> but was: <null>` (`RedisURI.getUsername()` is null because the username went to `CLIENT NAME`)
- pass-after: both new tests pass; full module suite passes (273 tests, 0 failures, 4 pre-existing skips)
- Verified against lettuce-core 6.8.2.RELEASE (the version resolved by the build): `withClientName` sets only the client name, `withAuthentication(String, char[])` sets the credentials used for `AUTH`

**AI assistance disclosure**: the bug analysis, fix and tests in this PR were prepared with the help of an AI coding agent, and were verified locally by the author as described above.