### PR TITLE
[fix] drop macOS from native collector matrix and unstick upgrade doc assertion

### DIFF
--- a/.github/workflows/collector-native-build.yml
+++ b/.github/workflows/collector-native-build.yml
@@ -39,12 +39,6 @@ jobs:
           - platform: linux-arm64
             runner: ubuntu-24.04-arm
             archive_ext: tar.gz
-          - platform: macos-amd64
-            runner: macos-13
-            archive_ext: tar.gz
-          - platform: macos-arm64
-            runner: macos-14
-            archive_ext: tar.gz
           - platform: windows-amd64
             runner: windows-latest
             archive_ext: zip

--- a/hertzbeat-startup/src/test/java/org/apache/hertzbeat/startup/EntityFreeObservabilityTransitionContractTest.java
+++ b/hertzbeat-startup/src/test/java/org/apache/hertzbeat/startup/EntityFreeObservabilityTransitionContractTest.java
@@ -233,7 +233,7 @@ class EntityFreeObservabilityTransitionContractTest {
             String content = Files.readString(REPOSITORY_ROOT.resolve(relativePath));
             assertTrue(content.contains("`POST /api/logs/otlp/v1/logs` | `POST /api/otlp/v1/logs`"), relativePath);
             assertTrue(content.contains("`GET /api/logs/list` | `GET /api/observability/logs`"), relativePath);
-            assertTrue(content.contains("`GET /api/traces/**` | `GET /api/observability/traces/**`"), relativePath);
+            assertFalse(content.contains("`GET /api/traces/**`"), relativePath);
         }
 
         String logService = Files.readString(REPOSITORY_ROOT.resolve("web-app/src/app/service/log.service.ts"));


### PR DESCRIPTION
## What's changed?

Two fixes for the 1.9.0 release build.

**1. Drop macOS from the native collector release matrix**

`Collector Native Release` fails on macOS. On run [34308128208](https://github.com/apache/hertzbeat/actions/runs/34308128208):

| platform | runner | spec | result |
|---|---|---|---|
| linux-amd64 | ubuntu-24.04 | 4c / 16G | ✅ 8m56s |
| linux-arm64 | ubuntu-24.04-arm | 4c / 16G | ✅ 7m51s |
| windows-amd64 | windows-latest | 4c / 16G | ✅ 11m17s |
| macos-arm64 | macos-14 | 3c / 7G | ❌ aborted after 66m |
| macos-amd64 | macos-13 | — | ⏳ never scheduled |

The macos-arm64 builder gets only 5.68GB of heap:

GC warning: 2358.4s spent in 246 GCs during the last stage, taking up 74.27% of the time.
            Please ensure more than 3.20GB of memory is available for Native Image
=== Used heap size: 5944 / Maximum heap size: 5944
=== Image generator watchdog is aborting image generation.
Error: ... failed with exit status 30

The image has 46,955 reachable types; 7GB standard runners cannot build it, and GitHub offers no larger free macOS runner. This removes both macOS matrix entries so the workflow produces the three platforms it can actually build.

The `native-platform-macos-*` profiles and assembly descriptors are untouched, so `mvn clean package -pl hertzbeat-collector/hertzbeat-collector-collector -am -Pnative` still produces a macOS package when run on a macOS host.

**2. Unstick a stale assertion in `EntityFreeObservabilityTransitionContractTest`**

The test required the upgrade guide to contain a `GET /api/traces/**` → `GET /api/observability/traces/**` migration row, which f859f1a removed. The removal was correct: the 1.8.0 tree contains no trace sources at all (no ingestion route, no query API, no traces page), so that row described a migration that never existed. The assertion is inverted to `assertFalse` so the bogus row cannot be reintroduced.

## Checklist

- [x]  I have read the [Contributing Guide](https://hertzbeat.apache.org/docs/community/code_style_and_quality_guide)
- [x]  I have written the necessary doc or comment.
- [x]  I have added the necessary unit tests and all cases have passed.

## Add or update API

- [ ] I have added the necessary e2e tests and all cases have passed.