### PR TITLE
[fix] sync sureness.yml in release artifacts with the packaged rules

### DIFF
--- a/script/docker-compose/hertzbeat-mysql-iotdb/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-mysql-iotdb/conf/sureness.yml
@@ -66,6 +66,10 @@ resourceRole:
   - /api/collector/**===post===[admin,user]
   - /api/collector/**===put===[admin,user]
   - /api/collector/**===delete===[admin]
+  - /api/plugin/**===get===[admin]
+  - /api/plugin/**===post===[admin]
+  - /api/plugin/**===put===[admin]
+  - /api/plugin/**===delete===[admin]
   # the secret config holds the jwt signing key and the aes key protecting stored
   # credentials, so it stays admin only and is additionally refused by the controller
   - /api/config/secret===get===[admin]
@@ -117,6 +121,9 @@ resourceRole:
   - /api/logs/ingest/**===post===[admin,user]
   - /api/observability/logs===delete===[admin]
   - /api/observability/**===get===[admin,user,guest]
+  - /api/account/token===get===[admin]
+  - /api/account/token/**===post===[admin]
+  - /api/account/token/**===delete===[admin]
   # The OpenAPI document is a map of every route, parameter and model, so it is
   # scoped like any other administrative resource instead of being anonymous
   - /v3/api-docs/**===get===[admin]
@@ -151,6 +158,9 @@ excludedResource:
   - /passport/**===get
   - /status/**===get
   - /log/**===get
+  - /observability/**===get
+  - /metrics/**===get
+  - /trace/**===get
   - /**/*.html===get
   - /**/*.js===get
   - /**/*.css===get

--- a/script/docker-compose/hertzbeat-mysql-tdengine/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-mysql-tdengine/conf/sureness.yml
@@ -66,6 +66,10 @@ resourceRole:
   - /api/collector/**===post===[admin,user]
   - /api/collector/**===put===[admin,user]
   - /api/collector/**===delete===[admin]
+  - /api/plugin/**===get===[admin]
+  - /api/plugin/**===post===[admin]
+  - /api/plugin/**===put===[admin]
+  - /api/plugin/**===delete===[admin]
   # the secret config holds the jwt signing key and the aes key protecting stored
   # credentials, so it stays admin only and is additionally refused by the controller
   - /api/config/secret===get===[admin]
@@ -117,6 +121,9 @@ resourceRole:
   - /api/logs/ingest/**===post===[admin,user]
   - /api/observability/logs===delete===[admin]
   - /api/observability/**===get===[admin,user,guest]
+  - /api/account/token===get===[admin]
+  - /api/account/token/**===post===[admin]
+  - /api/account/token/**===delete===[admin]
   # The OpenAPI document is a map of every route, parameter and model, so it is
   # scoped like any other administrative resource instead of being anonymous
   - /v3/api-docs/**===get===[admin]
@@ -151,6 +158,9 @@ excludedResource:
   - /passport/**===get
   - /status/**===get
   - /log/**===get
+  - /observability/**===get
+  - /metrics/**===get
+  - /trace/**===get
   - /**/*.html===get
   - /**/*.js===get
   - /**/*.css===get

--- a/script/docker-compose/hertzbeat-mysql-victoria-metrics/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-mysql-victoria-metrics/conf/sureness.yml
@@ -66,6 +66,10 @@ resourceRole:
   - /api/collector/**===post===[admin,user]
   - /api/collector/**===put===[admin,user]
   - /api/collector/**===delete===[admin]
+  - /api/plugin/**===get===[admin]
+  - /api/plugin/**===post===[admin]
+  - /api/plugin/**===put===[admin]
+  - /api/plugin/**===delete===[admin]
   # the secret config holds the jwt signing key and the aes key protecting stored
   # credentials, so it stays admin only and is additionally refused by the controller
   - /api/config/secret===get===[admin]
@@ -117,6 +121,9 @@ resourceRole:
   - /api/logs/ingest/**===post===[admin,user]
   - /api/observability/logs===delete===[admin]
   - /api/observability/**===get===[admin,user,guest]
+  - /api/account/token===get===[admin]
+  - /api/account/token/**===post===[admin]
+  - /api/account/token/**===delete===[admin]
   # The OpenAPI document is a map of every route, parameter and model, so it is
   # scoped like any other administrative resource instead of being anonymous
   - /v3/api-docs/**===get===[admin]
@@ -151,6 +158,9 @@ excludedResource:
   - /passport/**===get
   - /status/**===get
   - /log/**===get
+  - /observability/**===get
+  - /metrics/**===get
+  - /trace/**===get
   - /**/*.html===get
   - /**/*.js===get
   - /**/*.css===get

--- a/script/docker-compose/hertzbeat-postgresql-greptimedb/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-postgresql-greptimedb/conf/sureness.yml
@@ -66,6 +66,10 @@ resourceRole:
   - /api/collector/**===post===[admin,user]
   - /api/collector/**===put===[admin,user]
   - /api/collector/**===delete===[admin]
+  - /api/plugin/**===get===[admin]
+  - /api/plugin/**===post===[admin]
+  - /api/plugin/**===put===[admin]
+  - /api/plugin/**===delete===[admin]
   # the secret config holds the jwt signing key and the aes key protecting stored
   # credentials, so it stays admin only and is additionally refused by the controller
   - /api/config/secret===get===[admin]
@@ -117,6 +121,9 @@ resourceRole:
   - /api/logs/ingest/**===post===[admin,user]
   - /api/observability/logs===delete===[admin]
   - /api/observability/**===get===[admin,user,guest]
+  - /api/account/token===get===[admin]
+  - /api/account/token/**===post===[admin]
+  - /api/account/token/**===delete===[admin]
   # The OpenAPI document is a map of every route, parameter and model, so it is
   # scoped like any other administrative resource instead of being anonymous
   - /v3/api-docs/**===get===[admin]

--- a/script/docker-compose/hertzbeat-postgresql-victoria-metrics/conf/sureness.yml
+++ b/script/docker-compose/hertzbeat-postgresql-victoria-metrics/conf/sureness.yml
@@ -66,6 +66,10 @@ resourceRole:
   - /api/collector/**===post===[admin,user]
   - /api/collector/**===put===[admin,user]
   - /api/collector/**===delete===[admin]
+  - /api/plugin/**===get===[admin]
+  - /api/plugin/**===post===[admin]
+  - /api/plugin/**===put===[admin]
+  - /api/plugin/**===delete===[admin]
   # the secret config holds the jwt signing key and the aes key protecting stored
   # credentials, so it stays admin only and is additionally refused by the controller
   - /api/config/secret===get===[admin]
@@ -117,6 +121,9 @@ resourceRole:
   - /api/logs/ingest/**===post===[admin,user]
   - /api/observability/logs===delete===[admin]
   - /api/observability/**===get===[admin,user,guest]
+  - /api/account/token===get===[admin]
+  - /api/account/token/**===post===[admin]
+  - /api/account/token/**===delete===[admin]
   # The OpenAPI document is a map of every route, parameter and model, so it is
   # scoped like any other administrative resource instead of being anonymous
   - /v3/api-docs/**===get===[admin]
@@ -151,6 +158,9 @@ excludedResource:
   - /passport/**===get
   - /status/**===get
   - /log/**===get
+  - /observability/**===get
+  - /metrics/**===get
+  - /trace/**===get
   - /**/*.html===get
   - /**/*.js===get
   - /**/*.css===get

--- a/script/sureness.yml
+++ b/script/sureness.yml
@@ -66,6 +66,10 @@ resourceRole:
   - /api/collector/**===post===[admin,user]
   - /api/collector/**===put===[admin,user]
   - /api/collector/**===delete===[admin]
+  - /api/plugin/**===get===[admin]
+  - /api/plugin/**===post===[admin]
+  - /api/plugin/**===put===[admin]
+  - /api/plugin/**===delete===[admin]
   # the secret config holds the jwt signing key and the aes key protecting stored
   # credentials, so it stays admin only and is additionally refused by the controller
   - /api/config/secret===get===[admin]
@@ -117,6 +121,9 @@ resourceRole:
   - /api/logs/ingest/**===post===[admin,user]
   - /api/observability/logs===delete===[admin]
   - /api/observability/**===get===[admin,user,guest]
+  - /api/account/token===get===[admin]
+  - /api/account/token/**===post===[admin]
+  - /api/account/token/**===delete===[admin]
   # The OpenAPI document is a map of every route, parameter and model, so it is
   # scoped like any other administrative resource instead of being anonymous
   - /v3/api-docs/**===get===[admin]


### PR DESCRIPTION
## What's changed?

#4257 and #4271 added the `/api/plugin/**` and `/api/account/token*` admin rules to `hertzbeat-startup/src/main/resources/sureness.yml`, but the six copies we actually ship were never updated:

- `script/sureness.yml` — the file `docs/start/docker-deploy.md` tells `docker run` users to download and mount over the one in the image.
- `conf/sureness.yml` in all five Docker Compose variants — compose mounts it as `./conf/sureness.yml:/opt/hertzbeat/config/sureness.yml`, overriding the image copy.

Sureness lets a path with no matching rule through for any authenticated role, so on both of those deployments **guest can still upload plugins and issue or revoke API tokens** — the two fixes above never took effect on the released artifacts. Four of the compose copies were also missing the `/observability/**`, `/metrics/**` and `/trace/**` static-resource exclusions.

This PR aligns all six copies with `hertzbeat-startup/src/main/resources/sureness.yml`; they now `diff` clean against it. Those omissions were the only differences — the `sureness.auths` account section is unchanged.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.
