### PR TITLE
[bugfix] preserve special characters in promql queries

### DIFF
--- a/hertzbeat-warehouse/src/main/java/org/apache/hertzbeat/warehouse/db/PromqlQueryExecutor.java
+++ b/hertzbeat-warehouse/src/main/java/org/apache/hertzbeat/warehouse/db/PromqlQueryExecutor.java
@@ -57,6 +57,7 @@ public abstract class PromqlQueryExecutor implements QueryExecutor {
     private static final String QUERY_RANGE_PATH = "/api/v1/query_range";
     private static final String QUERY_PATH = "/api/v1/query";
     protected static final String HTTP_QUERY_PARAM = "query";
+    private static final String QUERY_TEMPLATE = "{query}";
     protected static final String HTTP_TIME_PARAM = "time";
     protected static final String HTTP_START_PARAM = "start";
     protected static final String HTTP_END_PARAM = "end";
@@ -99,8 +100,8 @@ public abstract class PromqlQueryExecutor implements QueryExecutor {
             HttpEntity<Void> httpEntity = new HttpEntity<>(headers);
 
             UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(httpPromqlProperties.url + QUERY_PATH);
-            uriComponentsBuilder.queryParam(HTTP_QUERY_PARAM, queryString);
-            URI uri = uriComponentsBuilder.build().toUri();
+            uriComponentsBuilder.queryParam(HTTP_QUERY_PARAM, QUERY_TEMPLATE);
+            URI uri = uriComponentsBuilder.encode().buildAndExpand(queryString).toUri();
             ResponseEntity<PromQlQueryContent> responseEntity = restTemplate.exchange(uri,
                     HttpMethod.GET, httpEntity, PromQlQueryContent.class);
             if (responseEntity.getStatusCode().is2xxSuccessful()) {
@@ -151,15 +152,15 @@ public abstract class PromqlQueryExecutor implements QueryExecutor {
             URI uri;
             if (datasourceQuery.getTimeType().equals(RANGE)) {
                 uri = UriComponentsBuilder.fromUriString(httpPromqlProperties.url() + QUERY_RANGE_PATH)
-                        .queryParam(HTTP_QUERY_PARAM, datasourceQuery.getExpr())
+                        .queryParam(HTTP_QUERY_PARAM, QUERY_TEMPLATE)
                         .queryParam(HTTP_START_PARAM, datasourceQuery.getStart())
                         .queryParam(HTTP_END_PARAM, datasourceQuery.getEnd())
                         .queryParam(HTTP_STEP_PARAM, datasourceQuery.getStep())
-                        .build().toUri();
+                        .encode().buildAndExpand(datasourceQuery.getExpr()).toUri();
             } else if (datasourceQuery.getTimeType().equals(INSTANT)) {
                 uri = UriComponentsBuilder.fromUriString(httpPromqlProperties.url() + QUERY_PATH)
-                        .queryParam(HTTP_QUERY_PARAM, datasourceQuery.getExpr())
-                        .build().toUri();
+                        .queryParam(HTTP_QUERY_PARAM, QUERY_TEMPLATE)
+                        .encode().buildAndExpand(datasourceQuery.getExpr()).toUri();
             } else {
                 throw new IllegalArgumentException(String.format("no such time type for query id %s.", datasourceQuery.getRefId()));
             }

--- a/hertzbeat-warehouse/src/test/java/org/apache/hertzbeat/warehouse/db/PromqlQueryExecutorTest.java
+++ b/hertzbeat-warehouse/src/test/java/org/apache/hertzbeat/warehouse/db/PromqlQueryExecutorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.hertzbeat.warehouse.db;
+
+import static org.apache.hertzbeat.warehouse.constants.WarehouseConstants.INSTANT;
+import static org.apache.hertzbeat.warehouse.constants.WarehouseConstants.RANGE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.hertzbeat.common.entity.dto.query.DatasourceQuery;
+import org.apache.hertzbeat.warehouse.store.history.tsdb.vm.PromQlQueryContent;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+class PromqlQueryExecutorTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"execute", INSTANT, RANGE})
+    void preservesQueryExpression(String operation) {
+        String expression = "sum(up{job=~\"api.+\",label=\"a&b=50%\"}) + 1";
+        RestTemplate restTemplate = mock(RestTemplate.class);
+        when(restTemplate.exchange(any(URI.class), eq(HttpMethod.GET), any(HttpEntity.class),
+                eq(PromQlQueryContent.class))).thenReturn(ResponseEntity.ok(new PromQlQueryContent()));
+        PromqlQueryExecutor executor = new PromqlQueryExecutor(restTemplate,
+                new PromqlQueryExecutor.HttpPromqlProperties("http://localhost:8428", null, null)) {
+            @Override
+            public String getDatasource() {
+                return "test";
+            }
+        };
+
+        if ("execute".equals(operation)) {
+            executor.execute(expression);
+        } else {
+            executor.query(DatasourceQuery.builder().refId("A").timeType(operation)
+                    .expr(expression).start(1712300000L).end(1712300300L).step("60s").build());
+        }
+
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        verify(restTemplate).exchange(uriCaptor.capture(), eq(HttpMethod.GET), any(HttpEntity.class),
+                eq(PromQlQueryContent.class));
+        URI uri = uriCaptor.getValue();
+        Map<String, String> parameters = Arrays.stream(uri.getRawQuery().split("&"))
+                .map(pair -> pair.split("=", 2))
+                .collect(Collectors.toMap(pair -> pair[0],
+                        pair -> URLDecoder.decode(pair[1], StandardCharsets.UTF_8)));
+        assertEquals(expression, parameters.get("query"));
+        assertEquals(RANGE.equals(operation) ? "/api/v1/query_range" : "/api/v1/query", uri.getPath());
+        if (RANGE.equals(operation)) {
+            assertEquals(Map.of("query", expression, "start", "1712300000", "end", "1712300300", "step", "60s"), parameters);
+        } else {
+            assertEquals(Map.of("query", expression), parameters);
+        }
+    }
+}


### PR DESCRIPTION
## What's changed?

PromQL expressions are inserted directly into query parameters, leaving `+` and `&` unescaped. The server decodes addition operators and regex quantifiers as spaces, and an ampersand in a label value splits the expression into another parameter. For example, `sum(up{job=~"api.+",label="a&b=50%"}) + 1` arrives truncated and altered.

Encode the expression as a URI template value in `execute` and both instant and range `query` requests. The regression captures the URI from each actual executor path and checks the server-decoded parameters, including the range bounds and step.

Validation on Windows with Java 25: all 10 query-executor tests pass, including the three new regressions that fail before the fix. Maven Checkstyle and `git diff --check` pass. The full warehouse suite and a live Prometheus server were not run.

## Checklist

- [x] I have read the contributing guide.
- [x] The regression test documents the affected query and expected behavior.
- [x] Added the necessary unit tests; all query-executor tests pass.

## Add or update API

No API changes.