### PR TITLE
[fix] register JMX value types via metadata instead of enable-monitoring

### DIFF
--- a/hertzbeat-collector/hertzbeat-collector-collector/pom.xml
+++ b/hertzbeat-collector/hertzbeat-collector-collector/pom.xml
@@ -424,7 +424,6 @@
                             <imageName>${native.image.name}</imageName>
                             <buildArgs>
                                 <buildArg>-H:+UnlockExperimentalVMOptions</buildArg>
-                                <buildArg>--enable-monitoring=jmxclient</buildArg>
                                 <buildArg>-H:-AddAllFileSystemProviders</buildArg>
                                 <buildArg>-H:ServiceLoaderFeatureExcludeServiceProviders=org.apache.sshd.common.file.root.RootedFileSystemProvider,org.apache.sshd.sftp.client.fs.SftpFileSystemProvider</buildArg>
                                 <buildArg>--initialize-at-build-time=net.i2p.crypto.eddsa.EdDSASecurityProvider,org.apache.arrow.memory.util.MemoryUtil</buildArg>

--- a/hertzbeat-collector/hertzbeat-collector-collector/src/main/resources/META-INF/native-image/org.apache.hertzbeat/hertzbeat-collector-native/reachability-metadata.json
+++ b/hertzbeat-collector/hertzbeat-collector-collector/src/main/resources/META-INF/native-image/org.apache.hertzbeat/hertzbeat-collector-native/reachability-metadata.json
@@ -13,6 +13,13 @@
     {"type": "io.netty.channel.epoll.EpollEventLoopGroup", "allPublicConstructors": true},
     {"type": "io.netty.channel.socket.nio.NioDatagramChannel", "allPublicConstructors": true},
     {"type": "io.netty.channel.socket.nio.NioSocketChannel", "allPublicConstructors": true},
-    {"type": "io.netty.channel.nio.NioEventLoopGroup", "allPublicConstructors": true}
+    {"type": "io.netty.channel.nio.NioEventLoopGroup", "allPublicConstructors": true},
+
+    {"type": "java.lang.management.ThreadInfo", "allPublicMethods": true},
+    {"type": "java.lang.management.LockInfo", "allPublicMethods": true},
+    {"type": "java.lang.management.MonitorInfo", "allPublicMethods": true},
+    {"type": "java.lang.StackTraceElement", "allPublicMethods": true},
+    {"type": "java.lang.management.MemoryUsage", "allPublicMethods": true},
+    {"type": "com.sun.management.GcInfo", "allPublicMethods": true}
   ]
 }


### PR DESCRIPTION
### Problem

The Windows native collector still fails to start after #4375:

NotCompliantMBeanException: com.sun.management.ThreadMXBean: Method getThreadInfo has parameter or return type that cannot be translated into an open type

Linux and macOS are fine — same commit, same build args.

### Cause

#4375 handled the platform MXBean value types with `--enable-monitoring=jmxclient`. That option does not take effect on
Windows (oracle/graal#9563; still experimental per the docs), so `ThreadInfo` and friends are never registered there.

String comparison of the CI Windows binary against a local macOS build of commit 3089f72580:

| marker | Windows (CI) | macOS |
|---|---|---|
| `JMXConnectorFactory` | 0 | 8 |
| `getLockedMonitors` | 0 | 1 |
| `javax.management.remote` | 9 | 54 |

### Fix

Register the value types explicitly in `reachability-metadata.json` (`ThreadInfo`, `LockInfo`, `MonitorInfo`, `StackTraceElement`, `MemoryUsage`, `GcInfo`) and remove `--enable-monitoring=jmxclient`. Metadata files are read by native-image on every platform, so this does not depend on the broken feature path.

### Verification

macos-arm64, built from this branch:

- `JMXConnectorFactory` absent (option really gone)
- `getLockedMonitors` present (metadata really applied)
- `Started Collector in 0.105 seconds`, 37 collect strategies registered, process stays up
