### PR TITLE
[fix] add missing ntfy default notice template

### DIFF
--- a/hertzbeat-manager/src/main/resources/templates/15-NtfyTemplate.txt
+++ b/hertzbeat-manager/src/main/resources/templates/15-NtfyTemplate.txt
@@ -1,0 +1,47 @@
+## 🔔 HertzBeat Alert Notification
+
+### Alert Summary
+> - Status: ${status}
+<#if commonLabels??>
+<#if commonLabels.severity??>
+> - Severity: ${commonLabels.severity?switch("critical", "❤️ Critical", "warning", "💛 Warning", "info", "💚 Info", "Unknown")}
+</#if>
+<#if commonLabels.alertname??>
+> - Alert Name: ${commonLabels.alertname}
+</#if>
+</#if>
+
+### Alert Details
+<#list alerts as alert>
+#### Alert ${alert?index + 1}
+<#if alert.labels??>
+<#list alert.labels?keys as key>
+> - ${key}: ${alert.labels[key]}
+</#list>
+</#if>
+<#if alert.content?? && alert.content != "">
+> - Content: ${alert.content}
+</#if>
+> - Trigger Count: ${alert.triggerTimes}
+> - Start Time: ${(alert.startAt?number_to_datetime)?string('yyyy-MM-dd HH:mm:ss')}
+<#if alert.activeAt??>
+> - Active Time: ${(alert.activeAt?number_to_datetime)?string('yyyy-MM-dd HH:mm:ss')}
+</#if>
+<#if alert.endAt??>
+> - End Time: ${(alert.endAt?number_to_datetime)?string('yyyy-MM-dd HH:mm:ss')}
+</#if>
+
+<#if alert.annotations?? && alert.annotations?size gt 0>
+##### Additional Information
+<#list alert.annotations?keys as key>
+> - ${key}: ${alert.annotations[key]}
+</#list>
+</#if>
+</#list>
+
+<#if commonAnnotations?? && commonAnnotations?size gt 0>
+### Common Information
+<#list commonAnnotations?keys as key>
+> - ${key}: ${commonAnnotations[key]}
+</#list>
+</#if>

--- a/hertzbeat-manager/src/test/java/org/apache/hertzbeat/manager/service/PresetNoticeTemplateCoverageTest.java
+++ b/hertzbeat-manager/src/test/java/org/apache/hertzbeat/manager/service/PresetNoticeTemplateCoverageTest.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hertzbeat.manager.service;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.hertzbeat.alert.notice.AlertNotifyHandler;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Test case for the preset notice template resources shipped in this module.
+ * The templates live here while the loader and the notify handlers live in the alerter module,
+ * so this is the only place where both sides are on the same classpath.
+ */
+class PresetNoticeTemplateCoverageTest {
+
+    /**
+     * Same location and suffixes that NoticeConfigServiceImpl scans on startup.
+     */
+    private static final String TEMPLATE_LOCATION = "classpath:templates/*.*";
+
+    private static final String HANDLER_PACKAGE = "org.apache.hertzbeat.alert.notice.impl";
+
+    /**
+     * Sms notifications render their own message, so AlertNoticeDispatch skips the template lookup for them.
+     */
+    private static final byte SMS_TYPE = 0;
+
+    @Test
+    void everyRegisteredNotifyHandlerHasPresetTemplate() throws IOException {
+        Set<Byte> presetTypes = loadPresetTemplateTypes();
+        Map<Byte, String> registeredHandlers = loadRegisteredHandlers();
+
+        assertFalse(registeredHandlers.isEmpty(), "No notify handler was discovered, the scan is broken");
+
+        List<String> missing = new ArrayList<>();
+        registeredHandlers.forEach((type, handlerName) -> {
+            if (type != SMS_TYPE && !presetTypes.contains(type)) {
+                missing.add(handlerName + "(type=" + type + ")");
+            }
+        });
+
+        // AlertNoticeDispatch throws a NullPointerException and drops the notice when a receiver
+        // is not bound to a template and the handler type has no preset template to fall back on.
+        assertTrue(missing.isEmpty(),
+                "Notify handlers without a preset notice template in resources/templates: " + missing);
+    }
+
+    private Set<Byte> loadPresetTemplateTypes() throws IOException {
+        Set<Byte> types = new HashSet<>(16);
+        Resource[] resources = new PathMatchingResourcePatternResolver().getResources(TEMPLATE_LOCATION);
+        for (Resource resource : resources) {
+            String filename = resource.getFilename();
+            if (filename == null || (!filename.endsWith("txt") && !filename.endsWith("html"))) {
+                continue;
+            }
+            String[] names = filename.replace(".txt", "").replace(".html", "").split("-");
+            if (names.length != 2) {
+                continue;
+            }
+            types.add(Byte.parseByte(names[0]));
+        }
+        return types;
+    }
+
+    private Map<Byte, String> loadRegisteredHandlers() {
+        Map<Byte, String> handlers = new HashMap<>(16);
+        ClassPathScanningCandidateComponentProvider scanner = new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AssignableTypeFilter(AlertNotifyHandler.class));
+        for (BeanDefinition definition : scanner.findCandidateComponents(HANDLER_PACKAGE)) {
+            Class<?> handlerClass;
+            try {
+                handlerClass = Class.forName(definition.getBeanClassName());
+            } catch (ClassNotFoundException e) {
+                throw new IllegalStateException(e);
+            }
+            // Only handlers that Spring actually registers reach AlertNoticeDispatch
+            if (!handlerClass.isAnnotationPresent(Component.class)) {
+                continue;
+            }
+            // type() returns a constant, so a mock calling real methods reports it without wiring the dependencies
+            AlertNotifyHandler handler = (AlertNotifyHandler) mock(handlerClass,
+                    withSettings().defaultAnswer(CALLS_REAL_METHODS));
+            handlers.put(handler.type(), handlerClass.getSimpleName());
+        }
+        return handlers;
+    }
+}


### PR DESCRIPTION
## What's changed?

`NtfyAlertNotifyHandlerImpl` declares `type() == 15`, but `resources/templates/` has no `15-*` file. `NoticeConfigServiceImpl` builds `PRESET_TEMPLATE` by scanning that directory, so `getDefaultNoticeTemplateByType((byte) 15)` returns null and `AlertNoticeDispatch#sendNoticeMsg` throws `NullPointerException` for every ntfy receiver that is not bound to a custom template — the notification is dropped. The "send test message" button fails the same way, since it also passes a null template.

Regression from #4132, which added the channel without its preset template.

- Add `15-NtfyTemplate.txt`, identical to the other markdown channels (the handler already sends `Markdown: yes`).
- Add `PresetNoticeTemplateCoverageTest` asserting the general invariant: every `@Component` `AlertNotifyHandler` other than SMS (which `AlertNoticeDispatch` exempts) has a preset template. It lives in `hertzbeat-manager` because that is the only module where both the template resources and the handler classes are on the same classpath. Verified it fails with `[NtfyAlertNotifyHandlerImpl(type=15)]` when the new template is removed.

`WeChatAlertNotifyHandlerImpl` (type 3) also has no template, but it carries no `@Component` and is never registered, so it is out of scope here and excluded by the test.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
