### PR TITLE
fix(alerter): fall back to default repeat interval when group rule was deleted

### DIFF
--- a/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/reduce/AlarmGroupReduce.java
+++ b/hertzbeat-alerter/src/main/java/org/apache/hertzbeat/alert/reduce/AlarmGroupReduce.java
@@ -291,7 +291,9 @@ public class AlarmGroupReduce implements DisposableBean {
         // For firing alerts, check repeat interval
         if (CommonConstants.ALERT_STATUS_FIRING.equals(status)) {
             AlertGroupConverge ruleConfig = groupDefines.get(cache.getGroupDefineName());
-            long repeatInterval = ruleConfig.getRepeatInterval() != null
+            // The rule may have been deleted, renamed or disabled while this group cache
+            // still holds firing alerts; fall back to the default interval like shouldSendGroup.
+            long repeatInterval = ruleConfig != null && ruleConfig.getRepeatInterval() != null
                     ? ruleConfig.getRepeatInterval() * MS_PER_SECOND : DEFAULT_REPEAT_INTERVAL;
 
             // Skip if within repeat interval. The throttle only suppresses repeated firing

--- a/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/reduce/AlarmGroupReduceTest.java
+++ b/hertzbeat-alerter/src/test/java/org/apache/hertzbeat/alert/reduce/AlarmGroupReduceTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.lang.reflect.Field;
 import org.apache.hertzbeat.alert.dao.AlertGroupConvergeDao;
 import org.apache.hertzbeat.common.config.VirtualThreadProperties;
 import org.apache.hertzbeat.common.entity.alerter.AlertGroupConverge;
@@ -210,6 +211,37 @@ class AlarmGroupReduceTest {
         assertTrue(groups.stream().anyMatch(g -> g.getAlerts().stream().anyMatch(
                         a -> "mem".equals(a.getFingerprint()) && "resolved".equals(a.getStatus()))),
                 "memory recovery was silently dropped by the firing repeat-interval throttle");
+    }
+
+    /**
+     * Regression: deleting (or renaming/disabling) a converge rule while its group cache still
+     * holds a firing alert must not break the periodic group dispatch with an NPE. The orphaned
+     * group has to fall back to the default repeat interval, like shouldSendGroup already does
+     * for the group wait/interval.
+     */
+    @Test
+    void whenRuleDeleted_firingGroupCacheMustStillBeDispatched() throws Exception {
+        alarmGroupReduce.refreshGroupDefines(Collections.singletonList(groupRule()));
+
+        alarmGroupReduce.processGroupAlert(alert("cpu", "firing", "host1"));
+
+        // The rule is deleted or disabled; refresh loads only enabled rules, orphaning the cache.
+        alarmGroupReduce.refreshGroupDefines(Collections.emptyList());
+
+        // Age the cache past the default group wait so the periodic check picks the group up.
+        Field cachesField = AlarmGroupReduce.class.getDeclaredField("groupCacheMap");
+        cachesField.setAccessible(true);
+        Map<?, ?> caches = (Map<?, ?>) cachesField.get(alarmGroupReduce);
+        for (Object cache : caches.values()) {
+            Field createTimeField = cache.getClass().getDeclaredField("createTime");
+            createTimeField.setAccessible(true);
+            createTimeField.setLong(cache, System.currentTimeMillis() - 60_000);
+        }
+
+        alarmGroupReduce.runCheckAndSendGroups();
+
+        verify(alarmInhibitReduce, atLeastOnce()).inhibitAlarm(argThat(group ->
+                group.getAlerts().stream().anyMatch(a -> "cpu".equals(a.getFingerprint()))));
     }
 
     private AlertGroupConverge groupRule() {


### PR DESCRIPTION
## What's changed

When a converge rule is deleted, renamed or disabled while its group cache still holds firing alerts, `AlarmGroupReduce.sendGroupAlert` looks up the rule and dereferences it without a null check (`hertzbeat-alerter/.../AlarmGroupReduce.java:294`):

```java
AlertGroupConverge ruleConfig = groupDefines.get(cache.getGroupDefineName());
long repeatInterval = ruleConfig.getRepeatInterval() != null ...
```

`refreshGroupDefines` clears and reloads only enabled rules (called on every rule add/update/delete from `AlertGroupConvergeServiceImpl`), but entries in `groupCacheMap` keep their `groupDefineName`, so the lookup returns null for an orphaned group.

Impact is worse than a one-off NPE: `runCheckAndSendGroups` iterates `groupCacheMap.forEach` and the NPE aborts the whole iteration each cycle (caught at the loop level), so **every group ordered after the orphaned one stops receiving converged alerts, permanently, on every 1-second check cycle** until restart.

The sibling method `shouldSendGroup` in the same file already null-checks the identical lookup for `groupWait`/`groupInterval` and falls back to defaults; this PR applies the same fallback to `repeatInterval`.

## Checklist

- [x] I have read the [Contributing Guidelines](CONTRIBUTING.md).
- [x] I have added a unit test for the change (`whenRuleDeleted_firingGroupCacheMustStillBeDispatched` in `AlarmGroupReduceTest`).
- [x] All tests pass locally (`mvn -pl hertzbeat-alerter -am test`: 474 tests, 0 failures).

---

**Verification**

- fail-before: the new test fails on master — the dispatch is aborted by
  `java.lang.NullPointerException: Cannot invoke "AlertGroupConverge.getRepeatInterval()" because "ruleConfig" is null` at `AlarmGroupReduce.java:294`, logged by `runCheckAndSendGroups`' catch, and `inhibitAlarm` is never invoked for the orphaned group
- pass-after: the orphaned firing group is dispatched with the default repeat interval; all 7 `AlarmGroupReduceTest` tests and the full alerter module suite pass (474 tests, 0 failures, 2 pre-existing skips)

**AI assistance disclosure**: the bug analysis, fix and test in this PR were prepared with the help of an AI coding agent, and were verified locally by the author as described above.