### PR TITLE
[doc] add Redis Sentinel and Apache Kvrocks monitoring help documentation

### DIFF
--- a/home/docs/help/kvrocks.md
+++ b/home/docs/help/kvrocks.md
@@ -1,0 +1,146 @@
+---
+id: kvrocks
+title: Monitoring Apache Kvrocks
+sidebar_label: Kvrocks
+keywords: [ open source monitoring tool, open source Kvrocks monitoring tool, monitoring Kvrocks metrics ]
+---
+
+> Collect and monitor the general performance metrics of Apache Kvrocks database. Support Apache Kvrocks 2.9.0+.
+
+## Configuration parameter
+
+| Parameter name | Parameter help description |
+|---|---|
+| Target Host | The IP, IPV6, or domain name of the monitored endpoint. Note ⚠️: Do not include protocol headers (eg: https://, http://). |
+| Port | The port provided by Apache Kvrocks, default value is 6666. |
+| Timeout(ms) | Set the timeout time when Kvrocks info query does not respond to data, unit: ms, default: 3000ms. |
+| Username | Database connection username, optional. |
+| Password | Database connection password, optional. |
+
+### Collection Metric
+
+#### Metric set：server
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| kvrocks_version | none | kvrocks_version |
+| redis_version | none | redis_version |
+| git_sha1 | none | git_sha1 |
+| kvrocks_mode | none | kvrocks_mode |
+| os | none | os |
+| arch_bits | none | arch_bits |
+| multiplexing_api | none | multiplexing_api |
+| atomicvar_api | none | atomicvar_api |
+| gcc_version | none | gcc_version |
+| process_id | none | process_id |
+| tcp_port | none | tcp_port |
+| server_time_usec | none | server_time_usec |
+| uptime_in_seconds | none | uptime_in_seconds |
+| uptime_in_days | none | uptime_in_days |
+| hz | none | hz |
+| configured_hz | none | configured_hz |
+| lru_clock | none | lru_clock |
+| executable | none | executable |
+| config_file | none | config_file |
+| io_threads_active | none | io_threads_active |
+
+#### Metric set：clients
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| connected_clients | none | connected_clients |
+| maxclients | none | maxclients |
+| blocked_clients | none | blocked_clients |
+| monitor_clients | none | monitor_clients |
+
+#### Metric set：memory
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| used_memory_rss | none | used_memory_rss |
+| used_memory_rss_human | MB | used_memory_rss_human |
+| used_memory_lua | none | used_memory_lua |
+| used_memory_lua_human | KB | used_memory_lua_human |
+| used_memory_startup | none | used_memory_startup |
+
+#### Metric set：persistence
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| loading | none | loading |
+| bgsave_in_progress | none | bgsave_in_progress |
+| last_bgsave_time | none | last_bgsave_time |
+| last_bgsave_status | none | last_bgsave_status |
+| last_bgsave_time_sec | none | last_bgsave_time_sec |
+
+#### Metric set：stats
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| total_connections_received | none | total_connections_received |
+| total_commands_processed | none | total_commands_processed |
+| instantaneous_ops_per_sec | none | instantaneous_ops_per_sec |
+| total_net_input_bytes | none | total_net_input_bytes |
+| total_net_output_bytes | none | total_net_output_bytes |
+| instantaneous_input_kbps | none | instantaneous_input_kbps |
+| instantaneous_output_kbps | none | instantaneous_output_kbps |
+| sync_full | none | sync_full |
+| sync_partial_ok | none | sync_partial_ok |
+| sync_partial_err | none | sync_partial_err |
+| pubsub_channels | none | pubsub_channels |
+| pubsub_patterns | none | pubsub_patterns |
+
+#### Metric set：replication
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| role | none | role |
+| connected_slaves | none | connected_slaves |
+| master_repl_offset | none | master_repl_offset |
+
+#### Metric set：cpu
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| used_cpu_sys | none | used_cpu_sys |
+| used_cpu_user | none | used_cpu_user |
+
+#### Metric set：Commandstats
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| cmdstat_command | none | cmdstat_command |
+| cmdstat_info | none | cmdstat_info |
+
+#### Metric set：cluster
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| cluster_enabled | none | cluster_enabled |
+
+#### Metric set：commandstats
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| cmdstat_client | none | cmdstat_client |
+| cmdstat_config | none | cmdstat_config |
+| cmdstat_get | none | cmdstat_get |
+| cmdstat_hello | none | cmdstat_hello |
+| cmdstat_info | none | cmdstat_info |
+| cmdstat_keys | none | cmdstat_keys |
+| cmdstat_ping | none | cmdstat_ping |
+| cmdstat_select | none | cmdstat_select |
+| cmdstat_set | none | cmdstat_set |
+
+#### Metric set：keyspace
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| db0 | none | db0 |
+| sequence | none | sequence |
+| used_db_size | none | used_db_size |
+| max_db_size | none | max_db_size |
+| used_percent | none | used_percent |
+| disk_capacity | none | disk_capacity |
+| used_disk_size | none | used_disk_size |
+| used_disk_percent | none | used_disk_percent |

--- a/home/docs/help/redis_sentinel.md
+++ b/home/docs/help/redis_sentinel.md
@@ -1,0 +1,137 @@
+---
+id: redis_sentinel
+title: Monitoring Redis Sentinel
+sidebar_label: Redis Sentinel
+keywords: [ open source monitoring tool, open source Redis Sentinel monitoring tool, monitoring Redis Sentinel metrics ]
+---
+
+> Collect and monitor the general performance metrics of Redis Sentinel. Support Redis 2.8+.
+
+## Configuration parameter
+
+| Parameter name | Parameter help description |
+|---|---|
+| Target Host | The IP, IPV6, or domain name of the monitored endpoint. Note ⚠️: Do not include protocol headers (eg: https://, http://). |
+| Port | The port provided by Redis Sentinel, default value is 26379. |
+| Query Timeout(ms) | Set the timeout time when Sentinel query does not respond to data, unit: ms, default: 3000ms. |
+| Username | Connection user name, optional. |
+| Password | Connection password, optional. |
+| Pattern | Regular expression pattern for filtering Redis Sentinel info output, optional. |
+| Enable SSH Tunnel | Whether to enable SSH tunneling to access Sentinel behind a firewall, default: false. |
+| SSH Host | SSH Tunnel host IP or domain name. |
+| SSH Port | SSH Tunnel port, default: 22. |
+| SSH Timeout(ms) | SSH connection timeout in milliseconds, default: 60000ms. |
+| SSH Username | SSH Tunnel login username. |
+| SSH Password | SSH Tunnel login password. |
+| Share SSH Connection | Whether to share SSH connection across requests. |
+| SSH PrivateKey | SSH private key content (RSA/DSA/ED25519) if using key authentication. |
+| SSH PrivateKey PassPhrase | Passphrase for encrypted SSH private key. |
+
+### Collection Metric
+
+#### Metric set：server
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| identity | none | identity |
+| redis_version | none | redis_version |
+| redis_git_sha1 | none | redis_git_sha1 |
+| redis_git_dirty | none | redis_git_dirty |
+| redis_build_id | none | redis_build_id |
+| redis_mode | none | redis_mode |
+| os | none | os |
+| arch_bits | none | arch_bits |
+| multiplexing_api | none | multiplexing_api |
+| atomicvar_api | none | atomicvar_api |
+| gcc_version | none | gcc_version |
+| process_id | none | process_id |
+| process_supervised | none | process_supervised |
+| run_id | none | run_id |
+| tcp_port | none | tcp_port |
+| server_time_usec | none | server_time_usec |
+| uptime_in_seconds | none | uptime_in_seconds |
+| uptime_in_days | none | uptime_in_days |
+| hz | none | hz |
+| configured_hz | none | configured_hz |
+| lru_clock | none | lru_clock |
+| executable | none | executable |
+| config_file | none | config_file |
+| io_threads_active | none | io_threads_active |
+
+#### Metric set：clients
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| connected_clients | none | connected_clients |
+| cluster_connections | none | cluster_connections |
+| maxclients | none | maxclients |
+| client_recent_max_input_buffer | none | client_recent_max_input_buffer |
+| client_recent_max_output_buffer | none | client_recent_max_output_buffer |
+| blocked_clients | none | blocked_clients |
+| tracking_clients | none | tracking_clients |
+| clients_in_timeout_table | none | clients_in_timeout_table |
+
+#### Metric set：stats
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| total_connections_received | none | total_connections_received |
+| total_commands_processed | none | total_commands_processed |
+| instantaneous_ops_per_sec | none | instantaneous_ops_per_sec |
+| total_net_input_bytes | none | total_net_input_bytes |
+| total_net_output_bytes | none | total_net_output_bytes |
+| instantaneous_input_kbps | none | instantaneous_input_kbps |
+| instantaneous_output_kbps | none | instantaneous_output_kbps |
+| rejected_connections | none | rejected_connections |
+| sync_full | none | sync_full |
+| sync_partial_ok | none | sync_partial_ok |
+| sync_partial_err | none | sync_partial_err |
+| expired_keys | none | expired_keys |
+| expired_stale_perc | none | expired_stale_perc |
+| expired_time_cap_reached_count | none | expired_time_cap_reached_count |
+| expire_cycle_cpu_milliseconds | none | expire_cycle_cpu_milliseconds |
+| evicted_keys | none | evicted_keys |
+| keyspace_hits | none | keyspace_hits |
+| keyspace_misses | none | keyspace_misses |
+| pubsub_channels | none | pubsub_channels |
+| pubsub_patterns | none | pubsub_patterns |
+| latest_fork_usec | none | latest_fork_usec |
+| total_forks | none | total_forks |
+| migrate_cached_sockets | none | migrate_cached_sockets |
+| slave_expires_tracked_keys | none | slave_expires_tracked_keys |
+| active_defrag_hits | none | active_defrag_hits |
+| active_defrag_misses | none | active_defrag_misses |
+| active_defrag_key_hits | none | active_defrag_key_hits |
+| active_defrag_key_misses | none | active_defrag_key_misses |
+| tracking_total_keys | none | tracking_total_keys |
+| tracking_total_items | none | tracking_total_items |
+| tracking_total_prefixes | none | tracking_total_prefixes |
+| unexpected_error_replies | none | unexpected_error_replies |
+| total_error_replies | none | total_error_replies |
+| dump_payload_sanitizations | none | dump_payload_sanitizations |
+| total_reads_processed | none | total_reads_processed |
+| total_writes_processed | none | total_writes_processed |
+| io_threaded_reads_processed | none | io_threaded_reads_processed |
+| io_threaded_writes_processed | none | io_threaded_writes_processed |
+
+#### Metric set：cpu
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| used_cpu_sys | none | used_cpu_sys |
+| used_cpu_user | none | used_cpu_user |
+| used_cpu_sys_children | none | used_cpu_sys_children |
+| used_cpu_user_children | none | used_cpu_user_children |
+| used_cpu_sys_main_thread | none | used_cpu_sys_main_thread |
+| used_cpu_user_main_thread | none | used_cpu_user_main_thread |
+
+#### Metric set：sentinel
+
+| Metric name | Metric unit | Metric help description |
+|---|---|---|
+| sentinel_masters | none | sentinel_masters |
+| sentinel_tilt | none | sentinel_tilt |
+| sentinel_running_scripts | none | sentinel_running_scripts |
+| sentinel_timedout_scripts | none | sentinel_timedout_scripts |
+| sentinel_scripts_queue_length | none | sentinel_scripts_queue_length |
+| sentinel_simulate_failure_flags | none | sentinel_simulate_failure_flags |

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/kvrocks.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/kvrocks.md
@@ -1,0 +1,146 @@
+---
+id: kvrocks
+title: 监控：Kvrocks 数据库监控
+sidebar_label: Kvrocks 数据库
+keywords: [开源监控系统, 开源数据库监控, Kvrocks数据库监控]
+---
+
+> 对 Apache Kvrocks 数据库的通用性能指标进行采集监控。支持 Apache Kvrocks 2.9.0+。
+
+## 配置参数
+
+| 参数名称 | 参数帮助描述 |
+|---|---|
+| 目标Host | 被监控的对端IPV4，IPV6或域名。注意⚠️不带协议头(eg: https://, http://)。 |
+| 端口 | Apache Kvrocks 对外提供的端口，默认值为 6666。 |
+| 超时时间(ms) | 设置 Kvrocks info 查询未响应数据时的超时时间，单位ms毫秒，默认 3000 毫秒。 |
+| 用户名 | 数据库连接用户名，可选。 |
+| 密码 | 数据库连接密码，可选。 |
+
+### 采集指标
+
+#### 指标集合：server
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| kvrocks_version | 无 | kvrocks_version |
+| redis_version | 无 | redis_version |
+| git_sha1 | 无 | git_sha1 |
+| kvrocks_mode | 无 | kvrocks_mode |
+| os | 无 | os |
+| arch_bits | 无 | arch_bits |
+| multiplexing_api | 无 | multiplexing_api |
+| atomicvar_api | 无 | atomicvar_api |
+| gcc_version | 无 | gcc_version |
+| process_id | 无 | process_id |
+| tcp_port | 无 | tcp_port |
+| server_time_usec | 无 | server_time_usec |
+| uptime_in_seconds | 无 | uptime_in_seconds |
+| uptime_in_days | 无 | uptime_in_days |
+| hz | 无 | hz |
+| configured_hz | 无 | configured_hz |
+| lru_clock | 无 | lru_clock |
+| executable | 无 | executable |
+| config_file | 无 | config_file |
+| io_threads_active | 无 | io_threads_active |
+
+#### 指标集合：clients
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| connected_clients | 无 | connected_clients |
+| maxclients | 无 | maxclients |
+| blocked_clients | 无 | blocked_clients |
+| monitor_clients | 无 | monitor_clients |
+
+#### 指标集合：memory
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| used_memory_rss | 无 | used_memory_rss |
+| used_memory_rss_human | MB | used_memory_rss_human |
+| used_memory_lua | 无 | used_memory_lua |
+| used_memory_lua_human | KB | used_memory_lua_human |
+| used_memory_startup | 无 | used_memory_startup |
+
+#### 指标集合：persistence
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| loading | 无 | loading |
+| bgsave_in_progress | 无 | bgsave_in_progress |
+| last_bgsave_time | 无 | last_bgsave_time |
+| last_bgsave_status | 无 | last_bgsave_status |
+| last_bgsave_time_sec | 无 | last_bgsave_time_sec |
+
+#### 指标集合：stats
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| total_connections_received | 无 | total_connections_received |
+| total_commands_processed | 无 | total_commands_processed |
+| instantaneous_ops_per_sec | 无 | instantaneous_ops_per_sec |
+| total_net_input_bytes | 无 | total_net_input_bytes |
+| total_net_output_bytes | 无 | total_net_output_bytes |
+| instantaneous_input_kbps | 无 | instantaneous_input_kbps |
+| instantaneous_output_kbps | 无 | instantaneous_output_kbps |
+| sync_full | 无 | sync_full |
+| sync_partial_ok | 无 | sync_partial_ok |
+| sync_partial_err | 无 | sync_partial_err |
+| pubsub_channels | 无 | pubsub_channels |
+| pubsub_patterns | 无 | pubsub_patterns |
+
+#### 指标集合：replication
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| role | 无 | role |
+| connected_slaves | 无 | connected_slaves |
+| master_repl_offset | 无 | master_repl_offset |
+
+#### 指标集合：cpu
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| used_cpu_sys | 无 | used_cpu_sys |
+| used_cpu_user | 无 | used_cpu_user |
+
+#### 指标集合：Commandstats
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| cmdstat_command | 无 | cmdstat_command |
+| cmdstat_info | 无 | cmdstat_info |
+
+#### 指标集合：cluster
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| cluster_enabled | 无 | cluster_enabled |
+
+#### 指标集合：commandstats
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| cmdstat_client | 无 | cmdstat_client |
+| cmdstat_config | 无 | cmdstat_config |
+| cmdstat_get | 无 | cmdstat_get |
+| cmdstat_hello | 无 | cmdstat_hello |
+| cmdstat_info | 无 | cmdstat_info |
+| cmdstat_keys | 无 | cmdstat_keys |
+| cmdstat_ping | 无 | cmdstat_ping |
+| cmdstat_select | 无 | cmdstat_select |
+| cmdstat_set | 无 | cmdstat_set |
+
+#### 指标集合：keyspace
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| db0 | 无 | db0 |
+| sequence | 无 | sequence |
+| used_db_size | 无 | used_db_size |
+| max_db_size | 无 | max_db_size |
+| used_percent | 无 | used_percent |
+| disk_capacity | 无 | disk_capacity |
+| used_disk_size | 无 | used_disk_size |
+| used_disk_percent | 无 | used_disk_percent |

--- a/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/redis_sentinel.md
+++ b/home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/redis_sentinel.md
@@ -1,0 +1,137 @@
+---
+id: redis_sentinel
+title: 监控：Redis Sentinel监控
+sidebar_label: Redis Sentinel
+keywords: [开源监控系统, 开源数据库监控, Redis Sentinel监控]
+---
+
+> 对 Redis Sentinel 的通用性能指标进行采集监控。支持 Redis 2.8+。
+
+## 配置参数
+
+| 参数名称 | 参数帮助描述 |
+|---|---|
+| 目标Host | 被监控的对端IPV4，IPV6或域名。注意⚠️不带协议头(eg: https://, http://)。 |
+| 端口 | Redis Sentinel 对外提供的端口，默认值为26379。 |
+| 查询超时时间(ms) | 设置 Sentinel info 查询未响应数据时的超时时间，单位ms毫秒，默认3000毫秒。 |
+| 用户名 | 连接用户名，可选。 |
+| 密码 | 连接密码，可选。 |
+| Pattern | 匹配过滤 Redis Sentinel info 输出的正则表达式，可选。 |
+| 启用 SSH 隧道 | 是否通过 SSH 隧道访问处于私网或防火墙后的 Sentinel 节点，默认 false。 |
+| SSH 主机 | SSH 隧道的主机 IP 或域名。 |
+| SSH 端口 | SSH 隧道的连接端口，默认为 22。 |
+| SSH 超时时间(ms) | SSH 连接超时时间，单位毫秒，默认 60000 毫秒。 |
+| SSH 用户名 | SSH 隧道的登录用户名。 |
+| SSH 密码 | SSH 隧道的登录密码。 |
+| 共享 SSH 连接 | 是否在多个监控指标采集之间共享 SSH 连接会话。 |
+| SSH 私钥 | 使用密钥对认证时的 SSH 私钥内容（RSA/DSA/ED25519）。 |
+| SSH 私钥密码 | 加密私钥的解密口令。 |
+
+### 采集指标
+
+#### 指标集合：server
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| identity | 无 | identity |
+| redis_version | 无 | redis_version |
+| redis_git_sha1 | 无 | redis_git_sha1 |
+| redis_git_dirty | 无 | redis_git_dirty |
+| redis_build_id | 无 | redis_build_id |
+| redis_mode | 无 | redis_mode |
+| os | 无 | os |
+| arch_bits | 无 | arch_bits |
+| multiplexing_api | 无 | multiplexing_api |
+| atomicvar_api | 无 | atomicvar_api |
+| gcc_version | 无 | gcc_version |
+| process_id | 无 | process_id |
+| process_supervised | 无 | process_supervised |
+| run_id | 无 | run_id |
+| tcp_port | 无 | tcp_port |
+| server_time_usec | 无 | server_time_usec |
+| uptime_in_seconds | 无 | uptime_in_seconds |
+| uptime_in_days | 无 | uptime_in_days |
+| hz | 无 | hz |
+| configured_hz | 无 | configured_hz |
+| lru_clock | 无 | lru_clock |
+| executable | 无 | executable |
+| config_file | 无 | config_file |
+| io_threads_active | 无 | io_threads_active |
+
+#### 指标集合：clients
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| connected_clients | 无 | connected_clients |
+| cluster_connections | 无 | cluster_connections |
+| maxclients | 无 | maxclients |
+| client_recent_max_input_buffer | 无 | client_recent_max_input_buffer |
+| client_recent_max_output_buffer | 无 | client_recent_max_output_buffer |
+| blocked_clients | 无 | blocked_clients |
+| tracking_clients | 无 | tracking_clients |
+| clients_in_timeout_table | 无 | clients_in_timeout_table |
+
+#### 指标集合：stats
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| total_connections_received | 无 | total_connections_received |
+| total_commands_processed | 无 | total_commands_processed |
+| instantaneous_ops_per_sec | 无 | instantaneous_ops_per_sec |
+| total_net_input_bytes | 无 | total_net_input_bytes |
+| total_net_output_bytes | 无 | total_net_output_bytes |
+| instantaneous_input_kbps | 无 | instantaneous_input_kbps |
+| instantaneous_output_kbps | 无 | instantaneous_output_kbps |
+| rejected_connections | 无 | rejected_connections |
+| sync_full | 无 | sync_full |
+| sync_partial_ok | 无 | sync_partial_ok |
+| sync_partial_err | 无 | sync_partial_err |
+| expired_keys | 无 | expired_keys |
+| expired_stale_perc | 无 | expired_stale_perc |
+| expired_time_cap_reached_count | 无 | expired_time_cap_reached_count |
+| expire_cycle_cpu_milliseconds | 无 | expire_cycle_cpu_milliseconds |
+| evicted_keys | 无 | evicted_keys |
+| keyspace_hits | 无 | keyspace_hits |
+| keyspace_misses | 无 | keyspace_misses |
+| pubsub_channels | 无 | pubsub_channels |
+| pubsub_patterns | 无 | pubsub_patterns |
+| latest_fork_usec | 无 | latest_fork_usec |
+| total_forks | 无 | total_forks |
+| migrate_cached_sockets | 无 | migrate_cached_sockets |
+| slave_expires_tracked_keys | 无 | slave_expires_tracked_keys |
+| active_defrag_hits | 无 | active_defrag_hits |
+| active_defrag_misses | 无 | active_defrag_misses |
+| active_defrag_key_hits | 无 | active_defrag_key_hits |
+| active_defrag_key_misses | 无 | active_defrag_key_misses |
+| tracking_total_keys | 无 | tracking_total_keys |
+| tracking_total_items | 无 | tracking_total_items |
+| tracking_total_prefixes | 无 | tracking_total_prefixes |
+| unexpected_error_replies | 无 | unexpected_error_replies |
+| total_error_replies | 无 | total_error_replies |
+| dump_payload_sanitizations | 无 | dump_payload_sanitizations |
+| total_reads_processed | 无 | total_reads_processed |
+| total_writes_processed | 无 | total_writes_processed |
+| io_threaded_reads_processed | 无 | io_threaded_reads_processed |
+| io_threaded_writes_processed | 无 | io_threaded_writes_processed |
+
+#### 指标集合：cpu
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| used_cpu_sys | 无 | used_cpu_sys |
+| used_cpu_user | 无 | used_cpu_user |
+| used_cpu_sys_children | 无 | used_cpu_sys_children |
+| used_cpu_user_children | 无 | used_cpu_user_children |
+| used_cpu_sys_main_thread | 无 | used_cpu_sys_main_thread |
+| used_cpu_user_main_thread | 无 | used_cpu_user_main_thread |
+
+#### 指标集合：sentinel
+
+| 指标名称 | 指标单位 | 指标帮助描述 |
+|---|---|---|
+| sentinel_masters | 无 | sentinel_masters |
+| sentinel_tilt | 无 | sentinel_tilt |
+| sentinel_running_scripts | 无 | sentinel_running_scripts |
+| sentinel_timedout_scripts | 无 | sentinel_timedout_scripts |
+| sentinel_scripts_queue_length | 无 | sentinel_scripts_queue_length |
+| sentinel_simulate_failure_flags | 无 | sentinel_simulate_failure_flags |

--- a/home/sidebars.json
+++ b/home/sidebars.json
@@ -200,7 +200,13 @@
         {
           "type": "category",
           "label": "cache",
-          "items": ["help/redis", "help/memcached", "help/valkey"]
+          "items": [
+            "help/redis",
+            "help/redis_sentinel",
+            "help/kvrocks",
+            "help/memcached",
+            "help/valkey"
+          ]
         },
         {
           "type": "category",


### PR DESCRIPTION
## What's changed?

- Added user help documentation for **Redis Sentinel** monitoring in both English (`home/docs/help/redis_sentinel.md`) and Chinese (`home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/redis_sentinel.md`), detailing configuration parameters, SSH tunnel parameters, and metrics sets (`server`, `clients`, `stats`, `cpu`, `sentinel`).
- Added user help documentation for **Apache Kvrocks** monitoring in both English (`home/docs/help/kvrocks.md`) and Chinese (`home/i18n/zh-cn/docusaurus-plugin-content-docs/current/help/kvrocks.md`), detailing configuration parameters and metrics sets (`server`, `clients`, `memory`, `persistence`, `stats`, `replication`, `cpu`, `cluster`, `commandstats`, `keyspace`).
- Updated `home/sidebars.json` under the `cache` category to register `help/redis_sentinel` and `help/kvrocks`, eliminating 404 links from the monitoring console help buttons.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [ ]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary [e2e tests](https://github.com/apache/hertzbeat/tree/master/e2e) and all cases have passed.


fixes #4370 