### PR TITLE
fix(common): parse +Inf/-Inf as real infinity in StrBuffer.parseDouble

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/prometheus/parser/OnlineParserTest.java
+++ b/hertzbeat-collector/hertzbeat-collector-basic/src/test/java/org/apache/hertzbeat/collector/collect/prometheus/parser/OnlineParserTest.java
@@ -108,11 +108,8 @@ class OnlineParserTest {
             MetricFamily metricFamily1 = metricFamilyMap1.get(metricFamilyName);
             Set<Double> metricValueSet = metricFamily2.getMetricList().stream().map(MetricFamily.Metric::getValue).collect(Collectors.toSet());
             metricFamily1.getMetricList().forEach(metric -> {
-                // this is for something different between two algorithms above, and both of them is current on this parsing behavior.
-                if (!(metric.getValue() == Double.POSITIVE_INFINITY || metric.getValue() == Double.NEGATIVE_INFINITY)) {
-                    if (!metricValueSet.contains(metric.getValue())) {
-                        fail();
-                    }
+                if (!metricValueSet.contains(metric.getValue())) {
+                    fail();
                 }
             });
         });

--- a/hertzbeat-common-core/src/main/java/org/apache/hertzbeat/common/util/StrBuffer.java
+++ b/hertzbeat-common-core/src/main/java/org/apache/hertzbeat/common/util/StrBuffer.java
@@ -153,9 +153,9 @@ public class StrBuffer {
      */
     public static double parseDouble(String s) {
         if (POSITIVE_INF.equalsIgnoreCase(s)) {
-            return POSITIVE_INF_VALUE;
+            return Double.POSITIVE_INFINITY;
         } else if (NEGATIVE_INF.equalsIgnoreCase(s)) {
-            return NEGATIVE_INF_VALUE;
+            return Double.NEGATIVE_INFINITY;
         }
         return Double.parseDouble(s);
     }

--- a/hertzbeat-common-core/src/test/java/org/apache/hertzbeat/common/util/StrBufferTest.java
+++ b/hertzbeat-common-core/src/test/java/org/apache/hertzbeat/common/util/StrBufferTest.java
@@ -91,10 +91,10 @@ class StrBufferTest {
         assertEquals(123.45, buffer.toDouble());
 
         buffer = new StrBuffer("+inf");
-        assertEquals(POSITIVE_INF_VALUE, buffer.toDouble());
+        assertEquals(Double.POSITIVE_INFINITY, buffer.toDouble());
 
         buffer = new StrBuffer("-inf");
-        assertEquals(NEGATIVE_INF_VALUE, buffer.toDouble());
+        assertEquals(Double.NEGATIVE_INFINITY, buffer.toDouble());
     }
 
     @Test
@@ -144,8 +144,8 @@ class StrBufferTest {
     void testParseDouble() {
 
         assertEquals(123.45, StrBuffer.parseDouble("123.45"));
-        assertEquals(POSITIVE_INF_VALUE, StrBuffer.parseDouble("+inf"));
-        assertEquals(NEGATIVE_INF_VALUE, StrBuffer.parseDouble("-inf"));
+        assertEquals(Double.POSITIVE_INFINITY, StrBuffer.parseDouble("+inf"));
+        assertEquals(Double.NEGATIVE_INFINITY, StrBuffer.parseDouble("-inf"));
     }
 
 }


### PR DESCRIPTION
## What's changed?

`StrBuffer.parseDouble("+inf"/"-inf")` returned the raw IEEE-754 bit-pattern constants `0x7FF0000000000000L` / `0xFFF0000000000000L` **widened to `double`** — i.e. `9.218868437227405E18` and `-4.503599627370496E15` — instead of real infinities. Those constants are the bit patterns of ±Infinity and are only meaningful through `Double.longBitsToDouble`; returning them as plain numbers contradicts the javadoc intent ("We need to determine if it's INF") and the Prometheus text exposition format, which allows `+Inf`/`-Inf`/`NaN` as sample values.

`OnlineParser.toDouble` — the parser the collectors actually use — already maps these spellings to `Double.POSITIVE_INFINITY` / `Double.NEGATIVE_INFINITY`. This PR aligns `StrBuffer.parseDouble` (used by `TextParser` via `toDouble`) with that behavior.

Impact honesty note: `TextParser` is currently only referenced from `OnlineParserTest` (the collectors go through `OnlineParser`), so no live monitor data is affected today. This corrects the public `hertzbeat-common-core` utility and its only consumer, and removes a test workaround that papered over the divergence.

Changes:
- `StrBuffer.parseDouble`: return `Double.POSITIVE_INFINITY` / `Double.NEGATIVE_INFINITY` for `+inf` / `-inf` (case-insensitive matching unchanged; `NaN` already worked via `Double.parseDouble`).
- `StrBufferTest`: assert real infinities — the previous assertions encoded the widened bit patterns, i.e. they pinned the buggy behavior.
- `OnlineParserTest.parseMetrics2`: drop the ±Inf exclusion in the OnlineParser-vs-TextParser value cross-check. Both parsers now agree, and the existing fixture (`go_gc_duration_seconds` quantiles containing `-Inf`, `+Inf`, `NaN`) verifies it end-to-end.

`StrBuffer.parseLong` is deliberately untouched: it has no callers and `long` has no infinity representation, so any change there would be speculative.

## Verification (JDK 25, `./mvnw`)

- **fail-before** (only test changes applied, fix stashed):
  - `StrBufferTest.testToDouble` / `testParseDouble`: `expected: <Infinity> but was: <9.218868437227405E18>`
  - `OnlineParserTest.parseMetrics2`: fails at the un-skipped cross-check (OnlineParser's `+Inf` value missing from TextParser's value set)
- **pass-after**: `./mvnw -pl hertzbeat-common-core,hertzbeat-collector/hertzbeat-collector-basic -am test` → BUILD SUCCESS; `StrBufferTest` 10/10, `OnlineParserTest` 17 run / 0 failures, 133 test groups green across the reactor.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.

---

> [!NOTE]
> This PR was created with AI assistance (autonomous agent). All findings were personally verified against snmp4j/lettuce/repo sources before making changes; fail-before/pass-after evidence is quoted verbatim above. Happy to adjust or split the test-only changes if preferred.
